### PR TITLE
Resolving accidental merge of merge conflict symbols

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -132,13 +132,8 @@
 	<test>
 		<testCaseName>renaissance-future-genetic</testCaseName>
 		<disabled>
-<<<<<<< HEAD
 			<comment>https://github.com/adoptium/aqa-tests/issues/2183#issuecomment-763180051</comment>
-			<plat>.*windows.*</plat>
-=======
-			<comment>https://github.com/AdoptOpenJDK/openjdk-tests/issues/2183#issuecomment-763180051</comment>
 			<platform>.*windows.*</platform>
->>>>>>> Update <plat> to <platform> for disabled element
 		</disabled>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)future-genetic.json$(Q) future-genetic; \
 		$(TEST_STATUS)</command>


### PR DESCRIPTION
This typo seems to be causing test failure. I think the file now
looks like how it was meant to look after PR 2579, where
the typo was merged.

Signed-off-by: Adam Farley <adfarley@redhat.com>