### PR TITLE
Exclude suspected jdk_management hang tests for openj9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -155,7 +155,9 @@ java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium
 javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 com/sun/management/OperatingSystemMXBean/GetFreePhysicalMemorySize.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
-
+sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
+sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
+sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 ############################################################################
 
 # jdk_jmx

--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -118,7 +118,9 @@ sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.java   https://gi
 sun/management/jmxremote/startstop/JMXStartStopTest.java  https://github.com/adoptium/aqa-tests/issues/932 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java   https://github.com/adoptium/aqa-tests/issues/932 generic-all
 sun/management/jmxremote/startstop/JMXStatusTest.java   https://github.com/adoptium/aqa-tests/issues/932 generic-all
-
+sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
+sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
+sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 ############################################################################
 
 # jdk_jmx


### PR DESCRIPTION
Those tests causes hang problem, which has been excluded for hotspot. Should also  be excluded for
openj9.

Excluded those tests jdk_management only takes 1 minute, though still other test failures. Will keep jdk_managment disabled. 

https://ci.adoptopenjdk.net/view/work-in-progress/job/grinder_sandbox_new/87/

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>