### PR TITLE
Add 1-hour timeout around initial cleanWs

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -274,7 +274,9 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
 
             node(LABEL) {
                 try {
-                    cleanWs()
+                    timeout(time: 1, unit: 'HOURS') {
+                        cleanWs()
+                    }
                     if (params.PLATFORM.contains('zos')) {
                         /* Ensure correct CC env */
                         env._CC_CCMODE = '1'


### PR DESCRIPTION
I have seen test builds hang on this step several times.
Adding a 1 hour timeout will hopefully prevent this.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>