### PR TITLE
rename opendjk-tests to aqa-tests

### DIFF
--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -1,4 +1,4 @@
-name: "PR Comment Build Action for openjdk-tests"
+name: "PR Comment Build Action for aqa-tests"
 on:
   issue_comment:
     types: [created]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For nightly and release builds, there are test jobs running as part of the Adopt
 
 #### Test 'Inventory'
 
-The directory structure in this openjdk-tests repository is meant to reflect the different types of test we run (and pull from lots of other locations).  The diagrams below show the test make target for each of the types, along with in-plan, upcoming additions (denoted by dotted line grey boxes). The provided links jump to test jobs in Jenkins (ci.adoptopenjdk.net).
+The directory structure in this aqa-tests repository is meant to reflect the different types of test we run (and pull from lots of other locations).  The diagrams below show the test make target for each of the types, along with in-plan, upcoming additions (denoted by dotted line grey boxes). The provided links jump to test jobs in Jenkins (ci.adoptopenjdk.net).
 
 ![overview of tests](doc/diagrams/overviewOfAdoptTests.svg)
 
@@ -83,7 +83,7 @@ The test infrastructure in this repository allows us to lightly yoke a great var
 
 #### How can you help?
 You can:
-- browse through the [openjdk-tests issues list](https://github.com/adoptium/aqa-tests/issues), select one, add a comment to claim it and ask questions
+- browse through the [aqa-tests issues list](https://github.com/adoptium/aqa-tests/issues), select one, add a comment to claim it and ask questions
 - browse through the [aqa-systemtest issues](https://github.com/adoptium/aqa-systemtest/issues) or [stf issues](https://github.com/adoptium/stf/issues), claim one with a comment and dig right in
 - triage live test jobs at [ci.adoptopenjdk.net](https://ci.adoptopenjdk.net), check out the [triage doc](https://github.com/adoptium/aqa-tests/blob/master/doc/Triage.md) for guidance
   - if you would like to regularly triage test jobs, you can optionally 'sign up for duty' via the [triage rotas](https://github.com/adoptium/aqa-tests/wiki/AdoptOpenJDK-Test-Triage-Rotas)

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -13,8 +13,8 @@ def getBuildList() {
 }
 
 def makeTest(testParam) {
-	String tearDownCmd = "$RESOLVED_MAKE; \$MAKE -f ./openjdk-tests/TKG/testEnv.mk testEnvTeardown"
-	String makeTestCmd = "$RESOLVED_MAKE; cd ./openjdk-tests/TKG; \$MAKE $testParam"
+	String tearDownCmd = "$RESOLVED_MAKE; \$MAKE -f ./aqa-tests/TKG/testEnv.mk testEnvTeardown"
+	String makeTestCmd = "$RESOLVED_MAKE; cd ./aqa-tests/TKG; \$MAKE $testParam"
 	try {
 		sh "$tearDownCmd"
 		sh "$makeTestCmd"
@@ -158,8 +158,8 @@ def setupParallelEnv() {
 				try {
 					//get cached TRSS JSON data
 					timeout(time: 1, unit: 'HOURS') {
-						copyArtifacts fingerprintArtifacts: true, projectName: "getTRSSOutput", selector: lastSuccessful(), target: 'openjdk-tests/TKG/resources/TRSS'
-						sh "cd ./openjdk-tests/TKG/resources/TRSS; gzip -cd TRSSOutput.tar.gz | tar xof -; rm TRSSOutput.tar.gz"
+						copyArtifacts fingerprintArtifacts: true, projectName: "getTRSSOutput", selector: lastSuccessful(), target: 'aqa-tests/TKG/resources/TRSS'
+						sh "cd ./aqa-tests/TKG/resources/TRSS; gzip -cd TRSSOutput.tar.gz | tar xof -; rm TRSSOutput.tar.gz"
 					}
 				} catch (Exception e) {
 					echo 'Cannot get cached TRSS JSON data. Skipping copyArtifacts...'
@@ -168,16 +168,16 @@ def setupParallelEnv() {
 				try {
 					//get pre-staged jars from test.getDependency build
 					timeout(time: 1, unit: 'HOURS') {
-						copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'openjdk-tests/TKG/lib'
+						copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'aqa-tests/TKG/lib'
 					}
 				} catch (Exception e) {
 					echo 'Cannot run copyArtifacts from test.getDependency. Skipping copyArtifacts...'
 				}
 
-				sh "cd ./openjdk-tests/TKG; make genParallelList ${PARALLEL_OPTIONS}"
+				sh "cd ./aqa-tests/TKG; make genParallelList ${PARALLEL_OPTIONS}"
 
 				// get NUM_LIST from parallelList.mk. NUM_LIST can be different than numOfMachines
-				def parallelList = "openjdk-tests/TKG/parallelList.mk"
+				def parallelList = "aqa-tests/TKG/parallelList.mk"
 				int NUM_LIST = -1
 				if (fileExists("${parallelList}")) {
 					if (SPEC.startsWith('zos')) {
@@ -195,7 +195,7 @@ def setupParallelEnv() {
 				} else if ( NUM_LIST > 0) {
 					childJobNum = NUM_LIST
 					echo "Saving parallelList.mk file on jenkins..."
-					dir('openjdk-tests/TKG') {
+					dir('aqa-tests/TKG') {
 						archiveArtifacts artifacts: 'parallelList.mk', fingerprint: true, allowEmptyArchive: false
 					}
 
@@ -203,7 +203,7 @@ def setupParallelEnv() {
 					assert false : "Build failed because cannot find NUM_LIST in parallelList.mk file."
 				}
 			} else if (params.PARALLEL == "Subdir") {
-				dir("$WORKSPACE/openjdk-tests/${env.BUILD_LIST}") {
+				dir("$WORKSPACE/aqa-tests/${env.BUILD_LIST}") {
 					testSubDirs = sh(returnStdout: true, script: "ls -d */").trim().tokenize()
 				}
 
@@ -353,7 +353,7 @@ def createJob( TEST_JOB_NAME, ARCH_OS ) {
 		}
 	}
 
-	def templatePath = 'openjdk-tests/buildenv/jenkins/testJobTemplate'
+	def templatePath = 'aqa-tests/buildenv/jenkins/testJobTemplate'
 
 	if (params.LIGHT_WEIGHT_CHECKOUT) {
 		jobParams.put('LIGHT_WEIGHT_CHECKOUT', params.LIGHT_WEIGHT_CHECKOUT)
@@ -433,7 +433,7 @@ def setup() {
 			// Only set image required to false if params is set to false. In get.sh, the default value is true
 			TEST_IMAGES_REQUIRED = (params.TEST_IMAGES_REQUIRED == false) ? "--test_images_required false" : ""
 			DEBUG_IMAGES_REQUIRED = (params.DEBUG_IMAGES_REQUIRED == false) ? "--debug_images_required false" : ""
-			GET_SH_CMD = "./openjdk-tests/get.sh -s `pwd` -t `pwd`/openjdk-tests -p $PLATFORM -r ${SDK_RESOURCE} ${JDK_VERSION_OPTION} ${JDK_IMPL_OPTION} ${CUSTOMIZED_SDK_URL_OPTION} ${CUSTOMIZED_SDK_SOURCE_URL_OPTION} ${CLONE_OPENJ9_OPTION} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${TKG_REPO_OPTION} ${TKG_BRANCH_OPTION} ${TKG_SHA_OPTION} ${VENDOR_TEST_REPOS} ${VENDOR_TEST_BRANCHES} ${VENDOR_TEST_DIRS} ${VENDOR_TEST_SHAS} ${TEST_IMAGES_REQUIRED} ${DEBUG_IMAGES_REQUIRED}"
+			GET_SH_CMD = "./aqa-tests/get.sh -s `pwd` -t `pwd`/aqa-tests -p $PLATFORM -r ${SDK_RESOURCE} ${JDK_VERSION_OPTION} ${JDK_IMPL_OPTION} ${CUSTOMIZED_SDK_URL_OPTION} ${CUSTOMIZED_SDK_SOURCE_URL_OPTION} ${CLONE_OPENJ9_OPTION} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${TKG_REPO_OPTION} ${TKG_BRANCH_OPTION} ${TKG_SHA_OPTION} ${VENDOR_TEST_REPOS} ${VENDOR_TEST_BRANCHES} ${VENDOR_TEST_DIRS} ${VENDOR_TEST_SHAS} ${TEST_IMAGES_REQUIRED} ${DEBUG_IMAGES_REQUIRED}"
 
 			RESOLVED_MAKE = "if [ `uname` = AIX ] || [ `uname` = SunOS ] || [ `uname` = *BSD ]; then MAKE=gmake; else MAKE=make; fi"
 			
@@ -452,7 +452,7 @@ def setup() {
 }
 
 def getJobProperties() {
-	def jobProperties = "./openjdk-tests/job.properties"
+	def jobProperties = "./aqa-tests/job.properties"
 	if (fileExists("${jobProperties}")) {
 		echo "readProperties file: ${jobProperties}"
 		def properties = readProperties file: "${jobProperties}"
@@ -483,7 +483,7 @@ def get_sources() {
 }
 
 def makeCompileTest() {
-	String makeTestCmd = "$RESOLVED_MAKE; cd ./openjdk-tests/TKG; \$MAKE compile"
+	String makeTestCmd = "$RESOLVED_MAKE; cd ./aqa-tests/TKG; \$MAKE compile"
 	// use sshagent with Jenkins credentials ID for all platforms except zOS
 	if (!env.SPEC.startsWith('zos')) {
 		sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"], ignoreMissing: true) {
@@ -510,7 +510,7 @@ def buildTest() {
 			if (params.UPSTREAM_TEST_JOB_NAME && params.UPSTREAM_TEST_JOB_NUMBER) {
 				try {
 					timeout(time: 1, unit: 'HOURS') {
-						copyArtifacts fingerprintArtifacts: true, projectName: params.UPSTREAM_TEST_JOB_NAME, selector: specific(params.UPSTREAM_TEST_JOB_NUMBER), target: './openjdk-tests/TKG/'
+						copyArtifacts fingerprintArtifacts: true, projectName: params.UPSTREAM_TEST_JOB_NAME, selector: specific(params.UPSTREAM_TEST_JOB_NUMBER), target: './aqa-tests/TKG/'
 					}
 				} catch (Exception e) {
 					echo "Cannot run copyArtifacts from ${params.UPSTREAM_TEST_JOB_NAME} ${params.UPSTREAM_TEST_JOB_NUMBER}. Skipping copyArtifacts..."
@@ -520,7 +520,7 @@ def buildTest() {
 			try {
 				//get pre-staged jars from test.getDependency build before test compilation
 				timeout(time: 1, unit: 'HOURS') {
-					copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'openjdk-tests/TKG/lib'
+					copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'aqa-tests/TKG/lib'
 				}
 			} catch (Exception e) {
 				echo 'Cannot run copyArtifacts from test.getDependency. Skipping copyArtifacts...'
@@ -530,7 +530,7 @@ def buildTest() {
 				if (env.BUILD_LIST.startsWith('system') || env.BUILD_LIST.startsWith('jck')) {
 					//get pre-staged test jars from systemtest.getDependency build before system test compilation
 					timeout(time: 1, unit: 'HOURS') {
-						copyArtifacts fingerprintArtifacts: true, projectName: "systemtest.getDependency", selector: lastSuccessful(), target: 'openjdk-tests'
+						copyArtifacts fingerprintArtifacts: true, projectName: "systemtest.getDependency", selector: lastSuccessful(), target: 'aqa-tests'
 					}
 				}
 			} catch (Exception e) {
@@ -574,7 +574,7 @@ def runTest( ) {
 			if (!TARGET.startsWith('-f')) {
 				TARGET="_${params.TARGET}"
 			} else if (TARGET.contains('-f parallelList.mk') && SPEC.startsWith('zos')) {
-				def parallelList = "openjdk-tests/TKG/parallelList.mk"
+				def parallelList = "aqa-tests/TKG/parallelList.mk"
 				if (fileExists("${parallelList}")) {
 					echo 'Converting parallelList.mk file from ascii to ebcdic...'
 					sh "iconv -f iso8859-1 -t ibm-1047 ${parallelList} > ${parallelList}.ebcdic; rm ${parallelList}; mv ${parallelList}.ebcdic ${parallelList}"
@@ -628,7 +628,7 @@ def post(output_name) {
 			def pax_opt = ""
 			if (SPEC.startsWith('zos')) {
 				echo 'Converting tap file from ebcdic to ascii...'
-				sh 'cd ./openjdk-tests/TKG'
+				sh 'cd ./aqa-tests/TKG'
 				def tapFiles = findFiles(glob: "**/*.tap")
 				for (String tapFile : tapFiles) {
 					sh "iconv -f ibm-1047 -t iso8859-1 ${tapFile} > ${tapFile}.ascii; rm ${tapFile}; mv ${tapFile}.ascii ${tapFile}"
@@ -656,7 +656,7 @@ def post(output_name) {
 
 			if (env.BUILD_LIST.startsWith('jck')) {
 				xunit (
-				tools: [Custom(customXSL: "$WORKSPACE/openjdk-tests/jck/xUnit.xsl",
+				tools: [Custom(customXSL: "$WORKSPACE/aqa-tests/jck/xUnit.xsl",
 					deleteOutputFiles: true,
 					failIfNotNew: true,
 					pattern: "**/TKG/output_*/**/report.xml",
@@ -668,7 +668,7 @@ def post(output_name) {
 			//for performance test, archive regardless the build result
 			if (env.BUILD_LIST.startsWith('perf')) {
 				def benchmark_output_tar_name = "benchmark_test_output${suffix}"
-				sh "${tar_cmd} ${benchmark_output_tar_name} ${pax_opt} ./openjdk-tests/TKG/output_*"
+				sh "${tar_cmd} ${benchmark_output_tar_name} ${pax_opt} ./aqa-tests/TKG/output_*"
 				if (!params.ARTIFACTORY_SERVER) {
 					echo "ARTIFACTORY_SERVER is not set. Saving artifacts on jenkins."
 					archiveArtifacts artifacts: benchmark_output_tar_name, fingerprint: true, allowEmptyArchive: true
@@ -679,9 +679,9 @@ def post(output_name) {
 			} else if ((currentBuild.result == 'UNSTABLE' || currentBuild.result == 'FAILURE' || currentBuild.result == 'ABORTED') || params.ARCHIVE_TEST_RESULTS) {
 				def test_output_tar_name = "${output_name}_test_output${suffix}"
 				if (tar_cmd.startsWith('tar')) {
-					sh "${tar_cmd} - ${pax_opt} ./openjdk-tests/TKG/output_* ${tar_cmd_suffix} > ${test_output_tar_name}"
+					sh "${tar_cmd} - ${pax_opt} ./aqa-tests/TKG/output_* ${tar_cmd_suffix} > ${test_output_tar_name}"
 				} else {
-					sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./openjdk-tests/TKG/output_* ${tar_cmd_suffix}"
+					sh "${tar_cmd} ${test_output_tar_name} ${pax_opt} ./aqa-tests/TKG/output_* ${tar_cmd_suffix}"
 				}
 
 				if (!params.ARTIFACTORY_SERVER) {
@@ -825,7 +825,7 @@ def getJenkinsDomain() {
 }
 
 def archiveSHAFile() {
-	def shaFile = "openjdk-tests/TKG/SHA.txt";
+	def shaFile = "aqa-tests/TKG/SHA.txt";
 	if (!params.ARTIFACTORY_SERVER) {
 		echo "ARTIFACTORY_SERVER is not set. Saving SHA file on jenkins."
 		archiveArtifacts artifacts: shaFile, fingerprint: true, allowEmptyArchive: true

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -288,7 +288,7 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
                     def SCM_GIT_REPO_VAL = sh(script: "echo ${SCM_GIT_REPO}", returnStdout: true).trim()
                     SCM_GIT_REPO_VAL = SCM_GIT_REPO_VAL.replace("https://github.com/","git@github.com:")
 
-                    sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO_VAL} openjdk-tests"
+                    sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO_VAL} aqa-tests"
                 } else {
                     def gitConfig = scm.getUserRemoteConfigs().get(0)
 
@@ -300,11 +300,11 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
                         extensions: [
                             [$class: 'CleanBeforeCheckout'],
                             [$class: 'CloneOption', reference: ref_cache],
-                            [$class: 'RelativeTargetDirectory', relativeTargetDir: 'openjdk-tests']],
+                            [$class: 'RelativeTargetDirectory', relativeTargetDir: 'aqa-tests']],
                         userRemoteConfigs: [[url: "${gitConfig.getUrl()}"]]
                     ]
                 }
-                jenkinsfile = load "${WORKSPACE}/openjdk-tests/buildenv/jenkins/JenkinsfileBase"
+                jenkinsfile = load "${WORKSPACE}/aqa-tests/buildenv/jenkins/JenkinsfileBase"
                 if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') {
                     //Set dockerimage for azure agent. Fyre has stencil to setup the right environment
                     docker.image('adoptopenjdk/centos6_build_image').pull() 

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -136,7 +136,7 @@ def ADOPTOPENJDK_BRANCH = "master"
 // If LIGHT_WEIGHT_CHECKOUT is set to true, set Repository URL and Branch to its explicit value
 def ADOPTOPENJDK_REPO_BUILD_PARAM = '${ADOPTOPENJDK_REPO}'
 def ADOPTOPENJDK_BRANCH_BUILD_PARAM = '${ADOPTOPENJDK_BRANCH}'
-def SCRIPT_PATH = "openjdk-tests/buildenv/jenkins/openjdk_tests"
+def SCRIPT_PATH = "aqa-tests/buildenv/jenkins/openjdk_tests"
 
 LIGHT_WEIGHT_CHECKOUT = LIGHT_WEIGHT_CHECKOUT.toBoolean()
 if (LIGHT_WEIGHT_CHECKOUT) {
@@ -391,7 +391,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 									}
 									branch(ADOPTOPENJDK_BRANCH_BUILD_PARAM)
 									extensions {
-										relativeTargetDirectory('openjdk-tests')
+										relativeTargetDirectory('aqa-tests')
 										cleanBeforeCheckout()
 										pruneStaleBranch()
 										cloneOptions {

--- a/external/README.md
+++ b/external/README.md
@@ -1,6 +1,6 @@
 # External (Third Party Container) Tests
 
-Third Party container tests help verify that the AdoptOpenJDK binaries are *good* by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the AdoptOpenJDK binaries.  For each application, we choose to run a selection of their functional tests.  
+Third Party container tests help verify that the AdoptOpenJDK binaries are *good* by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the AdoptOpenJDK binaries.  For each application, we choose to run a selection of their functional tests.  
 
 ## Running External tests locally
 To run any AQA tests locally, you follow the same pattern:
@@ -10,15 +10,15 @@ To run any AQA tests locally, you follow the same pattern:
 1. Download/unpack the SDK that you want to test to your test machine
 1. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>` 
 1. `git clone https://github.com/adoptium/aqa-tests.git` 
-1. `cd openjdk-tests`
+1. `cd aqa-tests`
 1. `./get.sh`
 1. `cd TKG`
 1. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (example: `export BUILD_LIST=external/jacoco` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 1. `make compile`              (This fetches test material and compiles it, based on build.xml files in the test directories)
-1. `make _jacoco_test`   (When you defined BUILD_LIST to point to a directory in [openjdk-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
+1. `make _jacoco_test`   (When you defined BUILD_LIST to point to a directory in [aqa-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
 
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory.  This is unadvisable!  Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`  
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory.  This is unadvisable!  Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`  
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).
 
@@ -49,7 +49,7 @@ There are 4 common triage scenarios, with associated appropriate actions to take
 - Clone https://github.com/adoptium/aqa-tests.git and look at external directory.
 - Copy the 'example-test' subdirectory and rename it after the application you are adding. 
 - Modify the files in your new sub-directory according to your needs. 
-- Check in the changes into https://github.com/[YOUR-BRANCH]/openjdk-tests and test it using a <a href="https://github.com/adoptium/aqa-tests/wiki/How-to-Run-a-Personal-Test-Build-on-Jenkins">personal build</a>. 
+- Check in the changes into https://github.com/[YOUR-BRANCH]/aqa-tests and test it using a <a href="https://github.com/adoptium/aqa-tests/wiki/How-to-Run-a-Personal-Test-Build-on-Jenkins">personal build</a>. 
 
 #### Which files do I need to modify after making a copy of example-test?
 

--- a/external/camel/README.md
+++ b/external/camel/README.md
@@ -1,5 +1,5 @@
 # External Camel Tests
-Camel tests are part of the third-party application tests help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/Issue #172 lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests.Camel tests are functional tests pulled from the [camel-quarkus](https://github.com/apache/camel-quarkus.git) repository.
+Camel tests are part of the third-party application tests help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/Issue #172 lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests.Camel tests are functional tests pulled from the [camel-quarkus](https://github.com/apache/camel-quarkus.git) repository.
 
 ## Running External Camel tests locally
 To run any AQA tests locally, you follow the same pattern:
@@ -9,13 +9,13 @@ To run any AQA tests locally, you follow the same pattern:
 
 2. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>`
 3. `git clone https://github.com/adoptium/aqa-tests.git`
-4. `cd openjdk-tests`
+4. `cd aqa-tests`
 5. `./get.sh`
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/camel` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make _camel_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make _camel_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).
 

--- a/external/derby/README.md
+++ b/external/derby/README.md
@@ -14,8 +14,8 @@ To run any AQA tests locally, you follow the same pattern:
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/derby` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make derby-test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make derby-test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/elasticsearch/README.md
+++ b/external/elasticsearch/README.md
@@ -1,6 +1,6 @@
 # External Elasticsearch Tests
 
-Elasticsearch tests are a part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Elasticsearch test material is pulled from the [elasticsearch](https://github.com/elastic/elasticsearch.git) repository.
+Elasticsearch tests are a part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Elasticsearch test material is pulled from the [elasticsearch](https://github.com/elastic/elasticsearch.git) repository.
 
 ## Running External Elasticsearch tests locally
 
@@ -14,7 +14,7 @@ To run AQA tests locally using elasticsearch, you follow the same pattern:
 
 3. `git clone https://github.com/adoptium/aqa-tests.git`
 
-4. `cd openjdk-tests`
+4. `cd aqa-tests`
 
 5. `./get.sh`
 
@@ -24,8 +24,8 @@ To run AQA tests locally using elasticsearch, you follow the same pattern:
 
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
 
-9. `make _elasticsearch_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make _elasticsearch_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/functional-test/dockerfile/functional-test.sh
+++ b/external/functional-test/dockerfile/functional-test.sh
@@ -35,10 +35,10 @@ export BUILD_LIST=functional
 
 echo_setup
 
-cd /openjdk-tests
-./get.sh -t /openjdk-tests
+cd /aqa-tests
+./get.sh -t /aqa-tests
 
-cd /openjdk-tests/TKG
+cd /aqa-tests/TKG
 
 set -e
 

--- a/external/jacoco/README.md
+++ b/external/jacoco/README.md
@@ -1,6 +1,6 @@
 ## External Jacoco Tests
 
-Jacoco tests are part of the external third-party application tests that help verify that the Adoptium binaries are good, by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/Issue #172 lists the applications that we have initially targeted to best exercise the AdoptOpenJDK binaries. For each application, we choose to run a selection of their functional tests.
+Jacoco tests are part of the external third-party application tests that help verify that the Adoptium binaries are good, by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/Issue #172 lists the applications that we have initially targeted to best exercise the AdoptOpenJDK binaries. For each application, we choose to run a selection of their functional tests.
 Jacoco test material is pulled from the [Jacoco repository](https://github.com/jacoco/jacoco).
 
 ## Running External Jacoco tests locally
@@ -10,13 +10,13 @@ To run any AQA tests locally, you follow the same pattern:
 1. Download/unpack the SDK that you want to test to your test machine
 1. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>`
 1. `git clone https://github.com/adoptium/aqa-tests.git`
-1. `cd openjdk-tests`
+1. `cd aqa-tests`
 1. `./get.sh`
 1. `cd TKG`
 1. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/jacoco> and <export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`)
 1. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-1.`make _jacoco_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose).
+1.`make _jacoco_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose).
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/jenkins/README.md
+++ b/external/jenkins/README.md
@@ -12,7 +12,7 @@ To run any AQA tests locally, you follow the same pattern:
 1. Download/unpack the SDK that you want to test to your test machine
 1. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>`
 1. `git clone https://github.com/adoptium/aqa-tests.git`
-1. `cd openjdk-tests`
+1. `cd aqa-tests`
 1. `./get.sh`
 1. `cd TKG`
 1. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/jenkins> and <export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`)

--- a/external/kafka/README.md
+++ b/external/kafka/README.md
@@ -1,6 +1,6 @@
 # External Kafka Tests
 
-Apache kafka tests are part of the external third-party application tests that help verify that the Adoptium binaries are good, by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the AdoptOpenJDK binaries.  For each application, we choose to run a selection of their functional tests.
+Apache kafka tests are part of the external third-party application tests that help verify that the Adoptium binaries are good, by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the AdoptOpenJDK binaries.  For each application, we choose to run a selection of their functional tests.
 Kafka test material is pulled from the [Kafka](https://github.com/apache/kafka.git) repository. 
 
 ## Running External Kafka tests locally
@@ -11,14 +11,14 @@ To run any AQA tests locally, you follow the same pattern:
 1. Download/unpack the SDK that you want to test to your test machine.
 1. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>`
 1. `git clone https://github.com/adoptium/aqa-tests.git`
-1. `cd openjdk-tests`
+1. `cd aqa-tests`
 1. `./get.sh`
 1. `cd TKG`
 1. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (example: `export BUILD_LIST=external/kafka` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 1. `make compile`              (This fetches test material and compiles it, based on build.xml files in the test directories)
-1. `make _kafka_test`   (When you defined BUILD_LIST to point to a directory in [openjdk-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
+1. `make _kafka_test`   (When you defined BUILD_LIST to point to a directory in [aqa-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
 
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory.  This is unadvisable!  Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`  
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory.  This is unadvisable!  Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`  
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/lucene-solr/README.md
+++ b/external/lucene-solr/README.md
@@ -15,8 +15,8 @@ To run any AQA tests locally, you follow the same pattern:
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/lucene-solr` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make lucene-solr_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make lucene-solr_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/netty/README.md
+++ b/external/netty/README.md
@@ -1,6 +1,6 @@
 # External Netty Tests
 
-Netty tests are a part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Netty test material is pulled from the [netty](https://github.com/netty/netty.git) repository.
+Netty tests are a part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Netty test material is pulled from the [netty](https://github.com/netty/netty.git) repository.
 
 ## Running External Netty tests locally
 
@@ -14,7 +14,7 @@ To run AQA tests locally using netty, you follow the same pattern:
 
 3. `git clone https://github.com/adoptium/aqa-tests.git`
 
-4. `cd openjdk-tests`
+4. `cd aqa-tests`
 
 5. `./get.sh`
 
@@ -24,8 +24,8 @@ To run AQA tests locally using netty, you follow the same pattern:
 
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
 
-9. `make _netty_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make _netty_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/payara-mp-tck/README.md
+++ b/external/payara-mp-tck/README.md
@@ -13,7 +13,7 @@
 -->
 # External Payara-mp-tck Tests
 
-Payara-mp-tck(payara MicroProfile-tck) tests are part of the third-party application tests that helps verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/Issue #172 lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests.payara-mp-tck tests are functional tests pulled from the [payara/MicroProfile-TCK-Runners](https://github.com/payara/MicroProfile-TCK-Runners.git) repository.
+Payara-mp-tck(payara MicroProfile-tck) tests are part of the third-party application tests that helps verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/Issue #172 lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests.payara-mp-tck tests are functional tests pulled from the [payara/MicroProfile-TCK-Runners](https://github.com/payara/MicroProfile-TCK-Runners.git) repository.
 
 ## Running  External Payara-mp-tck tests locally
 To run any AQA tests locally, you follow the same pattern:
@@ -23,14 +23,14 @@ To run any AQA tests locally, you follow the same pattern:
 1. Download/unpack the SDK that you want to test to your test machine.
 2. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>` 
 3. `git clone https://github.com/adoptium/aqa-tests.git` 
-4. `cd openjdk-tests`
+4. `cd aqa-tests`
 5. `./get.sh`
 6. `cd TKG`
 7. Export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (example: `export BUILD_LIST=external/payara-mp-tck` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile`              (This fetches test material and compiles it, based on build.xml files in the test directories).
-9. `make _payara-mp-tck_test`   (When you defined BUILD_LIST to point to a directory in [openjdk-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose).
+9. `make _payara-mp-tck_test`   (When you defined BUILD_LIST to point to a directory in [aqa-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose).
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory.  This is unadvisable!  Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`  
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory.  This is unadvisable!  Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`  
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).
 

--- a/external/quarkus/README.md
+++ b/external/quarkus/README.md
@@ -15,8 +15,8 @@ To run any AQA tests locally, you follow the same pattern:
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/quarkus` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make quarkus_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make quarkus_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/quarkus_openshift/README.md
+++ b/external/quarkus_openshift/README.md
@@ -1,6 +1,6 @@
 # External quarkus_openshift Tests
 
-Quarkus_openshift tests are part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/Issue [#172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Quarkus Openshift tests are pulled from the [quarkus-openshift-test-suite](https://github.com/quarkus-qe/quarkus-openshift-test-suite.git) repository. These tests require an Openshift cluster environment to run.
+Quarkus_openshift tests are part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/Issue [#172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Quarkus Openshift tests are pulled from the [quarkus-openshift-test-suite](https://github.com/quarkus-qe/quarkus-openshift-test-suite.git) repository. These tests require an Openshift cluster environment to run.
 
 ## Running quarkus-openshift tests locally
 
@@ -14,7 +14,7 @@ To run any AQA tests locally, you follow the same pattern:
 
 3. `git clone https://github.com/adoptium/aqa-tests.git`
 
-4. `cd openjdk-tests`
+4. `cd aqa-tests`
 
 5. `./get.sh`
 
@@ -24,8 +24,8 @@ To run any AQA tests locally, you follow the same pattern:
 
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
 
-9.  `make _quarkus_openshift_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9.  `make _quarkus_openshift_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`.
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`.
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/quarkus_quickstarts/README.md
+++ b/external/quarkus_quickstarts/README.md
@@ -15,8 +15,8 @@ To run any AQA tests locally, you follow the same pattern:
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/quarkus_quickstart` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make quarkus_quickstart_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make quarkus_quickstart_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/scala/README.md
+++ b/external/scala/README.md
@@ -24,8 +24,8 @@ To run any AQA tests locally, you follow the same pattern:
 
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
 
-9.  `make scala_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9.  `make scala_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`.
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`.
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/spring/README.md
+++ b/external/spring/README.md
@@ -1,6 +1,6 @@
 # External Spring Tests
 
-Spring tests are part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/Issue [#172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Spring tests are pulled from the [spring-test-suite](https://github.com/spring-projects/spring-boot.git) repository.
+Spring tests are part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/Issue [#172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Spring tests are pulled from the [spring-test-suite](https://github.com/spring-projects/spring-boot.git) repository.
 
 
 ## Running spring tests locally
@@ -14,7 +14,7 @@ To run any AQA tests locally, you follow the same pattern:
 
    3. `git clone https://github.com/adoptium/aqa-tests.git`
 
-   4. `cd openjdk-tests`
+   4. `cd aqa-tests`
 
    5. `./get.sh`
 
@@ -24,8 +24,8 @@ To run any AQA tests locally, you follow the same pattern:
 
    8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
 
-   9. `make _spring_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+   9. `make _spring_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/system-test/dockerfile/Dockerfile
+++ b/external/system-test/dockerfile/Dockerfile
@@ -50,7 +50,7 @@ COPY ./dockerfile/system-test.sh /system-test.sh
 # Clone the repo where the 3rd party application code and tests reside. 
 WORKDIR /
 
-# Clone AdoptOpenJDK openjdk-tests repo
+# Clone AdoptOpenJDK aqa-tests repo
 RUN git clone https://github.com/adoptium/aqa-tests.git
 
 ENTRYPOINT ["/bin/bash", "/system-test.sh"]

--- a/external/system-test/dockerfile/system-test.sh
+++ b/external/system-test/dockerfile/system-test.sh
@@ -35,10 +35,10 @@ export BUILD_LIST=system
 
 echo_setup
 
-cd /openjdk-tests
-./get.sh -t /openjdk-tests
+cd /aqa-tests
+./get.sh -t /aqa-tests
 
-cd /openjdk-tests/TKG
+cd /aqa-tests/TKG
 
 make compile
 make $1

--- a/external/thorntail-mp-tck/README.md
+++ b/external/thorntail-mp-tck/README.md
@@ -1,6 +1,6 @@
 # External Thorntail Microprofile TCK Tests
 
-Thorntail Microprofile TCK tests are a part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Thorntail-mp-tck test material is pulled from the [thorntail](https://github.com/thorntail/thorntail) repository.
+Thorntail Microprofile TCK tests are a part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Thorntail-mp-tck test material is pulled from the [thorntail](https://github.com/thorntail/thorntail) repository.
 
 ## Running External Thorntail-mp-tck tests locally
 
@@ -14,7 +14,7 @@ To run AQA tests locally using thorntail-mp-tck, you follow the same pattern:
 
 3. `git clone https://github.com/adoptium/aqa-tests.git`
 
-4. `cd openjdk-tests`
+4. `cd aqa-tests`
 
 5. `./get.sh`
 
@@ -24,8 +24,8 @@ To run AQA tests locally using thorntail-mp-tck, you follow the same pattern:
 
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
 
-9. `make _thorntail-mp-tck_test` (When you defined BUILD_LIST to point to a directory in [openjdk-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make _thorntail-mp-tck_test` (When you defined BUILD_LIST to point to a directory in [aqa-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`thorntail-mp-tck`, and TARGET=`testCaseNameFromPlaylistUnderDirthorntail-mp-tck`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`thorntail-mp-tck`, and TARGET=`testCaseNameFromPlaylistUnderDirthorntail-mp-tck`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/tomcat/README.md
+++ b/external/tomcat/README.md
@@ -14,8 +14,8 @@ To run any AQA tests locally, you follow the same pattern:
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/tomcat` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make tomcat_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make tomcat_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/tomee/README.md
+++ b/external/tomee/README.md
@@ -1,6 +1,6 @@
 # External TomEE Tests
 
-Apache TomEE tests are part of the external third-party application tests that help verify that the Adoptium binaries are good... by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the AdoptOpenJDK binaries.  For each application, we choose to run a selection of their functional tests.  
+Apache TomEE tests are part of the external third-party application tests that help verify that the Adoptium binaries are good... by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the AdoptOpenJDK binaries.  For each application, we choose to run a selection of their functional tests.  
 
 ## Running External TomEE tests locally
 To run any AQA tests locally, you follow the same pattern:
@@ -10,14 +10,14 @@ To run any AQA tests locally, you follow the same pattern:
 1. Download/unpack the SDK that you want to test to your test machine
 1. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>`
 1. `git clone https://github.com/adoptium/aqa-tests.git`
-1. `cd openjdk-tests`
+1. `cd aqa-tests`
 1. `./get.sh`
 1. `cd TKG`
 1. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (example: `export BUILD_LIST=external/tomee` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 1. `make compile`              (This fetches test material and compiles it, based on build.xml files in the test directories)
-1. `make _tomee_test`   (When you defined BUILD_LIST to point to a directory in [openjdk-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
+1. `make _tomee_test`   (When you defined BUILD_LIST to point to a directory in [aqa-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
 
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory.  This is unadvisable!  Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`  
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory.  This is unadvisable!  Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`  
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/wildfly/README.md
+++ b/external/wildfly/README.md
@@ -1,6 +1,6 @@
 # External Wildfly Tests
 
-Wildfly tests are part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/Issue [#172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Wildfly tests are pulled from the [wildfly](https://github.com/wildfly/wildfly.git) repository.
+Wildfly tests are part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/Issue [#172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Wildfly tests are pulled from the [wildfly](https://github.com/wildfly/wildfly.git) repository.
 
 
 ## Running wildfly tests locally
@@ -14,7 +14,7 @@ To run any AQA tests locally, you follow the same pattern:
 
    3. `git clone https://github.com/adoptium/aqa-tests.git`
 
-   4. `cd openjdk-tests`
+   4. `cd aqa-tests`
 
    5. `./get.sh`
 
@@ -24,8 +24,8 @@ To run any AQA tests locally, you follow the same pattern:
 
    8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
 
-   9. `make _wildfly_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+   9. `make _wildfly_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/external/wycheproof/README.md
+++ b/external/wycheproof/README.md
@@ -1,6 +1,6 @@
 # External Wycheproof Tests
 
-Wycheproof tests are a part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/openjdk-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Wycheproof test material is pulled from the [wycheproof](https://github.com/google/wycheproof) repository.
+Wycheproof tests are a part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. AdoptOpenJDK/aqa-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Wycheproof test material is pulled from the [wycheproof](https://github.com/google/wycheproof) repository.
 
 ## Running External tests locally
 
@@ -14,7 +14,7 @@ To run any AQA tests locally, you follow the same pattern:
 
 3. `git clone https://github.com/adoptium/aqa-tests.git`
 
-4. `cd openjdk-tests`
+4. `cd aqa-tests`
 
 5. `./get.sh`
 
@@ -24,8 +24,8 @@ To run any AQA tests locally, you follow the same pattern:
 
 8. `make wycheproof`        (This fetches test material and compiles it, based on build.xml files in the test directories)
 
-9. `make wycheproof_test`   (When you defined BUILD_LIST to point to a directory in [openjdk-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make wycheproof_test`   (When you defined BUILD_LIST to point to a directory in [aqa-tests/external](https://github.com/adoptium/aqa-tests/tree/master/external), then this is a testCaseName from the playlist.xml file within the directory you chose)
 
-When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`wycheproof`, and TARGET=`testCaseNameFromPlaylistUnderDirwycheproof`
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`wycheproof`, and TARGET=`testCaseNameFromPlaylistUnderDirwycheproof`
 
 These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).

--- a/openjdk/README.md
+++ b/openjdk/README.md
@@ -24,7 +24,7 @@ While you can directly use the jtreg test harness to run these tests locally, we
 1. Download/unpack the SDK you want to your test machine (you can download them from our website: [adoptopenjdk.net](https://adoptopenjdk.net/)).
 1. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>` 
 1. `git clone https://github.com/adoptium/aqa-tests.git` 
-1. `cd openjdk-tests`
+1. `cd aqa-tests`
 1. `./get.sh`
 1. `cd TKG`
 1. `export BUILD_LIST=openjdk`

--- a/perf/README.md
+++ b/perf/README.md
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 
 We are in the process of adding more microbenchmarks (both bumblebench and jmh formats) and full open-source benchmarks to this directory. New perftest jobs are added to the [Test_perf](https://ci.adoptopenjdk.net/view/Test_perf/) view.  While we will run these benchmarks regularly at AdoptOpenJDK, the intention is to make it easy for developers to run performance testing locally.  
 
-You can follow the [same manual testing instructions](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline) to run these tests, as you do for all of the other tests we run.  The top-level make target for tests contained in this directory (openjdk-tests/perf) is "perf".  So, once you compile test material, running "make perf" will run all of the testcases defined in playlist.xml files in this directory and its subdirectories.  Each unique benchmark is housed in a 
+You can follow the [same manual testing instructions](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline) to run these tests, as you do for all of the other tests we run.  The top-level make target for tests contained in this directory (aqa-tests/perf) is "perf".  So, once you compile test material, running "make perf" will run all of the testcases defined in playlist.xml files in this directory and its subdirectories.  Each unique benchmark is housed in a 
 subdirectory and given a meaningful name.  Once the reorganization of this directory is complete, the directory structure will look like:
 
 ```

--- a/perf/liberty/configs/dt7_sufp.sh
+++ b/perf/liberty/configs/dt7_sufp.sh
@@ -20,7 +20,7 @@ echo "Current Dir: $(pwd)"
 
 TEST_RESROOT=${1}
 
-. "$TEST_RESROOT/../../../openjdk-tests/perf/affinity.sh" > /dev/null 2>&1
+. "$TEST_RESROOT/../../../aqa-tests/perf/affinity.sh" > /dev/null 2>&1
 setServerDBLoadAffinities --server-physcpu-num $SERVER_PHYSCPU_NUM --smt $SMT > /dev/null 2>&1
 
 export AFFINITY=${SERVER_AFFINITY_CMD}

--- a/perf/liberty/configs/dt7_throughput.sh
+++ b/perf/liberty/configs/dt7_throughput.sh
@@ -27,7 +27,7 @@ if [ -z "${SMT}" ]; then
     SMT=true
 fi
 
-. "$TEST_RESROOT/../../../openjdk-tests/perf/affinity.sh" > /dev/null 2>&1
+. "$TEST_RESROOT/../../../aqa-tests/perf/affinity.sh" > /dev/null 2>&1
 setServerDBLoadAffinities --server-physcpu-num $SERVER_PHYSCPU_NUM --smt $SMT > /dev/null 2>&1
 
 #TODO: We'll need to add affinity variables for client and DB in the scripts if we decide to run

--- a/rerun.sh
+++ b/rerun.sh
@@ -74,11 +74,11 @@ for i in "${!values[@]}"
 do
 	IFS=', '
 	read -ra j<<<$i
-	if [[ "${j[0]}" == *"openjdk-tests.git"* ]]
+	if [[ "${j[0]}" == *"aqa-tests.git"* ]]
 	then
-		echo "Fetching openjdk-tests..."
+		echo "Fetching aqa-tests..."
 		git clone "${j[0]}"
-		cd openjdk-tests
+		cd aqa-tests
 		git checkout "${j[1]}"
 	fi
 done
@@ -88,7 +88,7 @@ do
 # Here it splits the keys of array then controls the contents.
 	IFS=', '
 	read -ra j<<<$i
-	if [[ "${j[0]}" == *"openjdk-tests.git"* ]]
+	if [[ "${j[0]}" == *"aqa-tests.git"* ]]
 	then
 		continue
 	elif [[ "${j[0]}" == *"openj9.git"* ]]
@@ -105,7 +105,7 @@ do
 	fi		
 done
 
-cd openjdk-tests
+cd aqa-tests
 ./get.sh --openj9_sha "$OPENJ9_SHA" --tkg_sha "$TKG_SHA"
 cd TKG
 export BUILD_LIST="${BUILD_LIST}"


### PR DESCRIPTION
related: https://github.com/adoptium/aqa-tests/pull/2612
Signed-off-by: Yixin Qian <Yixin.Qian@ibm.com>