### PR TITLE
Fixing nativepath location issue on z/OS

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -121,9 +121,7 @@ CUSTOM_NATIVE_OPTIONS :=
 
 ifneq ($(JDK_VERSION),8)
 	ifdef TESTIMAGE_PATH
-		ifneq ($(OS),OS/390)
-			JDK_NATIVE_OPTIONS := -nativepath:"$(TESTIMAGE_PATH)$(D)jdk$(D)jtreg$(D)native"
-		endif
+		JDK_NATIVE_OPTIONS := -nativepath:"$(TESTIMAGE_PATH)$(D)jdk$(D)jtreg$(D)native"
 		ifeq ($(JDK_IMPL), hotspot)
 			JVM_NATIVE_OPTIONS := -nativepath:"$(TESTIMAGE_PATH)$(D)hotspot$(D)jtreg$(D)native"
 		# else if JDK_IMPL is openj9 or ibm


### PR DESCRIPTION
This PR fixes -nativepath location on z/OS. 

Verification :- hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/16791

This PR fixes runtimes/openj9-openjdk-jdk11-zos/issues/594