### PR TITLE
Remove spec completely

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -27,8 +27,8 @@ def setupEnv() {
 	env.JOBSTARTTIME = sh(script: 'LC_TIME=C date +"%a, %d %b %Y %T %z"', returnStdout: true).trim()
 
 	// Check what existing java processes are running
-		echo "PROCESSCATCH: Java processes which are currently on the machine:"
-	if (PLATFORM.contains("windows")) {
+	echo "PROCESSCATCH: Java processes which are currently on the machine:"
+	if (BASE_OS == 'windows') {
 		sh(script:'powershell -c "Get-Process java | select id,processname,starttime"', returnStatus:true)
 	} else {
 		sh(script:'ps -fu '+"${env.USER}"+' | grep java | egrep -v "remoting.jar|agent.jar|grep"', returnStatus: true)
@@ -39,7 +39,7 @@ def setupEnv() {
 		env.JDK_VERSION = params.JDK_VERSION.equalsIgnoreCase("next") ? "" : params.JDK_VERSION
 	}
 
-	env.SPEC = "${SPEC}"
+	env.BASE_OS = "${BASE_OS}"
 
 	ADOPTOPENJDK_REPO = params.ADOPTOPENJDK_REPO ? params.ADOPTOPENJDK_REPO : "https://github.com/adoptium/aqa-tests.git"
 	OPENJ9_REPO = params.OPENJ9_REPO ? params.OPENJ9_REPO : "https://github.com/eclipse-openj9/openj9.git"
@@ -50,7 +50,7 @@ def setupEnv() {
 
 	//For Zos, the right repo should be something like: git@github.ibm.com:runtimes/openj9-openjdk-jdk**-zos.git and for now there is only jdk11
 	env.JDK_REPO = params.JDK_REPO ? params.JDK_REPO : ""
-	if (env.SPEC.startsWith('zos')) {
+	if (env.BASE_OS == 'zos') {
 		ADOPTOPENJDK_REPO = ADOPTOPENJDK_REPO.replace("https://github.com/","git@github.com:")
 		OPENJ9_REPO = OPENJ9_REPO.replace("https://github.com/","git@github.com:")
 	}
@@ -123,7 +123,7 @@ def setupEnv() {
 	if( params.DOCKERIMAGE_TAG ) {
 		env.DOCKERIMAGE_TAG = params.DOCKERIMAGE_TAG
 	}
-	if ( env.SPEC.contains('sunos')) {
+	if ( env.BASE_OS == 'solaris') {
 		sh 'env'
 	} else {
 		sh 'printenv'
@@ -186,7 +186,7 @@ def setupParallelEnv() {
 				def parallelList = "aqa-tests/TKG/parallelList.mk"
 				int NUM_LIST = -1
 				if (fileExists("${parallelList}")) {
-					if (SPEC.startsWith('zos')) {
+					if (env.BASE_OS == 'zos') {
 						echo 'Converting parallelList.mk file from ebcdic to ascii...'
 						sh "iconv -f ibm-1047 -t iso8859-1 ${parallelList} > ${parallelList}.ascii; rm ${parallelList}; mv ${parallelList}.ascii ${parallelList}"
 					}
@@ -445,12 +445,12 @@ def setup() {
 			RESOLVED_MAKE = "if [ `uname` = AIX ] || [ `uname` = SunOS ] || [ `uname` = *BSD ]; then MAKE=gmake; else MAKE=make; fi"
 			
 			dir( WORKSPACE) {
-				// use sshagent with Jenkins credentials ID for all platforms except zOS
 				// on zOS use the user's ssh key
-				if (!env.SPEC.startsWith('zos')) {
-					get_sources_with_authentication()
-				} else {
+				// use sshagent with Jenkins credentials ID for all other platforms
+				if (env.BASE_OS == 'zos') {
 					get_sources()
+				} else {
+					get_sources_with_authentication()
 				}
 				getJobProperties()
 			}
@@ -494,12 +494,12 @@ def get_sources() {
 def makeCompileTest() {
 	String makeTestCmd = "$RESOLVED_MAKE; cd ./aqa-tests/TKG; \$MAKE compile"
 	// use sshagent with Jenkins credentials ID for all platforms except zOS
-	if (!env.SPEC.startsWith('zos')) {
+	if (env.BASE_OS == 'zos') {
+		sh "$makeTestCmd"
+	} else {
 		sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"], ignoreMissing: true) {
 			sh "$makeTestCmd";
 		}
-	} else {
-		sh "$makeTestCmd";
 	}
 }
 
@@ -582,7 +582,7 @@ def runTest( ) {
 			}
 			if (!TARGET.startsWith('-f')) {
 				TARGET="_${params.TARGET}"
-			} else if (TARGET.contains('-f parallelList.mk') && SPEC.startsWith('zos')) {
+			} else if (TARGET.contains('-f parallelList.mk') && env.BASE_OS == 'zos') {
 				def parallelList = "aqa-tests/TKG/parallelList.mk"
 				if (fileExists("${parallelList}")) {
 					echo 'Converting parallelList.mk file from ascii to ebcdic...'
@@ -592,19 +592,19 @@ def runTest( ) {
 			RUNTEST_CMD = "${TARGET} ${CUSTOM_OPTION}"
 			for (int i = 1; i <= ITERATIONS; i++) {
 				echo "ITERATION: ${i}/${ITERATIONS}"
-				if (env.SPEC.startsWith('aix')) {
+				if (env.BASE_OS == 'aix') {
 					sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX :0 &"
 					env.DISPLAY = ":0"
 					echo "env.DISPLAY is ${env.DISPLAY}"
 					makeTest("${RUNTEST_CMD}")
 				}
-				else if (env.SPEC.startsWith('sunos')) {
+				else if (env.BASE_OS == 'solaris') {
 					sh "nohup /usr/X11/bin/Xvfb :2 -screen 0 1024x768x24 &"
 					env.DISPLAY = ":2"
 					echo "env.DISPLAY is ${env.DISPLAY}"
 					makeTest("${RUNTEST_CMD}")
 				}
-				else if (env.SPEC.startsWith('linux') && !(LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure')) {
+				else if (env.BASE_OS == 'linux' && !(LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure')) {
 					// Add an additional 10 second timeout due to issue: https://github.com/adoptium/temurin-build/issues/2368#issuecomment-756683888
 					wrap([$class: 'Xvfb', autoDisplayName: true, timeout:10]) {
 						def DISPLAY = sh (
@@ -641,7 +641,7 @@ def post(output_name) {
 			def tar_cmd_suffix = "| (pigz -9 2>/dev/null || gzip -9)"
 			def suffix = ".tar.gz"
 			def pax_opt = ""
-			if (SPEC.startsWith('zos')) {
+			if (env.BASE_OS == 'zos') {
 				echo 'Converting tap file from ebcdic to ascii...'
 				sh 'cd ./aqa-tests/TKG'
 				def tapFiles = findFiles(glob: "**/*.tap")
@@ -764,7 +764,7 @@ def terminateJavaProcesses() {
 		echo 'terminateJavaProcesses iteration: '+(i+1)
 
 		// Terminate Java processes
-		if (PLATFORM.contains("windows")) {
+		if (env.BASE_OS == 'windows') {
 			// Windows code based on https://github.com/adoptium/infrastructure/issues/1669#issuecomment-727863096
 			echo "PROCESSCATCH: Showing java processes - one will be the jenkins agent - removing any of these created since ${env.JOBSTARTTIME}:"
 			sh(script:'powershell -c "Get-Process java | select id,processname,starttime"', returnStatus:true)
@@ -951,7 +951,7 @@ def getGitRepoBranch(ownerBranch, defaultOwnerBranch, repo) {
 
 	String owner = actualRepoBranch[0].trim()
 	String repoURL = "https://github.com/${owner}/${repo}.git"
-	if (env.SPEC.startsWith('zos')) {
+	if (env.BASE_OS == 'zos') {
 		repoURL = repoURL.replace("https://github.com/","git@github.com:")
 	}
 	actualRepoBranch[0] = repoURL

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -150,136 +150,136 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
         parallel testJobs
     }
 } else {
-    if (PLATFORM_MAP.containsKey(params.PLATFORM)) {
-        SPEC = PLATFORM_MAP[params.PLATFORM]["SPEC"]
-        LABEL = params.LABEL ? params.LABEL : PLATFORM_MAP[params.PLATFORM]["LABEL"]
+    if (!PLATFORM_MAP.containsKey(params.PLATFORM)) {
+        assert false : "Cannot find key PLATFORM: ${params.PLATFORM} in PLATFORM_MAP: ${PLATFORM_MAP}."
+    }
 
-        if (params.DOCKER_REQUIRED) {
-            LABEL += "&&sw.tool.docker"
-        }
+    SPEC = PLATFORM_MAP[params.PLATFORM]["SPEC"]
+    LABEL = params.LABEL ? params.LABEL : PLATFORM_MAP[params.PLATFORM]["LABEL"]
 
-        if (params.LABEL_ADDITION) {
-            LABEL += "&&${params.LABEL_ADDITION}"
-        }
+    if (params.DOCKER_REQUIRED) {
+        LABEL += "&&sw.tool.docker"
+    }
 
-        println "SPEC: ${SPEC}"
-        println "LABEL: ${LABEL}"
+    if (params.LABEL_ADDITION) {
+        LABEL += "&&${params.LABEL_ADDITION}"
+    }
 
-        dynamicAgents = []
-        if (LABEL == PLATFORM_MAP[params.PLATFORM]["LABEL"] && PLATFORM_MAP[params.PLATFORM].containsKey('DynamicAgents')) {
-            dynamicAgents = PLATFORM_MAP[params.PLATFORM]["DynamicAgents"]
-        }
+    println "SPEC: ${SPEC}"
+    println "LABEL: ${LABEL}"
 
-        stage('Queue') {
-            String[] onlineNodes = nodesByLabel(LABEL)
-            if (onlineNodes.size() < 1) {
-                int ACTIVE_NODE_TIMEOUT = params.ACTIVE_NODE_TIMEOUT ? params.ACTIVE_NODE_TIMEOUT : 0
-                timeout(ACTIVE_NODE_TIMEOUT) {
-                    // If there is available node before timeout
-                    node(LABEL) {
-                        echo "find the node with label as ${env.NODE_NAME}"
-                    }
-                }
-            } else {
-                // IF no nodes are idle we will check if there is supported virtual agent
-                // When Parallel the race condition could happen. Say the number of multiply jobs is larger than the available nodes the query's result may be delayed and wrong
-                // In this case jobs will be fooled to fall back to wait local busy nodes. 
-                if (params.CLOUD_PROVIDER != null && params.CLOUD_PROVIDER in dynamicAgents) {
-                    boolean isNodeIdle = false
-                    node {
-                        for (String onlineNode : onlineNodes) {
-                            def nodeStatus = sh(script: "curl -s ${env.JENKINS_URL}computer/${onlineNode}/api/xml?xpath=/*/idle",
-                                                returnStdout: true,
-                                                returnStatus: false
-                                                ).trim()
-                            if (nodeStatus.contains("true")) {
-                                isNodeIdle = true
-                                break
-                            }
-                        }
-                    }
-                    if (!isNodeIdle) {
-                       LABEL = LABEL.minus("ci.role.test&&")
-                       LABEL += '&&ci.agent.dynamic'
-                    }
+    dynamicAgents = []
+    if (LABEL == PLATFORM_MAP[params.PLATFORM]["LABEL"] && PLATFORM_MAP[params.PLATFORM].containsKey('DynamicAgents')) {
+        dynamicAgents = PLATFORM_MAP[params.PLATFORM]["DynamicAgents"]
+    }
+
+    stage('Queue') {
+        String[] onlineNodes = nodesByLabel(LABEL)
+        if (onlineNodes.size() < 1) {
+            int ACTIVE_NODE_TIMEOUT = params.ACTIVE_NODE_TIMEOUT ? params.ACTIVE_NODE_TIMEOUT : 0
+            timeout(ACTIVE_NODE_TIMEOUT) {
+                // If there is available node before timeout
+                node(LABEL) {
+                    echo "find the node with label as ${env.NODE_NAME}"
                 }
             }
-
-            node(LABEL) {
-                try {
-                    timeout(time: 1, unit: 'HOURS') {
-                        cleanWs()
-                    }
-                    if (params.PLATFORM.contains('zos')) {
-                        /* Ensure correct CC env */
-                        env._CC_CCMODE = '1'
-                        env._CXX_CCMODE = '1'
-                        env._C89_CCMODE = '1'
-
-                        def gitConfig = scm.getUserRemoteConfigs()[0]
-                        def SCM_GIT_REPO = gitConfig.getUrl()
-                        def SCM_GIT_BRANCH = scm.branches[0].name
-
-                        // SCM_GIT_REPO value only gets expanded in sh
-                        def SCM_GIT_REPO_VAL = sh(script: "echo ${SCM_GIT_REPO}", returnStdout: true).trim()
-                        SCM_GIT_REPO_VAL = SCM_GIT_REPO_VAL.replace("https://github.com/","git@github.com:")
-
-                        sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO_VAL} aqa-tests"
-                    } else {
-                        def gitConfig = scm.getUserRemoteConfigs().get(0)
-
-                        // Adopt windows machines require env here https://github.com/adoptium/aqa-tests/issues/1803
-                        ref_cache = "${env.HOME}/openjdk_cache"
-
-                        checkout scm: [$class: 'GitSCM',
-                            branches: [[name: "${scm.branches[0].name}"]],
-                            extensions: [
-                                [$class: 'CleanBeforeCheckout'],
-                                [$class: 'CloneOption', reference: ref_cache],
-                                [$class: 'RelativeTargetDirectory', relativeTargetDir: 'aqa-tests']],
-                            userRemoteConfigs: [[url: "${gitConfig.getUrl()}"]]
-                        ]
-                    }
-                    jenkinsfile = load "${WORKSPACE}/aqa-tests/buildenv/jenkins/JenkinsfileBase"
-                    if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') {
-                        //Set dockerimage for azure agent. Fyre has stencil to setup the right environment
-                        docker.image('adoptopenjdk/centos6_build_image').pull() 
-                        docker.image('adoptopenjdk/centos6_build_image').inside {
-                            jenkinsfile.testBuild()
+        } else {
+            // IF no nodes are idle we will check if there is supported virtual agent
+            // When Parallel the race condition could happen. Say the number of multiply jobs is larger than the available nodes the query's result may be delayed and wrong
+            // In this case jobs will be fooled to fall back to wait local busy nodes.
+            if (params.CLOUD_PROVIDER != null && params.CLOUD_PROVIDER in dynamicAgents) {
+                boolean isNodeIdle = false
+                node {
+                    for (String onlineNode : onlineNodes) {
+                        def nodeStatus = sh(script: "curl -s ${env.JENKINS_URL}computer/${onlineNode}/api/xml?xpath=/*/idle",
+                                            returnStdout: true,
+                                            returnStatus: false
+                                            ).trim()
+                        if (nodeStatus.contains("true")) {
+                            isNodeIdle = true
+                            break
                         }
-                    } else {
+                    }
+                }
+                if (!isNodeIdle) {
+                   LABEL = LABEL.minus("ci.role.test&&")
+                   LABEL += '&&ci.agent.dynamic'
+                }
+            }
+        }
+
+        node(LABEL) {
+            try {
+                timeout(time: 1, unit: 'HOURS') {
+                    cleanWs()
+                }
+                if (params.PLATFORM.contains('zos')) {
+                    /* Ensure correct CC env */
+                    env._CC_CCMODE = '1'
+                    env._CXX_CCMODE = '1'
+                    env._C89_CCMODE = '1'
+
+                    def gitConfig = scm.getUserRemoteConfigs()[0]
+                    def SCM_GIT_REPO = gitConfig.getUrl()
+                    def SCM_GIT_BRANCH = scm.branches[0].name
+
+                    // SCM_GIT_REPO value only gets expanded in sh
+                    def SCM_GIT_REPO_VAL = sh(script: "echo ${SCM_GIT_REPO}", returnStdout: true).trim()
+                    SCM_GIT_REPO_VAL = SCM_GIT_REPO_VAL.replace("https://github.com/","git@github.com:")
+
+                    sh "git clone -b ${SCM_GIT_BRANCH} ${SCM_GIT_REPO_VAL} aqa-tests"
+                } else {
+                    def gitConfig = scm.getUserRemoteConfigs().get(0)
+
+                    // Adopt windows machines require env here https://github.com/adoptium/aqa-tests/issues/1803
+                    ref_cache = "${env.HOME}/openjdk_cache"
+
+                    checkout scm: [$class: 'GitSCM',
+                        branches: [[name: "${scm.branches[0].name}"]],
+                        extensions: [
+                            [$class: 'CleanBeforeCheckout'],
+                            [$class: 'CloneOption', reference: ref_cache],
+                            [$class: 'RelativeTargetDirectory', relativeTargetDir: 'aqa-tests']],
+                        userRemoteConfigs: [[url: "${gitConfig.getUrl()}"]]
+                    ]
+                }
+                jenkinsfile = load "${WORKSPACE}/aqa-tests/buildenv/jenkins/JenkinsfileBase"
+                if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') {
+                    //Set dockerimage for azure agent. Fyre has stencil to setup the right environment
+                    docker.image('adoptopenjdk/centos6_build_image').pull()
+                    docker.image('adoptopenjdk/centos6_build_image').inside {
                         jenkinsfile.testBuild()
                     }
-                } catch (Exception e) {
-                    println("Exception: " + e.toString())
-                    // build result may not be updated correctly at the moment (see https://issues.jenkins.io/browse/JENKINS-56402)
-                    // if there is an exception, set currentBuild.result to FAILURE
-                    currentBuild.result = 'FAILURE'
-                } finally {
-                    if (params.SLACK_CHANNEL) {
-                        timeout(time: 5, unit: 'MINUTES') {
-                            if (currentBuild.result == 'FAILURE') {
-                                println("${env.JOB_NAME} #${env.BUILD_NUMBER} result is FAILURE. Checking console log for specific errors...")
-                                // create error list and regex can be used
-                                List<String> errorList = new ArrayList<String>();
-                                errorList.add(".*There is not enough space in the file system.*");
+                } else {
+                    jenkinsfile.testBuild()
+                }
+            } catch (Exception e) {
+                println("Exception: " + e.toString())
+                // build result may not be updated correctly at the moment (see https://issues.jenkins.io/browse/JENKINS-56402)
+                // if there is an exception, set currentBuild.result to FAILURE
+                currentBuild.result = 'FAILURE'
+            } finally {
+                if (params.SLACK_CHANNEL) {
+                    timeout(time: 5, unit: 'MINUTES') {
+                        if (currentBuild.result == 'FAILURE') {
+                            println("${env.JOB_NAME} #${env.BUILD_NUMBER} result is FAILURE. Checking console log for specific errors...")
+                            // create error list and regex can be used
+                            List<String> errorList = new ArrayList<String>();
+                            errorList.add(".*There is not enough space in the file system.*");
 
-                                // nightly/weekly builds should not have git clone issue
-                                if (!env.JOB_NAME.contains("Grinder") && !env.JOB_NAME.contains("_Personal")) {
-                                    errorList.add(".*ERROR: Error cloning remote repo.*");
-                                }
-                                checkErrors(errorList)
+                            // nightly/weekly builds should not have git clone issue
+                            if (!env.JOB_NAME.contains("Grinder") && !env.JOB_NAME.contains("_Personal")) {
+                                errorList.add(".*ERROR: Error cloning remote repo.*");
                             }
+                            checkErrors(errorList)
                         }
                     }
                 }
             }
         }
-        if (currentBuild.result != 'FAILURE') {
-            jenkinsfile.run_parallel_tests()
-        }
-    } else {
-        assert false : "Cannot find key PLATFORM: ${params.PLATFORM} in PLATFORM_MAP: ${PLATFORM_MAP}."
+    }
+    if (currentBuild.result != 'FAILURE') {
+        jenkinsfile.run_parallel_tests()
     }
 }
 

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -2,99 +2,99 @@
 
 def PLATFORM_MAP = [
     'arm_linux' : [
-        'SPEC' : 'linux_arm',
-        'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch32',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&sw.os.linux&&hw.arch.aarch32',
     ],
     'aarch64_mac' : [
-        'SPEC' : 'osx_aarch64',
-        'LABEL' : 'ci.role.test&&sw.os.osx&&hw.arch.aarch64',
+        'BASE_OS': 'osx',
+        'LABEL'  : 'ci.role.test&&sw.os.osx&&hw.arch.aarch64',
     ],
     'aarch64_linux' : [
-        'SPEC' : 'linux_aarch64',
-        'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
     ],
     'ppc32_aix' : [
-        'SPEC' : 'aix_ppc',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
+        'BASE_OS': 'aix',
+        'LABEL'  : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
     ],
     'ppc32_linux' : [
-        'SPEC' : 'linux_ppc',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
     ],
     'ppc64_aix' : [
-        'SPEC' : 'aix_ppc-64',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
+        'BASE_OS': 'aix',
+        'LABEL'  : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',
     ],
     'ppc64_linux' : [
-        'SPEC' : 'linux_ppc-64',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&hw.arch.ppc64&&sw.os.linux',
     ],
     'ppc64le_linux' : [
-        'SPEC' : 'linux_ppc-64_le',
-        'LABEL' : 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&hw.arch.ppc64le&&sw.os.linux',
     ],
     'riscv64_linux' : [
-        'SPEC' : 'linux_riscv64',
-        'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.riscv&&hw.bits.64',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&sw.os.linux&&hw.arch.riscv&&hw.bits.64',
     ],
     'riscv64_linux_xl' : [
-        'SPEC' : 'linux_riscv64',
-        'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.riscv&&hw.bits.64',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&sw.os.linux&&hw.arch.riscv&&hw.bits.64',
     ],
     's390_linux' : [
-        'SPEC' : 'linux_390',
-        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux&&hw.bits.32',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&hw.arch.s390x&&sw.os.linux&&hw.bits.32',
         'DynamicAgents' : ['fyre']
     ],
     's390x_linux' : [
-        'SPEC' : 'linux_390-64',
-        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&hw.arch.s390x&&sw.os.linux',
         'DynamicAgents' : ['fyre']
     ],
     's390x_zos' : [
-        'SPEC' : 'zos_390-64',
-        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
+        'BASE_OS': 'zos',
+        'LABEL'  : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
     ],
     's390x_zos_xl' : [
-        'SPEC' : 'zos_390-64',
-        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
+        'BASE_OS': 'zos',
+        'LABEL'  : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
     ],
     's390_zos' : [
-        'SPEC' : 'zos_390',
-        'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
+        'BASE_OS': 'zos',
+        'LABEL'  : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
     ],
     'sparcv9_solaris' : [
-        'SPEC' : 'sunos_sparcv9-64',
-        'LABEL' : 'ci.role.test&&hw.arch.sparcv9&&sw.os.sunos',
+        'BASE_OS': 'solaris',
+        'LABEL'  : 'ci.role.test&&hw.arch.sparcv9&&sw.os.sunos',
     ],
     'x86-64_solaris' : [
-        'SPEC' : 'sunos_x86-64',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.sunos',
+        'BASE_OS': 'solaris',
+        'LABEL'  : 'ci.role.test&&hw.arch.x86&&sw.os.sunos',
     ],
     'x86-64_alpine-linux' : [
-        'SPEC' : 'alpine-linux',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.alpine-linux',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&hw.arch.x86&&sw.os.alpine-linux',
     ],
     'x86-32_linux' : [
-        'SPEC' : 'linux_x86',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
     ],
     'x86-32_windows' : [
-        'SPEC' : 'win_x86',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
+        'BASE_OS': 'windows',
+        'LABEL'  : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
     ],
     'x86-64_linux' : [
-        'SPEC' : 'linux_x86-64',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
+        'BASE_OS': 'linux',
+        'LABEL'  : 'ci.role.test&&hw.arch.x86&&sw.os.linux',
         'DynamicAgents' : ['azure', 'fyre']
     ],
     'x86-64_mac' : [
-        'SPEC' : 'osx_x86-64',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.osx',
+        'BASE_OS': 'osx',
+        'LABEL'  : 'ci.role.test&&hw.arch.x86&&sw.os.osx',
     ],
     'x86-64_windows' : [
-        'SPEC' : 'win_x86-64',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
+        'BASE_OS': 'windows',
+        'LABEL'  : 'ci.role.test&&hw.arch.x86&&sw.os.windows',
     ],
 ]
 
@@ -154,8 +154,8 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
         assert false : "Cannot find key PLATFORM: ${params.PLATFORM} in PLATFORM_MAP: ${PLATFORM_MAP}."
     }
 
-    SPEC = PLATFORM_MAP[params.PLATFORM]["SPEC"]
     LABEL = params.LABEL ? params.LABEL : PLATFORM_MAP[params.PLATFORM]["LABEL"]
+    BASE_OS = PLATFORM_MAP[params.PLATFORM]['BASE_OS']
 
     if (params.DOCKER_REQUIRED) {
         LABEL += "&&sw.tool.docker"
@@ -165,7 +165,6 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
         LABEL += "&&${params.LABEL_ADDITION}"
     }
 
-    println "SPEC: ${SPEC}"
     println "LABEL: ${LABEL}"
 
     dynamicAgents = []
@@ -213,7 +212,7 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
                 timeout(time: 1, unit: 'HOURS') {
                     cleanWs()
                 }
-                if (params.PLATFORM.contains('zos')) {
+                if (BASE_OS == 'zos') {
                     /* Ensure correct CC env */
                     env._CC_CCMODE = '1'
                     env._CXX_CCMODE = '1'

--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -47,7 +47,7 @@
 		</then>
 		<else>
 		 	<property name="openj9jtregtimeouthandler" value=""/>
-	       </else>
+		</else>
 	</if>
 	
 	<property name="LIB" value="${jtregTar}${openj9jtregtimeouthandler}"/>
@@ -77,7 +77,7 @@
 			<arg line="-d ${jtregTar}.tar.gz" />
 		</exec>
 		<if>
-			<contains string="${SPEC}" substring="zos" />
+			<equals arg="${BASE_OS}" arg2="zos" />
 			<then>
 				<exec executable="tar" failonerror="true">
 					<arg line="xfo ${jtregTar}.tar -C ${DEST}" />
@@ -96,7 +96,7 @@
 		     run the config command to allow file paths of 4096 characters 
 		-->
 		<if>
-			<contains string="${SPEC}" substring="win" />
+			<equals arg1="${BASE_OS}" arg2="windows" />
 			<then>
 				<exec executable="git" failonerror="false">
 					<arg line="config --global core.longpaths true" />
@@ -114,7 +114,7 @@
 			<then>
 				<echo> Using user specified repo and branch</echo>
 				<if>
-					<contains string="${SPEC}" substring="zos"/>
+					<equals arg1="${BASE_OS}" arg2="zos"/>
 					<then>
 						<propertyregex 
 							property="JDK_REPO_SPECIFIC"
@@ -174,7 +174,8 @@
 								<property name="jdkName" value="openj9-openjdk-jdk" />
 							</then>
 							<else>
-								<if> <contains string="${SPEC}" substring="zos"/>
+								<if>
+									<equals arg1="${BASE_OS}" arg2="zos"/>
 									<then>
 										<property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}-zos" />
 									</then>
@@ -185,7 +186,7 @@
 							</else>
 						</if>
 						<if>
-							<contains string="${SPEC}" substring="zos"/>
+							<equals arg1="${BASE_OS}" arg2="zos"/>
 							<then>
 								<property name="regressionRepo" value="git@github.ibm.com:runtimes/${jdkName}.git" />
 							</then>
@@ -197,7 +198,7 @@
 					<else>
 						<if>
 							<and>
-								<contains string="${env.SPEC}" substring="arm" />
+								<equals arg1="${PLATFORM}" arg2="arm_linux" />
 								<equals arg1="${JDK_VERSION}" arg2="8" />
 							</and>
 							<then>


### PR DESCRIPTION
Fixes #2363 

Goal: Use checks like `==` instead of `startsWith` to avoid string formatting requirements

Method: Replace `SPEC`, which is overly-general, with `BASE_OS` which is targeted towards all the `if` conditions I could find (except one, noted in comments)