### PR TITLE
Fix the issue when the node is temporarily unavailable

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -270,49 +270,49 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
                        LABEL += '&&ci.agent.dynamic'
                     }
                 }
+            }
 
-                node(LABEL) {
-                    cleanWs()
-                    if (params.PLATFORM.contains('zos')) {
-                        /* Ensure correct CC env */
-                        env._CC_CCMODE = '1'
-                        env._CXX_CCMODE = '1'
-                        env._C89_CCMODE = '1'
+            node(LABEL) {
+                cleanWs()
+                if (params.PLATFORM.contains('zos')) {
+                    /* Ensure correct CC env */
+                    env._CC_CCMODE = '1'
+                    env._CXX_CCMODE = '1'
+                    env._C89_CCMODE = '1'
 
-                        def gitConfig = scm.getUserRemoteConfigs()[0]
-                        def SCM_GIT_REPO = gitConfig.getUrl()
-                        def SCM_GIT_BRANCH = scm.branches[0].name
+                    def gitConfig = scm.getUserRemoteConfigs()[0]
+                    def SCM_GIT_REPO = gitConfig.getUrl()
+                    def SCM_GIT_BRANCH = scm.branches[0].name
 
-                        // SCM_GIT_REPO value only gets expanded in sh
-                        def SCM_GIT_REPO_VAL = sh(script: "echo ${SCM_GIT_REPO}", returnStdout: true).trim()
-                        SCM_GIT_REPO_VAL = SCM_GIT_REPO_VAL.replace("https://github.com/","git@github.com:")
+                    // SCM_GIT_REPO value only gets expanded in sh
+                    def SCM_GIT_REPO_VAL = sh(script: "echo ${SCM_GIT_REPO}", returnStdout: true).trim()
+                    SCM_GIT_REPO_VAL = SCM_GIT_REPO_VAL.replace("https://github.com/","git@github.com:")
 
-                        sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO_VAL} openjdk-tests"
-                    } else {
-                        def gitConfig = scm.getUserRemoteConfigs().get(0)
+                    sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO_VAL} openjdk-tests"
+                } else {
+                    def gitConfig = scm.getUserRemoteConfigs().get(0)
 
-                        // Adopt windows machines require env here https://github.com/AdoptOpenJDK/openjdk-tests/issues/1803
-                        ref_cache = "${env.HOME}/openjdk_cache"
+                    // Adopt windows machines require env here https://github.com/AdoptOpenJDK/openjdk-tests/issues/1803
+                    ref_cache = "${env.HOME}/openjdk_cache"
 
-                        checkout scm: [$class: 'GitSCM',
-                            branches: [[name: "${scm.branches[0].name}"]],
-                            extensions: [
-                                [$class: 'CleanBeforeCheckout'],
-                                [$class: 'CloneOption', reference: ref_cache],
-                                [$class: 'RelativeTargetDirectory', relativeTargetDir: 'openjdk-tests']],
-                            userRemoteConfigs: [[url: "${gitConfig.getUrl()}"]]
-                        ]
-                    }
-                    jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
-                    if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') {
-                        //Set dockerimage for azure agent. Fyre has stencil to setup the right environment
-                        docker.image('adoptopenjdk/centos6_build_image').pull() 
-                        docker.image('adoptopenjdk/centos6_build_image').inside {
-                            jenkinsfile.testBuild()
-                        }
-                    } else {
+                    checkout scm: [$class: 'GitSCM',
+                        branches: [[name: "${scm.branches[0].name}"]],
+                        extensions: [
+                            [$class: 'CleanBeforeCheckout'],
+                            [$class: 'CloneOption', reference: ref_cache],
+                            [$class: 'RelativeTargetDirectory', relativeTargetDir: 'openjdk-tests']],
+                        userRemoteConfigs: [[url: "${gitConfig.getUrl()}"]]
+                    ]
+                }
+                jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+                if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') {
+                    //Set dockerimage for azure agent. Fyre has stencil to setup the right environment
+                    docker.image('adoptopenjdk/centos6_build_image').pull() 
+                    docker.image('adoptopenjdk/centos6_build_image').inside {
                         jenkinsfile.testBuild()
                     }
+                } else {
+                    jenkinsfile.testBuild()
                 }
             }
         }


### PR DESCRIPTION
Currently, the pipleine breaks if users specify a note that is temporarily unavaiable (i.e, ci.agent.dynamic).
Fix the issue by moving the main test execution logic outside of else block.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>