### PR TITLE
Set machine limit for dynamic vm to 100

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -313,6 +313,7 @@ def setupParallelEnv() {
 def getNumMachines(){
 	int num = params.NUM_MACHINES ? params.NUM_MACHINES.toInteger() : 1
 	int limit = getMachineLimit()
+	echo "machine limit is ${limit}"
 	if (num > limit) {
 		echo "Number of machines cannot be greater than ${limit}. Set num to ${limit}"
 		num = limit
@@ -321,7 +322,12 @@ def getNumMachines(){
 }
 
 def getMachineLimit(){
-	return nodesByLabel(LABEL).size()
+	int limit = nodesByLabel(LABEL).size()
+	// Set limit for dynamic vm agents to 100
+	if (LABEL.contains('ci.agent.dynamic')) {
+		limit = 100
+	}
+	return limit
 }
 
 def createJob( TEST_JOB_NAME, ARCH_OS ) {


### PR DESCRIPTION
In parallelization, nodesByLabel(LABEL) for dynamic only returns the number of active vm agents.
This number may be less than the required number. For example, 1 active vm agent is
available and the parallel build requires 5 machines for parallelization. As a result,
we only have 1 machine for parallelization.

This PR sets the machine limit to 100 if LABEL contains dynamic. This number (100) limit
is per parallel parent build and it can be modified as needed in the future.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>