### PR TITLE
Un-exclude JCK-8 targets with failures not related to setup / infra

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -81,11 +81,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-api-signaturetest</testCaseName>
-		<disabled>
-			<comment>Temporarily disabled on aix on JDK8 for test setup issue: backlog/issues/506</comment>
-			<plat>ppc64_aix(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.java2schema/playlist.xml
+++ b/jck/devtools.java2schema/playlist.xml
@@ -16,11 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-java2schema-CustomizedMapping</testCaseName>
-		<disabled>
-			<comment>Disabled on x64 Linux + aarch64 + ppc64le + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.jaxws/playlist.xml
+++ b/jck/devtools.jaxws/playlist.xml
@@ -16,11 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-jaxws-mapping</testCaseName>
-		<disabled>
-			<comment>Disabled on Win32 on jdk8 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
-			<plat>x86-32_windows(_mixed)?|x86-64_windows(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.schema2java/playlist.xml
+++ b/jck/devtools.schema2java/playlist.xml
@@ -16,11 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-schema2java-nisttest</testCaseName>
-		<disabled>
-			<comment>Disabled on x64 Linux + aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -38,11 +33,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema2java-structures</testCaseName>
-		<disabled>
-			<comment>Disabled on aarch64 Linux + aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.schema_bind/playlist.xml
+++ b/jck/devtools.schema_bind/playlist.xml
@@ -16,11 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_class</testCaseName>
-		<disabled>
-			<comment>Disabled on x64 Linux + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>x86-64_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -38,11 +33,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_dom</testCaseName>
-		<disabled>
-			<comment>Disabled on aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -60,11 +50,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_factoryMethod</testCaseName>
-		<disabled>
-			<comment>Disabled on aarch64 + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>aarch64_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -82,11 +67,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_globalBindings</testCaseName>
-		<disabled>
-			<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302, on win64 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
-			<plat>aarch64_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -104,11 +84,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_inlineBinaryData</testCaseName>
-		<disabled>
-			<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>aarch64_linux(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -143,11 +118,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_property</testCaseName>
-		<disabled>
-			<comment>Disabled on x64 Linux + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>x86-64_linux(_mixed)?|x86-64_windows(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -165,11 +135,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_schemaBindings</testCaseName>
-		<disabled>
-			<comment>Disabled on ppc64le Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>ppc64le_linux(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.xml_schema/playlist.xml
+++ b/jck/devtools.xml_schema/playlist.xml
@@ -16,11 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-boeingData</testCaseName>
-		<disabled>
-			<comment>Disabled on x64 Linux + aarch64 + ppc64le + win32 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?|x86-32_windows(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -38,11 +33,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-msData</testCaseName>
-		<disabled>
-			<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -60,11 +50,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-nistData</testCaseName>
-		<disabled>
-			<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -82,11 +67,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-sunData</testCaseName>
-		<disabled>
-			<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<plat>x86-64_linux(_mixed)?||aarch64_linux(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -392,11 +392,6 @@
 			<plat>x86-64_mac</plat>
 			<version>16+</version>
 		</disabled>
-		<disabled>
-			<comment>Disabled on win64 on jdk8 due to backlog/issues/504. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-			<plat>x86-64_windows(_mixed)?</plat>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -544,11 +539,6 @@
 			<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<plat>x86-64_windows(_mixed)?</plat>
 			<version>11</version>
-		</disabled>
-		<disabled>
-			<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-			<plat>x86-64_windows(_mixed)?</plat>
-			<version>8</version>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
@@ -773,10 +763,6 @@
 			<comment>Disabled on all platforms due to backlog/issues/461. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 			<version>11</version>
 		</disabled>
-		<disabled>
-			<comment>Disabled on all platforms due to backlog/issues/461. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-			<version>8</version>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -893,8 +879,8 @@
 			<plat>x86-64_mac</plat>
 		</disabled>
 		<disabled>
-			<comment>Disabled on osx on jdk8 due to backlog/issues/5254 and on win32 due to backlog/issues/503. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-			<plat>x86-64_mac(_mixed)?|x86-32_windows(_mixed)?</plat>
+			<comment>Disabled on osx on jdk8 due to backlog/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<plat>x86-64_mac(_mixed)?</plat>
 			<version>8</version>
 		</disabled>
 		<variations>


### PR DESCRIPTION
This PR un-excludes jck8 targets with failures not related to setup/infra issues. Test issues corresponding to these excludes are listed in the table in backlog/issues/500 . This PR will make sure we are running the maximum set of tests at all times.  

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>

FYI @JasonFengJ9 