### PR TITLE
Exclude TestHandshake

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -373,6 +373,7 @@ vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse-openj9/op
 ############################################################################
 
 # jdk_foreign
+java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 
 # Foreign Linker API, JEP389, Failures
 java/foreign/TestNative.java https://github.com/eclipse-openj9/openj9/issues/11195 generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -378,6 +378,7 @@ java/foreign/TestLayouts.java	https://github.com/adoptium/aqa-tests/issues/1701 
 java/foreign/TestLayoutPaths.java	https://github.com/adoptium/aqa-tests/issues/1701	generic-all
 java/foreign/TestLayoutConstants.java	https://github.com/adoptium/aqa-tests/issues/1702	generic-all
 java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/stackwalk/TestStackWalk.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all


### PR DESCRIPTION
Test depends on RI behaviour not implemented.

Issue: https://github.com/eclipse-openj9/openj9/issues/13211
Signed-off-by: Eric Yang <eric.yang@ibm.com>