### PR TITLE
Re-enable superProtectedMethod lambda tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -156,7 +156,6 @@ jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	macosx-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
-java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse-openj9/openj9/issues/11783 generic-all
 java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse-openj9/openj9/issues/10648 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 ############################################################################


### PR DESCRIPTION
Re-enable superProtectedMethod lambda tests

Can be renabled once issue https://github.com/eclipse-openj9/openj9/issues/11783 is closed

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>