### PR TITLE
#1728 Remove _xl and _mixed from map (save zos, riscv)

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -117,9 +117,6 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
                     def ACTUAL_PLATFORM = PLATFORM
                     if (PLATFORM == "all") {
                         ACTUAL_PLATFORM = "ppc64_aix,ppc64le_linux,s390x_linux,x86-64_linux,x86-64_mac,x86-64_windows"
-                        if (JDK_IMPL == "openj9" || JDK_IMPL == "ibm"){
-                            ACTUAL_PLATFORM = ACTUAL_PLATFORM + ",ppc64_aix_xl,ppc64le_linux_xl,s390x_linux_xl,x86-64_linux_xl,x86-64_mac_xl,x86-64_windows_xl"
-                        }
                         if (JDK_VERSION == "8"){
                             ACTUAL_PLATFORM = ACTUAL_PLATFORM + ",x86-32_windows"
                         } else {

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -34,7 +34,7 @@ def PLATFORM_MAP = [
         'LABEL' : 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux',
     ],
     'riscv64_linux' : [
-        'SPEC' : 'linux_riscv64_cmprssptrs',
+        'SPEC' : 'linux_riscv64',
         'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.riscv&&hw.bits.64',
     ],
     'riscv64_linux_xl' : [
@@ -52,7 +52,7 @@ def PLATFORM_MAP = [
         'DynamicAgents' : ['fyre']
     ],
     's390x_zos' : [
-        'SPEC' : 'zos_390-64_cmprssptrs',
+        'SPEC' : 'zos_390-64',
         'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
     ],
     's390x_zos_xl' : [
@@ -64,11 +64,11 @@ def PLATFORM_MAP = [
         'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
     ],
     'sparcv9_solaris' : [
-        'SPEC' : 'sunos_sparcv9-64_cmprssptrs',
+        'SPEC' : 'sunos_sparcv9-64',
         'LABEL' : 'ci.role.test&&hw.arch.sparcv9&&sw.os.sunos',
     ],
     'x86-64_solaris' : [
-        'SPEC' : 'sunos_x86-64_cmprssptrs',
+        'SPEC' : 'sunos_x86-64',
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.sunos',
     ],
     'x86-64_alpine-linux' : [

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -10,7 +10,7 @@ def PLATFORM_MAP = [
         'LABEL' : 'ci.role.test&&sw.os.osx&&hw.arch.aarch64',
     ],
     'aarch64_linux' : [
-        'SPEC' : 'linux_aarch64_cmprssptrs',
+        'SPEC' : 'linux_aarch64',
         'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
     ],
     'ppc32_aix' : [
@@ -22,15 +22,15 @@ def PLATFORM_MAP = [
         'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
     ],
     'ppc64_aix' : [
-        'SPEC' : 'aix_ppc-64_cmprssptrs',
+        'SPEC' : 'aix_ppc-64',
         'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
     ],
     'ppc64_linux' : [
-        'SPEC' : 'linux_ppc-64_cmprssptrs',
+        'SPEC' : 'linux_ppc-64',
         'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
     ],
     'ppc64le_linux' : [
-        'SPEC' : 'linux_ppc-64_cmprssptrs_le',
+        'SPEC' : 'linux_ppc-64_le',
         'LABEL' : 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux',
     ],
     'riscv64_linux' : [
@@ -47,7 +47,7 @@ def PLATFORM_MAP = [
         'DynamicAgents' : ['fyre']
     ],
     's390x_linux' : [
-        'SPEC' : 'linux_390-64_cmprssptrs',
+        'SPEC' : 'linux_390-64',
         'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux',
         'DynamicAgents' : ['fyre']
     ],
@@ -64,11 +64,11 @@ def PLATFORM_MAP = [
         'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
     ],
     'sparcv9_solaris' : [
-        'SPEC' : 'sunos_sparcv9-64_cmprssptrs',
+        'SPEC' : 'sunos_sparcv9-64',
         'LABEL' : 'ci.role.test&&hw.arch.sparcv9&&sw.os.sunos',
     ],
     'x86-64_solaris' : [
-        'SPEC' : 'sunos_x86-64_cmprssptrs',
+        'SPEC' : 'sunos_x86-64',
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.sunos',
     ],
     'x86-64_alpine-linux' : [
@@ -84,16 +84,16 @@ def PLATFORM_MAP = [
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
     ],
     'x86-64_linux' : [
-        'SPEC' : 'linux_x86-64_cmprssptrs',
+        'SPEC' : 'linux_x86-64',
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
         'DynamicAgents' : ['azure', 'fyre']
     ],
     'x86-64_mac' : [
-        'SPEC' : 'osx_x86-64_cmprssptrs',
+        'SPEC' : 'osx_x86-64',
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.osx',
     ],
     'x86-64_windows' : [
-        'SPEC' : 'win_x86-64_cmprssptrs',
+        'SPEC' : 'win_x86-64',
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
     ],
 ]

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -13,14 +13,6 @@ def PLATFORM_MAP = [
         'SPEC' : 'linux_aarch64_cmprssptrs',
         'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
     ],
-    'aarch64_linux_mixed' : [
-        'SPEC' : 'linux_aarch64_mxdptrs',
-        'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
-    ],
-    'aarch64_linux_xl' : [
-        'SPEC' : 'linux_aarch64',
-        'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
-    ],
     'ppc32_aix' : [
         'SPEC' : 'aix_ppc',
         'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
@@ -33,32 +25,12 @@ def PLATFORM_MAP = [
         'SPEC' : 'aix_ppc-64_cmprssptrs',
         'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
     ],
-    'ppc64_aix_mixed' : [
-        'SPEC' : 'aix_ppc-64_mxdptrs',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
-    ],
-    'ppc64_aix_xl' : [
-        'SPEC' : 'aix_ppc-64',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
-    ],
     'ppc64_linux' : [
         'SPEC' : 'linux_ppc-64_cmprssptrs',
         'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
     ],
-    'ppc64_linux_xl' : [
-        'SPEC' : 'linux_ppc-64',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
-    ],
     'ppc64le_linux' : [
         'SPEC' : 'linux_ppc-64_cmprssptrs_le',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux',
-    ],
-    'ppc64le_linux_mixed' : [
-        'SPEC' : 'linux_ppc-64_mxdptrs_le',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux'
-    ],
-    'ppc64le_linux_xl' : [
-        'SPEC' : 'linux_ppc-64_le',
         'LABEL' : 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux',
     ],
     'riscv64_linux' : [
@@ -76,16 +48,6 @@ def PLATFORM_MAP = [
     ],
     's390x_linux' : [
         'SPEC' : 'linux_390-64_cmprssptrs',
-        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux',
-        'DynamicAgents' : ['fyre']
-    ],
-    's390x_linux_mixed' : [
-        'SPEC' : 'linux_390-64_mxdptrs',
-        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux',
-        'DynamicAgents' : ['fyre']
-    ],
-    's390x_linux_xl' : [
-        'SPEC' : 'linux_390-64',
         'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux',
         'DynamicAgents' : ['fyre']
     ],
@@ -126,38 +88,12 @@ def PLATFORM_MAP = [
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
         'DynamicAgents' : ['azure', 'fyre']
     ],
-    'x86-64_linux_mixed' : [
-        'SPEC' : 'linux_x86-64_mxdptrs',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
-        'DynamicAgents' : ['azure', 'fyre']
-    ],
-    'x86-64_linux_xl' : [
-        'SPEC' : 'linux_x86-64',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
-        'DynamicAgents' : ['azure', 'fyre']
-    ],
     'x86-64_mac' : [
         'SPEC' : 'osx_x86-64_cmprssptrs',
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.osx',
     ],
-    'x86-64_mac_mixed' : [
-        'SPEC' : 'osx_x86-64_mxdptrs',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.osx',
-    ],
-    'x86-64_mac_xl' : [
-        'SPEC' : 'osx_x86-64',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.osx',
-    ],
     'x86-64_windows' : [
         'SPEC' : 'win_x86-64_cmprssptrs',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
-    ],
-    'x86-64_windows_mixed' : [
-        'SPEC' : 'win_x86-64_mxdptrs',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
-    ],
-    'x86-64_windows_xl' : [
-        'SPEC' : 'win_x86-64',
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
     ],
 ]

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -64,11 +64,11 @@ def PLATFORM_MAP = [
         'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
     ],
     'sparcv9_solaris' : [
-        'SPEC' : 'sunos_sparcv9-64',
+        'SPEC' : 'sunos_sparcv9-64_cmprssptrs',
         'LABEL' : 'ci.role.test&&hw.arch.sparcv9&&sw.os.sunos',
     ],
     'x86-64_solaris' : [
-        'SPEC' : 'sunos_x86-64',
+        'SPEC' : 'sunos_x86-64_cmprssptrs',
         'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.sunos',
     ],
     'x86-64_alpine-linux' : [


### PR DESCRIPTION
Fixes #1728 

> the last checkbox still needs doing, which is to update the PLATFORM_MAP in the openjdk_tests file to remove entries that end in _xl and _mixed, with the exception of zos and riscv platforms.

