### PR TITLE
Un-exclude javax_net target on all platforms except z/OS

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -934,24 +934,16 @@
 	<test>
 		<testCaseName>jck-runtime-api-javax_net</testCaseName>
 		<disabled>
-			<comment>Disabled on all platforms due to backlog/issues/461. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-			<version>11</version>
-			<impl>ibm</impl>
-		</disabled>
-		<disabled>
-			<comment>Disabled on all platforms due to backlog/issues/461. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<comment>Disabled on z/OS due to backlog/issues/461</comment>
 			<version>8</version>
 			<impl>ibm</impl>
+			<platform>.*zos.*</platform>
 		</disabled>
 		<disabled>
-			<comment>Disabled on all platforms due to backlog/issues/461. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+			<comment>Disabled on z/OS due to backlog/issues/461</comment>
 			<version>11</version>
-			<impl>openj9</impl>
-		</disabled>
-		<disabled>
-			<comment>Disabled on all platforms due to backlog/issues/461. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-			<version>8</version>
-			<impl>openj9</impl>
+			<impl>ibm</impl>
+			<platform>.*zos.*</platform>
 		</disabled>
 		<variations>
 			<variation>NoOptions</variation>


### PR DESCRIPTION
- Un-exclude javax_net target on all platforms except z/OS
- Related to : https://github.com/adoptium/aqa-systemtest/pull/440

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>