### PR TITLE
Exclude compiler/gcbarriers/UnsafeIntrinsicsTest.java jdk11 aarch64

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -20,6 +20,12 @@
 
 ############################################################################
 
+# jdk_compiler
+
+compiler/gcbarriers/UnsafeIntrinsicsTest.java#shenandoah https://github.com/adoptium/aqa-tests/issues/2640 linux-aarch64
+
+############################################################################
+
 # jdk_lang
 
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all


### PR DESCRIPTION
Signed-off-by: Simon Rushton <srushton@redhat.com>