### PR TITLE
Allow different impl JVM option variations for jck-runtime-lang-CLSS-AIX

### DIFF
--- a/jck/runtime.lang/playlist.xml
+++ b/jck/runtime.lang/playlist.xml
@@ -44,7 +44,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>jck-runtime-lang-CLSS-AIX</testCaseName>
+		<testCaseName>jck-runtime-lang-CLSS-AIX-OPENJ9</testCaseName>
 		<variations>
 			<variation>-Xss2M -Xmso1M</variation>
 		</variations>
@@ -57,6 +57,28 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
+		<testCaseName>jck-runtime-lang-CLSS-AIX</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JCK_CMD_TEMPLATE) -test-args=$(Q)tests=lang/CLSS,jckRoot=$(JCK_ROOT),jckversion=$(JCK_VERSION),testsuite=RUNTIME$(Q); \
+	$(TEST_STATUS)</command>
+		<platformRequirements>os.aix</platformRequirements>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>jck</group>
+		</groups>
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-lang-CONV</testCaseName>


### PR DESCRIPTION
This testcase currently specifies OpenJ9 specific JVM options, we need to versions of this testcase an openj9/ibm one and a hotspot one.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>