### PR TITLE
Chmod SharedClasses natives only when they are compiled

### DIFF
--- a/system/common.xml
+++ b/system/common.xml
@@ -224,7 +224,15 @@
 		<copy todir="${SYSTEMTEST_DEST}/openj9-systemtest" failonerror="false">
 			<fileset dir="${SYSTEMTEST_ROOT}/openj9-systemtest" includes="**" />
 		</copy>
-		<chmod file="${SYSTEMTEST_DEST}/openj9-systemtest/openj9.test.sharedClasses.jvmti/bin/native/**" perm="755"/>
+		<if>
+			<or>
+				<contains string="${JVM_VERSION}" substring="openj9"/>
+				<contains string="${JVM_VERSION}" substring="ibm"/>
+			</or>
+				<then>
+					<chmod file="${SYSTEMTEST_DEST}/openj9-systemtest/openj9.test.sharedClasses.jvmti/bin/native/**" perm="755"/>
+				</then>
+		</if>
 		<copy todir="${SYSTEMTEST_DEST}/systemtest_prereqs/">
 			<fileset dir="${TEST_ROOT}/systemtest_prereqs/" includes="**" />
 		</copy>


### PR DESCRIPTION
Resolves https://github.com/adoptium/aqa-tests/issues/2798

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>

FYI @sophia-guo 