### PR TITLE
jck-runtime-api-java_nio jck test target to special level

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -626,7 +626,7 @@
 		<command>$(JCK_CMD_TEMPLATE) -test-args=$(Q)tests=api/java_nio,jckRoot=$(JCK_ROOT),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>jck</group>


### PR DESCRIPTION
Closes #2770 