### PR TITLE
Un-exclude devtools schema tests

### DIFF
--- a/jck/devtools.java2schema/playlist.xml
+++ b/jck/devtools.java2schema/playlist.xml
@@ -16,20 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-java2schema-CustomizedMapping</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on x64 Linux + aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on x64 Linux + aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -63,3 +49,4 @@
 		</versions>
 	</test>
 </playlist>
+

--- a/jck/devtools.schema2java/playlist.xml
+++ b/jck/devtools.schema2java/playlist.xml
@@ -16,20 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-schema2java-nisttest</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on x64 Linux + aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on x64 Linux + aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -47,20 +33,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema2java-structures</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aarch64 Linux + aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aarch64 Linux + aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.schema_bind/playlist.xml
+++ b/jck/devtools.schema_bind/playlist.xml
@@ -16,21 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_class</testCaseName>
-		
-		<disables>
-			<disable>
-				<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>			
-			</disable>
-			<disable>
-				<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -48,20 +33,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_dom</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -79,20 +50,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_factoryMethod</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -110,20 +67,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_globalBindings</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302, on win64 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302, on win64 due to backlog/issues/507. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -141,20 +84,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_inlineBinaryData</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aarch64 on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -189,20 +118,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_property</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -220,20 +135,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-schema_bind-bind_schemaBindings</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on ppc64le Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>ppc64le_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on ppc64le Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>ppc64le_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/devtools.xml_schema/playlist.xml
+++ b/jck/devtools.xml_schema/playlist.xml
@@ -16,20 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-boeingData</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on x64 Linux + aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on x64 Linux + aarch64 + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?|ppc64le_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -47,20 +33,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-msData-group1</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux|ppc64le_linux</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux|ppc64le_linux</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -78,20 +50,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-msData-group2</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux|ppc64le_linux</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux|ppc64le_linux</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -109,20 +67,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-msData-group3</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux|ppc64le_linux</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux|ppc64le_linux</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -140,20 +84,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-msData-group4</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux|ppc64le_linux</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aarch64 Linux + ppc64le on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>aarch64_linux|ppc64le_linux</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -171,20 +101,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-nistData</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?|aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -202,20 +118,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-devtools-xml_schema-sunData</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?||aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on x64 Linux on jdk8 due to backlog/issues/302. Awaiting potential test / setup issue resolution</comment>
-				<platform>x86-64_linux(_mixed)?||aarch64_linux(_mixed)?</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
This PR is to un-exclude the devtools schema test targets as the issue preventing these tests from running is now fixed via https://github.com/adoptium/aqa-systemtest/pull/439


FYI @JasonFengJ9 
 
Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>