### PR TITLE
Undo excludes for JEP 393 Foreign Memory Access

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -369,14 +369,6 @@ vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse-openj9/op
 
 # jdk_foreign
 
-# Foreign-Memory Access API, Third Incubator, JEP393 Failures
-java/foreign/TestByteBuffer.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestSharedAccess.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestSpliterator.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestNativeScope.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-
 # Foreign Linker API, JEP389, Failures
 java/foreign/TestNative.java https://github.com/eclipse-openj9/openj9/issues/11195 generic-all
 java/foreign/stackwalk/TestStackWalk.java https://github.com/eclipse-openj9/openj9/issues/11195 generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -367,14 +367,8 @@ vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse-openj9/op
 java/foreign/TestArrays.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
 java/foreign/TestLayouts.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
 java/foreign/TestLayoutPaths.java	https://github.com/adoptium/aqa-tests/issues/1701	generic-all
-java/foreign/TestByteBuffer.java	https://github.com/adoptium/aqa-tests/issues/1702	generic-all
 java/foreign/TestLayoutConstants.java	https://github.com/adoptium/aqa-tests/issues/1702	generic-all
 java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
-java/foreign/TestSharedAccess.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestSpliterator.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestByteBuffer.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/stackwalk/TestStackWalk.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
@@ -389,7 +383,6 @@ java/foreign/TestMemoryAlignment.java https://github.com/eclipse-openj9/openj9/i
 java/foreign/TestMemoryCopy.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestMemoryHandleAsUnsigned.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestMismatch.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestNativeScope.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestNulls.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestRebase.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestSegments.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all


### PR DESCRIPTION
The closeScope0 function has now been implemented.

Reverts: #2085
Related PR: eclipse-openj9/openj9#12857
Signed-off-by: Eric Yang <eric.yang@ibm.com>