### PR TITLE
Exclude javax/naming/InitialContext/NoApplet.java jdk8 macos openj9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -131,6 +131,7 @@ sun/management/jmxremote/startstop/JMXStatusTest.java   https://github.com/Adopt
 
 # jdk_other
 
+javax/naming/InitialContext/NoApplet.java https://github.com/eclipse-openj9/openj9/issues/12638 macosx-all
 ############################################################################
 
 # jdk_net


### PR DESCRIPTION
Signed-off-by: Simon Rushton <srushton@redhat.com>