### PR TITLE
Un-exclude devtools tests on Windows

### DIFF
--- a/jck/devtools.java2schema/playlist.xml
+++ b/jck/devtools.java2schema/playlist.xml
@@ -17,14 +17,14 @@
 	<test>
 		<testCaseName>jck-devtools-java2schema-CustomizedMapping</testCaseName>
 		<disabled>
-			<comment>Disabled on x64 Linux + aarch64 + ppc64le + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<comment>Disabled on x64 Linux + aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>ibm</impl>
 		</disabled>
 		<disabled>
-			<comment>Disabled on x64 Linux + aarch64 + ppc64le + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<comment>Disabled on x64 Linux + aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>openj9</impl>
 		</disabled>

--- a/jck/devtools.jaxws/playlist.xml
+++ b/jck/devtools.jaxws/playlist.xml
@@ -16,18 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-jaxws-mapping</testCaseName>
-		<disabled>
-			<comment>Disabled on Win32 on jdk8 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-32_windows(_mixed)?|x86-64_windows(_mixed)?</platform>
-			<version>8</version>
-			<impl>ibm</impl>
-		</disabled>
-		<disabled>
-			<comment>Disabled on Win32 on jdk8 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-32_windows(_mixed)?|x86-64_windows(_mixed)?</platform>
-			<version>8</version>
-			<impl>openj9</impl>
-		</disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.schema_bind/playlist.xml
+++ b/jck/devtools.schema_bind/playlist.xml
@@ -17,14 +17,14 @@
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_class</testCaseName>
 		<disabled>
-			<comment>Disabled on x64 Linux + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-64_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>x86-64_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>ibm</impl>
 		</disabled>
 		<disabled>
-			<comment>Disabled on x64 Linux + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-64_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>x86-64_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>openj9</impl>
 		</disabled>
@@ -75,14 +75,14 @@
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_factoryMethod</testCaseName>
 		<disabled>
-			<comment>Disabled on aarch64 + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>aarch64_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>aarch64_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>ibm</impl>
 		</disabled>
 		<disabled>
-			<comment>Disabled on aarch64 + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>aarch64_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>aarch64_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>openj9</impl>
 		</disabled>
@@ -105,13 +105,13 @@
 		<testCaseName>jck-devtools-schema_bind-bind_globalBindings</testCaseName>
 		<disabled>
 			<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302, on win64 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
-			<platform>aarch64_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<platform>aarch64_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>ibm</impl>
 		</disabled>
 		<disabled>
 			<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302, on win64 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
-			<platform>aarch64_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<platform>aarch64_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>openj9</impl>
 		</disabled>
@@ -179,14 +179,14 @@
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_property</testCaseName>
 		<disabled>
-			<comment>Disabled on x64 Linux + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-64_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>x86-64_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>ibm</impl>
 		</disabled>
 		<disabled>
-			<comment>Disabled on x64 Linux + win64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-64_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+			<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>x86-64_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>openj9</impl>
 		</disabled>

--- a/jck/devtools.xml_schema/playlist.xml
+++ b/jck/devtools.xml_schema/playlist.xml
@@ -17,14 +17,14 @@
 	<test>
 		<testCaseName>jck-devtools-xml_schema-boeingData</testCaseName>
 		<disabled>
-			<comment>Disabled on x64 Linux + aarch64 + ppc64le + win32 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?|x86-32_windows(_mixed)?</platform>
+			<comment>Disabled on x64 Linux + aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>ibm</impl>
 		</disabled>
 		<disabled>
-			<comment>Disabled on x64 Linux + aarch64 + ppc64le + win32 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-			<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?|x86-32_windows(_mixed)?</platform>
+			<comment>Disabled on x64 Linux + aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
+			<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
 			<version>8</version>
 			<impl>openj9</impl>
 		</disabled>


### PR DESCRIPTION
- This PR un-excludes the previously excluded devtools tests on Windows , since the original issue (backlog/issues/507) has now been fixed. 
 
Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>

FYI @JasonFengJ9 