### PR TITLE
Excluding DiagnosticCommandMBean tests on OpenJ9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -158,6 +158,11 @@ com/sun/management/OperatingSystemMXBean/GetFreePhysicalMemorySize.java https://
 sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+
 ############################################################################
 
 # jdk_jmx

--- a/openjdk/excludes/ProblemList_openjdk12-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk12-openj9.txt
@@ -182,6 +182,10 @@ java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aq
 java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk13-openj9.txt
@@ -168,6 +168,10 @@ java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aq
 java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk14-openj9.txt
@@ -161,6 +161,10 @@ java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aq
 java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk15-openj9.txt
@@ -178,6 +178,10 @@ java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aq
 java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -193,6 +193,10 @@ java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aq
 java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -195,6 +195,10 @@ java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aq
 java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
DiagnosticCommandMBean  tests from jdk_management uses Hotspot diagnostic option which is not supported on OpenJ9 implementation. Hence, excluding below testcases from JDK11+ OpenJ9.

com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java
com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java 
com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java 
com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java

For more info refer :- runtimes/openj9-openjdk-jdk11-zos/issues/463