### PR TITLE
Exclude JCK 16 targets that fail due to infra issue

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -388,6 +388,11 @@
 			<version>11</version>
 		</disabled>
 		<disabled>
+			<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<plat>x86-64_mac</plat>
+			<version>16</version>
+		</disabled>
+		<disabled>
 			<comment>Disabled on win64 on jdk8 due to backlog/issues/504. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<plat>x86-64_windows(_mixed)?</plat>
 			<version>8</version>
@@ -415,6 +420,11 @@
 			<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<plat>x86-64_mac(_mixed)?</plat>
 			<version>8</version>
+		</disabled>
+		<disabled>
+			<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<plat>x86-64_mac</plat>
+			<version>16</version>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
@@ -479,6 +489,10 @@
 		<disabled>
 			<comment>Disabled on all platforms due to backlog/issues/462. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>11</version>
+		</disabled>
+		<disabled>
+			<comment>Disabled on all platforms due to backlog/issues/462. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<version>16</version>
 		</disabled>
 		<disabled>
 			<comment>Disabled on all platforms due to backlog/issues/462. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
@@ -872,6 +886,10 @@
 		<disabled>
 			<comment>Disabled on osx for infrastructure/issues/5254, on win for backlog/issues/487 and on others for backlog/issues/484. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>11</version>
+		</disabled>
+		<disabled>
+			<comment>Disabled on osx for infrastructure/issues/5254, on win for backlog/issues/487 and on others for backlog/issues/484. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<version>16</version>
 		</disabled>
 		<disabled>
 			<comment>Disabled on osx on jdk8 due to backlog/issues/5254 and on win32 due to backlog/issues/503. Awaiting some automation improvements, in the interim these targets will be run manually</comment>


### PR DESCRIPTION
These JCK16 excludes include
- OSX excludes due to  infrastructure/issues/5254
- java_net exclude on all platforms due to backlog/issues/462

For details, please see backlog/issues/508

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>