### PR TITLE
Allow testsuite to be supplied as part of jck custom target

### DIFF
--- a/jck/README.md
+++ b/jck/README.md
@@ -41,11 +41,11 @@ This test directory contains:
 
 # How-to Run customized JCK test targets
 
-There is one custom JCK test targets `jck-runtime-custom`. This test target is used as an example to run custom JCK test target in JCK runtime suite.
+There is a custom JCK test target `jck_custom`. This is used to run custom JCK test targets in any JCK testsuite. RUNTIME is the default testsuite.
 
 1. Follow the Steps 1 - 4 mentioned above. 
 
-2. Export `JCK_CUSTOM_TARGET=<jck_test_subset>` as an environment variable or pass it in when run as a make command. For example `export JCK_CUSTOM_TARGET=api/java_math`
+2. Export `JCK_CUSTOM_TARGET=<jck_test_subset>` as an environment variable or pass it in when run as a make command. For example `export JCK_CUSTOM_TARGET=api/java_math`. If a testsuite other than the default is needed, provide that in JCK_CUSTOM_TARGET (e.g., JCK_CUSTOM_TARGET=lang/INFR/....html,testsuite=COMPILER).
 
 3. Make sure the JCK test subset is available in JCK test material folder, a.k.a. `$(JCK_ROOT)`.
 

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -63,6 +63,11 @@ ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
  OTHER_OPTS=-Xtrace:maximal=all{level2}
 endif
 
+# If testsuite is not specified, default to RUNTIME
+ifeq (,$(findstring testsuite, $(JCK_CUSTOM_TARGET)))
+   override JCK_CUSTOM_TARGET := $(JCK_CUSTOM_TARGET),testsuite=RUNTIME
+endif
+
 SYSTEMTEST_RESROOT=$(TEST_RESROOT)/../../system
 
 define JCK_CMD_TEMPLATE

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -19,7 +19,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) -test-args=$(Q)tests=$(JCK_CUSTOM_TARGET),jckRoot=$(JCK_ROOT),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+		<command>$(JCK_CMD_TEMPLATE) -test-args=$(Q)tests=$(JCK_CUSTOM_TARGET),jckRoot=$(JCK_ROOT),jckversion=$(JCK_VERSION)$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
- Resolves backlog/issues/537
- Make users pass in testsuite parameter as part of CUSTOM_TARGET value. This frees up `jck_custom` target from being bound to only one particular testsuite. 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>
