### PR TITLE
Updated github urls to refer to eclipse-openj9

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -42,7 +42,7 @@ def setupEnv() {
 	env.SPEC = "${SPEC}"
 
 	ADOPTOPENJDK_REPO = params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/AdoptOpenJDK/openjdk-tests.git"
-	OPENJ9_REPO = params.OPENJ9_REPO ? params.OPENJ9_REPO : "https://github.com/eclipse/openj9.git"
+	OPENJ9_REPO = params.OPENJ9_REPO ? params.OPENJ9_REPO : "https://github.com/eclipse-openj9/openj9.git"
 
 	String[] tkg = getGitRepoBranch(params.TKG_OWNER_BRANCH, "AdoptOpenJDK:master", "TKG")
 	TKG_REPO = tkg[0]

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -124,7 +124,7 @@ println "JDK_VERSIONS: ${JDK_VERSIONS}"
 println "GROUPS: ${GROUPS}"
 println "ARCH_OS_LIST: ${ARCH_OS_LIST}"
 
-def OPENJ9_REPO = "https://github.com/eclipse/openj9.git"
+def OPENJ9_REPO = "https://github.com/eclipse-openj9/openj9.git"
 def ADOPTOPENJDK_REPO = "https://github.com/AdoptOpenJDK/openjdk-tests.git"
 def ADOPTOPENJDK_BRANCH = "master"
 
@@ -226,7 +226,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('TKG_OWNER_BRANCH', "AdoptOpenJDK:master", "TestKitGen git [owner]:[branch]. Default is AdoptOpenJDK:master")
 							stringParam('TKG_SHA', "", "TKG sha")
 							stringParam('ADOPTOPENJDK_SYSTEMTEST_OWNER_BRANCH', "AdoptOpenJDK:master", "Personal Adoptium/aqa-systemtest repository owner:branch")
-							stringParam('OPENJ9_SYSTEMTEST_OWNER_BRANCH', "eclipse:master", "Personal eclipse/openj9-systemtest repository owner:branch")
+							stringParam('OPENJ9_SYSTEMTEST_OWNER_BRANCH', "eclipse:master", "Personal eclipse-openj9/openj9-systemtest repository owner:branch")
 							stringParam('STF_OWNER_BRANCH', "adoptium:master", "Personal stf repo owner:branch")
 							stringParam('JCK_GIT_REPO', ACTUAL_JCK_GIT_REPO, "For JCK test only")
 							booleanParam('LIGHT_WEIGHT_CHECKOUT', LIGHT_WEIGHT_CHECKOUT.toBoolean(), "Optional. Default is false for Grinders")

--- a/doc/Triage.md
+++ b/doc/Triage.md
@@ -32,7 +32,7 @@ There are many different test jobs running at the AdoptOpenJDK project.  No matt
 - product issue - additional steps may be necessary, before raising an issue
   - rerun the test - locally or using a Grinder: see [How to Run a Grinder wiki](https://github.com/AdoptOpenJDK/openjdk-tests/wiki/How-to-Run-a-Grinder-Build-on-Jenkins)
   - determine if the problem is occurs in other jdk versions, implementations and on other platforms
-  - if only observed against 1 implementation, raise an issue against that implementation in the correct upstream repo (typically either OpenJDK or [Eclipse OpenJ9](https://github.com/eclipse/openj9/issues) projects).
+  - if only observed against 1 implementation, raise an issue against that implementation in the correct upstream repo (typically either OpenJDK or [Eclipse OpenJ9](https://github.com/eclipse-openj9/openj9/issues) projects).
 
 ### Exclude the test
 

--- a/doc/userGuide.md
+++ b/doc/userGuide.md
@@ -6,7 +6,7 @@ Platform: x64_linux | x64_mac | s390x_linux | ppc64le_linux | aarch64_linux
 
 Java Version: SE80 | SE90 | SE100
 
-Set up your test machine with this [set of prerequisites](https://github.com/eclipse/openj9/blob/master/test/docs/Prerequisites.md).
+Set up your test machine with this [set of prerequisites](https://github.com/eclipse-openj9/openj9/blob/master/test/docs/Prerequisites.md).
 
 ## Jenkins setup and running
 While you can [run all the tests manually](#local-testing-via-make-targets-on-the-commandline) via the make targets on the command line, you may also run the tests in Jenkins. As part of the AdoptOpenJDK continuous integration (CI), AdoptOpenJDK runs test builds against the release and nightly SDK builds.
@@ -201,7 +201,7 @@ Usage : get.sh  --testdir|-t openjdktestdir
 
                 [--customizedURL|-c ] : optional. If downloading an sdk and if sdk source is set as customized, indicates sdk url 
                 [--clone_openj9 ] : optional. ture or false. Clone openj9 if this flag is set to true. Default to true
-                [--openj9_repo ] : optional. OpenJ9 git repo. Default value https://github.com/eclipse/openj9.git is used if not provided
+                [--openj9_repo ] : optional. OpenJ9 git repo. Default value https://github.com/eclipse-openj9/openj9.git is used if not provided
                 [--openj9_sha ] : optional. OpenJ9 pull request sha
                 [--openj9_branch ] : optional. OpenJ9 branch
                 [--tkg_repo ] : optional. TKG git repo. Default value https://github.com/AdoptOpenJDK/TKG.git is used if not provided
@@ -215,7 +215,7 @@ Usage : get.sh  --testdir|-t openjdktestdir
 
 #### Set environment variables, configure, build and run tests
 
-You can use the same approach as described in the [OpenJ9 functional tests README file]( https://github.com/eclipse/openj9/blob/master/test/README.md).  In the case of the tests run at AdoptOpenJDK, instead of using a make target called _sanity.functional, you can provide the appropriate make target to run the tests of interest to you. 
+You can use the same approach as described in the [OpenJ9 functional tests README file]( https://github.com/eclipse-openj9/openj9/blob/master/test/README.md).  In the case of the tests run at AdoptOpenJDK, instead of using a make target called _sanity.functional, you can provide the appropriate make target to run the tests of interest to you. 
 
 ##### Top-level test targets:
 - openjdk 
@@ -229,7 +229,7 @@ You can use the same approach as described in the [OpenJ9 functional tests READM
 - _extended.openjdk, _extended.system, _extended.external, _extended.perf, etc.
 
 ##### Sub-targets by directory:
-Refer to these instructions for how to [run tests by directory](https://github.com/eclipse/openj9/blob/master/test/README.md#5-how-to-execute-a-directory-of-tests)
+Refer to these instructions for how to [run tests by directory](https://github.com/eclipse-openj9/openj9/blob/master/test/README.md#5-how-to-execute-a-directory-of-tests)
 
 ##### Sub-targets by test name:
 In each playlist.xml file in each test directory, there are tests defined.  Test targets are generated from the ```<testCaseName>``` tag, so you can use the test case name as a make target.

--- a/external/README.md
+++ b/external/README.md
@@ -32,7 +32,7 @@ Our next steps to improve and expand this set of external tests is divided into 
 - Quick compare view, easy comparison of how different implementations stack up
 - Parallel testing (to improve execution time)
 - Startup-only testing (application startup, but not full runs of app functional testing)
-- Add high-value tests that exercise the AdoptOpenJDK binaries, including but not limited to functional test suites and Microprofile compliance tests (plan to start with [Fault Tolerance TCK](https://github.com/eclipse/microprofile-fault-tolerance/blob/master/tck/running_the_tck.asciidoc) and [Metrics API TCKs](https://github.com/eclipse/microprofile-metrics/blob/master/tck/running_the_tck.asciidoc) against [GlassFish](https://javaee.github.io/glassfish/) EE reference implementation) 
+- Add high-value tests that exercise the AdoptOpenJDK binaries, including but not limited to functional test suites and Microprofile compliance tests (plan to start with [Fault Tolerance TCK](https://github.com/eclipse-openj9/microprofile-fault-tolerance/blob/master/tck/running_the_tck.asciidoc) and [Metrics API TCKs](https://github.com/eclipse-openj9/microprofile-metrics/blob/master/tck/running_the_tck.asciidoc) against [GlassFish](https://javaee.github.io/glassfish/) EE reference implementation) 
  
 #### Strategic Goals
 - Engage with application communities, including the Eclipse Jakarta EE project, to:

--- a/get.sh
+++ b/get.sh
@@ -22,7 +22,7 @@ SDK_RESOURCE="nightly"
 CUSTOMIZED_SDK_URL=""
 CUSTOMIZED_SDK_SOURCE_URL=""
 CLONE_OPENJ9="true"
-OPENJ9_REPO="https://github.com/eclipse/openj9.git"
+OPENJ9_REPO="https://github.com/eclipse-openj9/openj9.git"
 OPENJ9_SHA=""
 OPENJ9_BRANCH=""
 TKG_REPO="https://github.com/AdoptOpenJDK/TKG.git"
@@ -54,7 +54,7 @@ usage ()
 	echo '                [--username ] : indicate username required if customized url requiring authorization is used'
 	echo '                [--password ] : indicate password required if customized url requiring authorization is used'
 	echo '                [--clone_openj9 ] : optional. ture or false. Clone openj9 if this flag is set to true. Default to true'
-	echo '                [--openj9_repo ] : optional. OpenJ9 git repo. Default value https://github.com/eclipse/openj9.git is used if not provided'
+	echo '                [--openj9_repo ] : optional. OpenJ9 git repo. Default value https://github.com/eclipse-openj9/openj9.git is used if not provided'
 	echo '                [--openj9_sha ] : optional. OpenJ9 pull request sha.'
 	echo '                [--openj9_branch ] : optional. OpenJ9 branch.'
 	echo '                [--tkg_repo ] : optional. TKG git repo. Default value https://github.com/AdoptOpenJDK/TKG.git is used if not provided'

--- a/openjdk/README.md
+++ b/openjdk/README.md
@@ -19,7 +19,7 @@ For more details on how the underlying jtreg harness works, you can refer to the
 ## Running OpenJDK tests locally
 While you can directly use the jtreg test harness to run these tests locally, we have also integrated them into our AQA test suite with TKG (TestKitGen) so that they can be run following the same pattern as any other AQA test:
 
-0. Ensure your test machine is set up with [test prereqs](https://github.com/eclipse/openj9/blob/master/test/docs/Prerequisites.md).  For openjdk tests, you do not need Docker installed.
+0. Ensure your test machine is set up with [test prereqs](https://github.com/eclipse-openj9/openj9/blob/master/test/docs/Prerequisites.md).  For openjdk tests, you do not need Docker installed.
 
 1. Download/unpack the SDK you want to your test machine (you can download them from our website: [adoptopenjdk.net](https://adoptopenjdk.net/)).
 1. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>` 

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -151,11 +151,11 @@
 	<test>
 		<testCaseName>jvm_native_sanity</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -185,11 +185,11 @@
 	<test>
 		<testCaseName>jvm_compiler</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -219,11 +219,11 @@
 	<test>
 		<testCaseName>runtime_nestmate</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -285,11 +285,11 @@
 			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2137#issuecomment-760598580</comment>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -317,11 +317,11 @@
 	<test>
 		<testCaseName>jdk_beans</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -679,11 +679,11 @@
 			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2123#issuecomment-758367994</comment>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -833,11 +833,11 @@
 	<test>
 		<testCaseName>jdk_time</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -864,11 +864,11 @@
 	<test>
 		<testCaseName>jdk_management</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -895,11 +895,11 @@
 	<test>
 		<testCaseName>jdk_jmx</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -949,11 +949,11 @@
 	<test>
 		<testCaseName>jdk_tools</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -984,7 +984,7 @@
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -1070,12 +1070,12 @@
 	<test>
 		<testCaseName>jdk_foreign_native</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/11760</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/11760</comment>
 			<version>16+</version>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -1107,11 +1107,11 @@
 	<test>
 		<testCaseName>jdk_instrument</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -1147,7 +1147,7 @@
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -1181,7 +1181,7 @@
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -1211,11 +1211,11 @@
 	<test>
 		<testCaseName>build</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<testCaseName>jdk_build</testCaseName>
@@ -1285,11 +1285,11 @@
 			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2137#issuecomment-759930182</comment>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -1378,11 +1378,11 @@
 			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2137#issuecomment-759938221</comment>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>
@@ -1416,11 +1416,11 @@
 			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2157#issuecomment-758317252</comment>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>openj9</impl>
 		</disabled>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/10757</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 			<impl>ibm</impl>
 		</disabled>
 		<variations>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -63,7 +63,7 @@
 	<test>
 		<testCaseName>dacapo-jython</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/11942</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/11942</comment>
 			<version>16+</version>
 			<impl>openj9</impl>
 		</disabled>

--- a/system/README.md
+++ b/system/README.md
@@ -4,7 +4,7 @@ System tests help verify that the AdoptOpenJDK binaries are *good* by running a 
 
 ## Related repositories: 
 - System tests that run both on AdoptOpenJDK and AdoptOpenJDK-OpenJ9 SDKs are located at:  github.com/AdoptOpenJDK/openjdk-systemtest.git
-- System tests specific to AdoptOpenJDK-OpenJ9 are located at: github.com/eclipse/openj9-systemtest.git
+- System tests specific to AdoptOpenJDK-OpenJ9 are located at: github.com/eclipse-openj9/openj9-systemtest.git
 - STF framework that runs system tests are located at: github.com/AdoptOpenJDK/stf.git
 
 ## How it works
@@ -12,6 +12,6 @@ The [build.xml](https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/system
 
 For detailed documentation, please see 
 - openjdk-systemtest [build instruction](https://github.com/AdoptOpenJDK/openjdk-systemtest/blob/master/openjdk.build/docs/build.md) 
-- openj9-systemtest [build instruction](https://github.com/eclipse/openj9-systemtest/blob/master/openj9.build/docs/build.md)
+- openj9-systemtest [build instruction](https://github.com/eclipse-openj9/openj9-systemtest/blob/master/openj9.build/docs/build.md)
 
 Please direct questions to the [#testing Slack channel](https://adoptopenjdk.slack.com/messages/C5219G28G).

--- a/system/common.xml
+++ b/system/common.xml
@@ -23,7 +23,7 @@
 		<isset property="env.ADOPTOPENJDK_SYSTEMTEST_BRANCH"/>
 	</condition>
 	
-	<condition property="openj9_systemtest_repo" value="${env.OPENJ9_SYSTEMTEST_REPO}" else="${git-prefix}://github.com/eclipse/openj9-systemtest.git">
+	<condition property="openj9_systemtest_repo" value="${env.OPENJ9_SYSTEMTEST_REPO}" else="${git-prefix}://github.com/eclipse-openj9/openj9-systemtest.git">
 		<isset property="env.OPENJ9_SYSTEMTEST_REPO"/>
 	</condition>
 	<condition property="openj9_systemtest_branch" value="${env.OPENJ9_SYSTEMTEST_BRANCH}" else="master">

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -225,7 +225,7 @@
 	<test>
 		<testCaseName>MathLoadTest_bigdecimal_special_5m</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/9104</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/9104</comment>
 			<variation>Mode614</variation>
 		</disabled>
 		<variations>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -17,7 +17,7 @@
 			<group>system</group>
 		</groups>
 	</test>
-	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse/openj9/issues/4091 -->
+	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse-openj9/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleThrdLoad_J9_5m</testCaseName>
 		<variations>
@@ -57,7 +57,7 @@
 			<impl>hotspot</impl>
 		</impls>
 	</test>
-	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse/openj9/issues/4091 -->
+	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse-openj9/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleInvocLoad_J9_5m</testCaseName>
 		<variations>
@@ -232,7 +232,7 @@
 	<test>
 		<testCaseName>MauveSingleThrdLoad_special_5m</testCaseName>
 		<disabled>
-			<comment>https://github.com/eclipse/openj9/issues/3771</comment>
+			<comment>https://github.com/eclipse-openj9/openj9/issues/3771</comment>
 		</disabled>
 		<variations>
 			<variation>Mode101</variation>

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -556,7 +556,7 @@
 		</groups>
 		<platformRequirements>^os.zos</platformRequirements>
 	</test>
-	<!-- Temporarily excluded from win due to : https://github.com/eclipse/openj9-systemtest/issues/68 -->
+	<!-- Temporarily excluded from win due to : https://github.com/eclipse-openj9/openj9-systemtest/issues/68 -->
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>Jlink_ReqMod</testCaseName>
@@ -578,7 +578,7 @@
 		</groups>
 		<platformRequirements>^os.win,^os.zos</platformRequirements>
 	</test>
-	<!-- Temporarily excluded from win due to : https://github.com/eclipse/openj9-systemtest/issues/68 -->
+	<!-- Temporarily excluded from win due to : https://github.com/eclipse-openj9/openj9-systemtest/issues/68 -->
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/568 -->
 	<test>
 		<testCaseName>Jlink_AddMLimitM</testCaseName>
@@ -621,7 +621,7 @@
 		</groups>
 		<platformRequirements>^os.zos</platformRequirements>
 	</test>
-	<!-- Temporarily excluded from win due to : https://github.com/eclipse/openj9-systemtest/issues/68 -->
+	<!-- Temporarily excluded from win due to : https://github.com/eclipse-openj9/openj9-systemtest/issues/68 -->
 	<test>
 		<testCaseName>Jlink_GenOpt</testCaseName>
 		<variations>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -177,7 +177,7 @@
 			<group>system</group>
 		</groups>
 	</test>
-	<!-- Temporarily exclude from Linux aarch64 for: https://github.com/eclipse/openj9/issues/3065 -->
+	<!-- Temporarily exclude from Linux aarch64 for: https://github.com/eclipse-openj9/openj9/issues/3065 -->
 	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/342-->
 	<test>
 		<testCaseName>NioLoadTest_5m</testCaseName>


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/2551