### PR TITLE
Move jck-runtime-api-java_net and jck-runtime-api-javax_security to special level - fixed L615 and L1018

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -612,7 +612,7 @@
 		<command>$(JCK_CMD_TEMPLATE) -test-args=$(Q)tests=api/java_net,jckRoot=$(JCK_ROOT),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>jck</group>
@@ -1015,7 +1015,7 @@
 		<command>$(JCK_CMD_TEMPLATE) -test-args=$(Q)tests=api/javax_security,jckRoot=$(JCK_ROOT),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>jck</group>


### PR DESCRIPTION
Replaced <level>extended</level> by <level>special</level>

Fixes #2739