### PR TITLE
Exclude LoaderLeakTest in JDK17

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -160,6 +160,7 @@ java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclip
 java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse-openj9/openj9/issues/11822 generic-all
 java/lang/invoke/VarHandles/VarHandleTestExact.java https://github.com/eclipse-openj9/openj9/issues/11256 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
+java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
 ############################################################################
 
 # jdk_internal


### PR DESCRIPTION
Exclude LoaderLeakTest in JDK17

Associated issue https://github.com/eclipse-openj9/openj9/issues/13201

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>