### PR TITLE
Fix JCK update logic

### DIFF
--- a/jck/build.xml
+++ b/jck/build.xml
@@ -127,6 +127,8 @@
 								<echo message="Updating ${JCK_ROOT_USED} with latest..." />
 								<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true">
 									<arg value="pull" />
+									<arg value="${JCK_GIT_REPO_USED}" />
+									<arg value="${jck_branch}" />
 								</exec>
 							</else>
 						</if>


### PR DESCRIPTION
- Resolves  backlog/issues/553
- Specify jck repo and branch explicitly in the git pull command in the case where jck update needs to take place. Without this change, sometimes some updates in remote repo is not getting picked up. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>