### PR TITLE
Add GENERATE_JOBS parameter

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -241,18 +241,26 @@ def setupParallelEnv() {
 
 				def TEST_JOB_NAME = "${JOB_NAME}_${childTest}"
 
-				def jobIsRunnable = false
-				try {
-					def JobHelper = library(identifier: 'openjdk-jenkins-helper@master').JobHelper
-					jobIsRunnable = JobHelper.jobIsRunnable("${TEST_JOB_NAME}")
-					echo "${TEST_JOB_NAME} jobIsRunnable: ${jobIsRunnable}"
-				} catch (Exception e) {
-					echo "Cannot call jobIsRunnable() from openjdk-jenkins-helper@master. Skipping..."
-				}
-				if (!jobIsRunnable) {
+				// If GENERATE_JOBS is set to true, force generate the child job. Otherwise, only generate the child job if it does not exist
+				if (params.GENERATE_JOBS) {
 					create_jobs[childTest] = {
-						echo "Test job ${TEST_JOB_NAME} doesn't exist, set test job ${TEST_JOB_NAME} params"
+						echo "GENERATE_JOBS is set to true, set test job ${TEST_JOB_NAME} params for generating the job"
 						createJob( TEST_JOB_NAME, PLATFORM)
+					}
+				} else {
+					def jobIsRunnable = false
+					try {
+						def JobHelper = library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+						jobIsRunnable = JobHelper.jobIsRunnable("${TEST_JOB_NAME}")
+						echo "${TEST_JOB_NAME} jobIsRunnable: ${jobIsRunnable}"
+					} catch (Exception e) {
+						echo "Cannot call jobIsRunnable() from openjdk-jenkins-helper@master. Skipping..."
+					}
+					if (!jobIsRunnable) {
+						create_jobs[childTest] = {
+							echo "Test job ${TEST_JOB_NAME} doesn't exist, set test job ${TEST_JOB_NAME} params for generating the job"
+							createJob( TEST_JOB_NAME, PLATFORM)
+						}
 					}
 				}
 

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -49,7 +49,7 @@ if (!binding.hasVariable('VENDOR_TEST_REPOS')) VENDOR_TEST_REPOS = ""
 if (!binding.hasVariable('VENDOR_TEST_BRANCHES')) VENDOR_TEST_BRANCHES = ""
 if (!binding.hasVariable('VENDOR_TEST_DIRS')) VENDOR_TEST_DIRS = ""
 if (!binding.hasVariable('USER_CREDENTIALS_ID')) USER_CREDENTIALS_ID = ""
-
+if (!binding.hasVariable('GENERATE_JOBS')) GENERATE_JOBS = false
 
 
 if (!binding.hasVariable('BUILDS_TO_KEEP')) {
@@ -350,6 +350,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							booleanParam('PERSONAL_BUILD', false, "Is this a personal build?")
 							stringParam('UPSTREAM_TEST_JOB_NAME', "", "Auto-populated. Upstream test job name. It will be used together with PARALLEL=Dynamic")
 							stringParam('UPSTREAM_TEST_JOB_NUMBER', "", "Auto-populated. Upstream test job number. It will be used together with PARALLEL=Dynamic")
+							booleanParam('GENERATE_JOBS', GENERATE_JOBS.toBoolean(), "Force generate child jobs?")
 
 							parameterSeparatorDefinition {
 							    name('POST_RUN_PARAMS')


### PR DESCRIPTION
If GENERATE_JOBS is set to true, force generate the child jobs.
Otherwise, only generate the child job if it does not exist.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>