### PR TITLE
Set Jenkins node temporarily offline due to specific machine issue

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -273,51 +273,98 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
             }
 
             node(LABEL) {
-                cleanWs()
-                if (params.PLATFORM.contains('zos')) {
-                    /* Ensure correct CC env */
-                    env._CC_CCMODE = '1'
-                    env._CXX_CCMODE = '1'
-                    env._C89_CCMODE = '1'
+                try {
+                    cleanWs()
+                    if (params.PLATFORM.contains('zos')) {
+                        /* Ensure correct CC env */
+                        env._CC_CCMODE = '1'
+                        env._CXX_CCMODE = '1'
+                        env._C89_CCMODE = '1'
 
-                    def gitConfig = scm.getUserRemoteConfigs()[0]
-                    def SCM_GIT_REPO = gitConfig.getUrl()
-                    def SCM_GIT_BRANCH = scm.branches[0].name
+                        def gitConfig = scm.getUserRemoteConfigs()[0]
+                        def SCM_GIT_REPO = gitConfig.getUrl()
+                        def SCM_GIT_BRANCH = scm.branches[0].name
 
-                    // SCM_GIT_REPO value only gets expanded in sh
-                    def SCM_GIT_REPO_VAL = sh(script: "echo ${SCM_GIT_REPO}", returnStdout: true).trim()
-                    SCM_GIT_REPO_VAL = SCM_GIT_REPO_VAL.replace("https://github.com/","git@github.com:")
+                        // SCM_GIT_REPO value only gets expanded in sh
+                        def SCM_GIT_REPO_VAL = sh(script: "echo ${SCM_GIT_REPO}", returnStdout: true).trim()
+                        SCM_GIT_REPO_VAL = SCM_GIT_REPO_VAL.replace("https://github.com/","git@github.com:")
 
-                    sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO_VAL} aqa-tests"
-                } else {
-                    def gitConfig = scm.getUserRemoteConfigs().get(0)
+                        sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO_VAL} aqa-tests"
+                    } else {
+                        def gitConfig = scm.getUserRemoteConfigs().get(0)
 
-                    // Adopt windows machines require env here https://github.com/adoptium/aqa-tests/issues/1803
-                    ref_cache = "${env.HOME}/openjdk_cache"
+                        // Adopt windows machines require env here https://github.com/adoptium/aqa-tests/issues/1803
+                        ref_cache = "${env.HOME}/openjdk_cache"
 
-                    checkout scm: [$class: 'GitSCM',
-                        branches: [[name: "${scm.branches[0].name}"]],
-                        extensions: [
-                            [$class: 'CleanBeforeCheckout'],
-                            [$class: 'CloneOption', reference: ref_cache],
-                            [$class: 'RelativeTargetDirectory', relativeTargetDir: 'aqa-tests']],
-                        userRemoteConfigs: [[url: "${gitConfig.getUrl()}"]]
-                    ]
-                }
-                jenkinsfile = load "${WORKSPACE}/aqa-tests/buildenv/jenkins/JenkinsfileBase"
-                if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') {
-                    //Set dockerimage for azure agent. Fyre has stencil to setup the right environment
-                    docker.image('adoptopenjdk/centos6_build_image').pull() 
-                    docker.image('adoptopenjdk/centos6_build_image').inside {
+                        checkout scm: [$class: 'GitSCM',
+                            branches: [[name: "${scm.branches[0].name}"]],
+                            extensions: [
+                                [$class: 'CleanBeforeCheckout'],
+                                [$class: 'CloneOption', reference: ref_cache],
+                                [$class: 'RelativeTargetDirectory', relativeTargetDir: 'aqa-tests']],
+                            userRemoteConfigs: [[url: "${gitConfig.getUrl()}"]]
+                        ]
+                    }
+                    jenkinsfile = load "${WORKSPACE}/aqa-tests/buildenv/jenkins/JenkinsfileBase"
+                    if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') {
+                        //Set dockerimage for azure agent. Fyre has stencil to setup the right environment
+                        docker.image('adoptopenjdk/centos6_build_image').pull() 
+                        docker.image('adoptopenjdk/centos6_build_image').inside {
+                            jenkinsfile.testBuild()
+                        }
+                    } else {
                         jenkinsfile.testBuild()
                     }
-                } else {
-                    jenkinsfile.testBuild()
+                } catch (Exception e) {
+                    println("Exception: " + e.toString())
+                    // build result may not be updated correctly at the moment (see https://issues.jenkins.io/browse/JENKINS-56402)
+                    // if there is an exception, set currentBuild.result to FAILURE
+                    currentBuild.result = 'FAILURE'
+                } finally {
+                    if (params.SLACK_CHANNEL) {
+                        timeout(time: 5, unit: 'MINUTES') {
+                            if (currentBuild.result == 'FAILURE') {
+                                println("${env.JOB_NAME} #${env.BUILD_NUMBER} result is FAILURE. Checking console log for specific errors...")
+                                // create error list and regex can be used
+                                List<String> errorList = new ArrayList<String>();
+                                errorList.add(".*There is not enough space in the file system.*");
+
+                                // nightly/weekly builds should not have git clone issue
+                                if (!env.JOB_NAME.contains("Grinder") && !env.JOB_NAME.contains("_Personal")) {
+                                    errorList.add(".*ERROR: Error cloning remote repo.*");
+                                }
+                                checkErrors(errorList)
+                            }
+                        }
+                    }
                 }
             }
         }
         jenkinsfile.run_parallel_tests()
     } else {
         assert false : "Cannot find key PLATFORM: ${params.PLATFORM} in PLATFORM_MAP: ${PLATFORM_MAP}."
+    }
+}
+
+def checkErrors(errorList) {
+    def foundError = ""
+    for (String error : errorList) {
+        if (manager.logContains(error)) {
+            foundError = error;
+            break;
+        }
+    }
+    if (foundError) {
+        def message = "${env.JOB_NAME} #${env.BUILD_NUMBER} failed on ${NODE_NAME} due to ${foundError}: ${env.BUILD_URL} \nSet ${NODE_NAME} temporarily offline! ${env.JENKINS_URL}computer/${NODE_NAME}"
+        def currentNode = Jenkins.instance.getNode(NODE_NAME).toComputer()
+        // set the current node temporarily offline
+        if (currentNode) {
+            println("${message}")
+            currentNode.setTemporarilyOffline(true, new hudson.slaves.OfflineCause.UserCause(User.current(), "${message}"))
+        }
+        // if SLACK_CHANNEL is provided, send the message in slack 
+        if (params.SLACK_CHANNEL) {
+            slackSend channel: SLACK_CHANNEL, message: "${message}"
+        }
     }
 }

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -42,6 +42,7 @@ if (!binding.hasVariable('TEST_JOB_NAME')) TEST_JOB_NAME = ""
 if (!binding.hasVariable('TARGET')) TARGET = ""
 if (!binding.hasVariable('BUILD_LIST')) BUILD_LIST = ""
 if (!binding.hasVariable('SDK_RESOURCE')) SDK_RESOURCE = "upstream"
+if (!binding.hasVariable('SLACK_CHANNEL')) SLACK_CHANNEL = ""
 if (!binding.hasVariable('TRIGGER_SCHEDULE')) TRIGGER_SCHEDULE = ""
 if (!binding.hasVariable('LIGHT_WEIGHT_CHECKOUT')) LIGHT_WEIGHT_CHECKOUT = false
 if (!binding.hasVariable('NUM_MACHINES')) NUM_MACHINES = ""
@@ -381,6 +382,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('ARTIFACTORY_SERVER', ARTIFACTORY_SERVER, "Optional. Default is to upload test output (failed build) onto artifactory only. By unset this value, test output will be archived to Jenkins")
 							stringParam('ARTIFACTORY_REPO', ARTIFACTORY_REPO, "Optional. It should be used with ARTIFACTORY_SERVER")
 							stringParam('ARTIFACTORY_ROOT_DIR', ARTIFACTORY_ROOT_DIR, "Optional. It should be used with ARTIFACTORY_SERVER and ARTIFACTORY_REPO. Default is to set root dir to be the same as the current Jenkins domain")
+							stringParam('SLACK_CHANNEL', SLACK_CHANNEL, "Slack channel. e.g., #rt-jenkins")
 							booleanParam('PERSONAL_BUILD', false, "Is this a personal build?")
 						}
 						cpsScm {


### PR DESCRIPTION
Currently, this feature is only enabled if params.SLACK_CHANNEL is provided.
This PR checks test build console output only if the build result is FAILURE. If the console
output contains a specific error message (i.e., There is not enough space in the file system, etc),
set the current node to be temporarily offline. If SLACK_CHANNEL is provided, send the message in
slack.

Resolve: #2370
Signed-off-by: lanxia <lan_xia@ca.ibm.com>