### PR TITLE
Excluding OpenJ9 and z/OS specific JTReg tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -155,6 +155,7 @@ java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/AdoptOpe
 javax/management/Introspector/ClassLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 com/sun/management/OperatingSystemMXBean/GetFreePhysicalMemorySize.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 z/OS-s390x
+
 ############################################################################
 
 # jdk_jmx
@@ -226,7 +227,8 @@ java/nio/channels/FileChannel/directio/ReadDirect.java https://github.com/AdoptO
 java/nio/channels/FileChannel/directio/PreadDirect.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 z/OS-s390x
 java/nio/channels/FileChannel/directio/PwriteDirect.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 z/OS-s390x
 java/nio/channels/FileChannel/TempDirectBuffersReclamation.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 z/OS-s390x
-
+java/nio/channels/FileChannel/directio/WriteDirect.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 z/OS-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 z/OS-s390x
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -146,7 +146,15 @@ sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.c
 sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
-
+java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+javax/management/Introspector/ClassLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+com/sun/management/OperatingSystemMXBean/GetFreePhysicalMemorySize.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 z/OS-s390x
 ############################################################################
 
 # jdk_jmx

--- a/openjdk/excludes/ProblemList_openjdk12-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk12-openj9.txt
@@ -174,6 +174,14 @@ sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.c
 sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+javax/management/Introspector/ClassLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk13-openj9.txt
@@ -160,6 +160,14 @@ sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.c
 sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+javax/management/Introspector/ClassLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk14-openj9.txt
@@ -152,6 +152,15 @@ sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.c
 sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+javax/management/Introspector/ClassLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk15-openj9.txt
@@ -170,6 +170,14 @@ sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.c
 sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+javax/management/Introspector/ClassLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -185,6 +185,14 @@ sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.c
 sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+javax/management/Introspector/ClassLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -187,6 +187,14 @@ sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.c
 sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+javax/management/Introspector/ClassLeakTest.java https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/AdoptOpenJDK/openjdk-tests/issues/1297 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Excuding openj9 specific tests and zos specific tests for jdk11 and later releases.

OpenJ9 exclusions:
java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh
java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh
java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh
java/lang/management/MemoryMXBean/MemoryTestAllGC.sh
java/lang/management/MemoryMXBean/MemoryTest.java
java/lang/management/MemoryMXBean/LowMemoryTest.java
javax/management/Introspector/ClassLeakTest.java
java/lang/management/MemoryMXBean/MemoryTestZGC.sh

z/OS specific exclusions:
com/sun/management/OperatingSystemMXBean/GetFreePhysicalMemorySize.java
java/nio/channels/FileChannel/directio/WriteDirect.java
java/nio/channels/DatagramChannel/Promiscuous.java

Note :- Openj9 specific exclusions are applicable for jdk11 and later versions whereas z/OS specific exclusions are applicable only for jdk11.