### PR TITLE
Exclude failing linux arm java.util.stream testcases due to issue #2263

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -369,13 +369,19 @@ java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tes
 java/util/stream/boottest/java/util/stream/SpinedBufferTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/ExplodeOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/FlatMapOpTest.java https://bugs.openjdk.java.net/browse/JDK-8173112    linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/FlatMapOpTest.java https://bugs.openjdk.java.net/browse/JDK-8173112    linux-s390x,linux-arm
 java/util/stream/test/org/openjdk/tests/java/util/stream/InfiniteStreamWithLimitOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/SequentialOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/SliceOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/StreamSpliteratorTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/SliceOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/StreamSpliteratorTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,linux-arm
 java/util/stream/test/org/openjdk/tests/java/util/stream/StreamBuilderTest.java https://bugs.openjdk.java.net/browse/JDK-8173112    linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/TabulatorsTest.java    https://bugs.openjdk.java.net/browse/JDK-8173112    linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/TabulatorsTest.java    https://bugs.openjdk.java.net/browse/JDK-8173112    linux-s390x,linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/TeeOpTest.java         https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/ForEachOpTest.java     https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/ConcatOpTest.java      https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/DistinctOpTest.java    https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/SortedOpTest.java      https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/StreamLinkTest.java    https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
 sun/util/calendar/zi/TestZoneInfo310.java		https://github.com/eclipse-openj9/openj9/issues/1131	generic-all
 java/util/Locale/Bug8040211.java https://github.com/adoptium/aqa-tests/issues/2420 linux-aarch64
 


### PR DESCRIPTION
Excluded for: https://github.com/adoptium/aqa-tests/issues/2263

Signed-off-by: Andrew Leonard <anleonar@redhat.com>