### PR TITLE
Exclude openjdk jdk/dynalink tests on openj9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -332,6 +332,9 @@ java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse/openj9/issues/
 
 # jdk_other
 
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2533 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2533 generic-all
+
 jdk/internal/misc/VM/GetNanoTimeAdjustment.java		https://github.com/eclipse/openj9/issues/7184		generic-all
 jdk/internal/misc/VM/RuntimeArguments.java		https://github.com/eclipse/openj9/issues/7186		generic-all
 jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/eclipse/openj9/issues/7245		generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -327,6 +327,9 @@ java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse/openj9/issues/
 
 # jdk_other
 
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2533 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/2533 generic-all
+
 jdk/internal/misc/VM/GetNanoTimeAdjustment.java		https://github.com/eclipse/openj9/issues/7184		generic-all
 jdk/internal/misc/VM/RuntimeArguments.java		https://github.com/eclipse/openj9/issues/7186		generic-all
 jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/eclipse/openj9/issues/7245		generic-all


### PR DESCRIPTION
Signed-off-by: Simon Rushton <srushton@redhat.com>