### PR TITLE
Remove chmod on extracted SDK tarball except on z/OS

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -226,7 +226,9 @@ getBinaryOpenjdk()
 				mv $jar_dir_name j2sdk-image
 			fi
 		done
-	chmod -R 755 j2sdk-image
+	if [[ "$PLATFORM" == "s390x_zos" ]]; then
+		chmod -R 755 j2sdk-image
+	fi
 }
 
 getOpenJDKSources() {


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/963

(Shelly, obviously I'm happy for alternatives to this, but not doing this by default seems sensible ...)

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>