### PR TITLE
WIP: add extraDockerArgs to build.xml so we can override docker image name

### DIFF
--- a/external/build.xml
+++ b/external/build.xml
@@ -24,7 +24,8 @@
 	<property name="DEST_EXTERNAL" value="${BUILD_ROOT}/external" />
 	<property environment="env" />
 	<property name="top" location="../" />
-	
+	<property name="extraDockerArgs" value="${env.EXTRA_DOCKER_ARGS}"/>
+
 	<if>
 		<isset property="env.DOCKERIMAGE_TAG"/>
 		<then>
@@ -50,7 +51,7 @@
 			<fileset dir="." includes="*.mk"/>
 		</copy>
 	</target>
-	
+
 	<target name="docker_prune" description="Remove all unused images from the machine before running new builds">
 		<exec executable="docker">
 			<arg line="system prune --all --force" />
@@ -58,7 +59,7 @@
 	</target>
 
 	<target name="clean_image" description="clean test docker image if there is one">
-		<echo message="Executing external.sh --clean --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} " />						
+		<echo message="Executing external.sh --clean --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} " />
 		<exec executable="bash">
 			<arg value="${DEST_EXTERNAL}/external.sh"/>
 			<arg value="--clean"/>
@@ -83,7 +84,7 @@
 	</target>
 
 	<target name="build_image" description="build test dockerfile">
-		<echo message="Executing external.sh --build --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} " />						
+		<echo message="Executing external.sh --build --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} " />
 		<exec executable="bash">
 			<arg value="${DEST_EXTERNAL}/external.sh"/>
 			<arg value="--build"/>

--- a/external/elasticsearch/build.xml
+++ b/external/elasticsearch/build.xml
@@ -38,7 +38,7 @@
 			</else>
 		</if>
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-elasticsearch-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg ELASTIC_VERSION=${ELASTIC_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
+			<arg line="build -t adoptopenjdk-elasticsearch-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg ELASTIC_VERSION=${ELASTIC_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag} ${extraDockerArgs}"/>
 		</exec>
 	</target>
 

--- a/external/example-test/build.xml
+++ b/external/example-test/build.xml
@@ -22,7 +22,7 @@
 
 	<target name="build_image" depends="clean_image" description="build example test docker image">
 		<exec executable="docker"  failonerror="true">
-			<arg line="build -t adoptopenjdk-example-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag}"/>
+			<arg line="build -t adoptopenjdk-example-test -f dockerfile/Dockerfile --pull . --build-arg SDK=${JVM_VERSION} --build-arg IMAGE_VERSION=${dockerImageTag} ${extraDockerArgs}"/>
 		</exec>
 	</target>
 


### PR DESCRIPTION
Proposing a change to read `EXTRA_DOCKER_ARGS` in external test build steps.

I am running external tests in Azure DevOps but getting the following error when executing `./maketest.sh`:

```
manifest for adoptopenjdk/openjdk11:linux--2020.6.0.8523-nightly not found: manifest unknown: manifest unknown
```
at this line:
https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/external/elasticsearch/build.xml#L41

~My guess is that we can't access the docker image specified in the Dockerfile, so my team has been overriding~
We would like to override the docker registry and image name with an image we created in AzDo.

The way this is done right now is to replace the following line 
 https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/external/elasticsearch/dockerfile/Dockerfile#L26:

with

```
ARG IMAGE_NAME=another-image-from-azure
...
```

This is clearly not the idea approach, so I'm proposing a change I'd like to upstream, which can be seen in my PR.

My concern with this approach is that I don't know all the use cases of `EXTRA_DOCKER_ARGS`, so I'm not sure about any potential side effects of having extra docker args in the build steps. 

Let me know what you think, thanks.