### PR TITLE
Exclude automated jck tests requiring a real UI to be run manually

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -349,6 +349,12 @@
 			<platform>x86-64_mac(_mixed)?</platform>
 			<impl>openj9</impl>
 		</disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_mac</platform>
+                        <impl>hotspot</impl>
+                </disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -387,6 +393,12 @@
 			<platform>x86-64_mac(_mixed)?</platform>
 			<impl>openj9</impl>
 		</disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_mac</platform>
+                        <impl>hotspot</impl>
+                </disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -435,6 +447,18 @@
 			<version>8</version>
 			<impl>openj9</impl>
 		</disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_mac</platform>
+                        <impl>hotspot</impl>
+                </disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_windows</platform>
+                        <impl>hotspot</impl>
+                </disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -485,6 +509,12 @@
 			<version>16+</version>
 			<impl>openj9</impl>
 		</disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_mac</platform>
+                        <impl>hotspot</impl>
+                </disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -739,6 +769,12 @@
 			<platform>x86-64_mac(_mixed)?</platform>
 			<impl>openj9</impl>
 		</disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_mac</platform>
+                        <impl>hotspot</impl>
+                </disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -877,6 +913,12 @@
 			<platform>x86-64_mac(_mixed)?</platform>
 			<impl>openj9</impl>
 		</disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_mac</platform>
+                        <impl>hotspot</impl>
+                </disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -935,6 +977,12 @@
 			<platform>x86-64_mac(_mixed)?</platform>
 			<impl>openj9</impl>
 		</disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_mac</platform>
+                        <impl>hotspot</impl>
+                </disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1001,6 +1049,12 @@
 			<platform>x86-64_mac(_mixed)?</platform>
 			<impl>openj9</impl>
 		</disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_mac</platform>
+                        <impl>hotspot</impl>
+                </disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1063,6 +1117,18 @@
 			<version>8</version>
 			<impl>openj9</impl>
 		</disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_mac</platform>
+                        <impl>hotspot</impl>
+                </disabled>
+                <disabled>
+                        <comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+                        <version>8</version>
+                        <platform>x86-64_windows</platform>
+                        <impl>hotspot</impl>
+                </disabled>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
Exclude those UI jck tests requiring manual running https://github.com/temurin-compliance/temurin-compliance/issues/29

Signed-off-by: Andrew Leonard <anleonar@redhat.com>