### PR TITLE
Re-enable DefaultStaticTest/DefaultStaticInvokeTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -142,7 +142,6 @@ java/lang/ref/OOMEInReferenceHandler.java	https://github.com/adoptium/aqa-tests/
 java/lang/ref/ReachabilityFenceTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/reflect/DefaultStaticTest/DefaultStaticInvokeTest.java https://github.com/eclipse-openj9/openj9/issues/13094 generic-all
 java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse-openj9/openj9/issues/7741	generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -144,7 +144,6 @@ java/lang/ref/OOMEInReferenceHandler.java	https://github.com/adoptium/aqa-tests/
 java/lang/ref/ReachabilityFenceTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/reflect/DefaultStaticTest/DefaultStaticInvokeTest.java	https://github.com/eclipse-openj9/openj9/issues/13094	generic-all
 java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse-openj9/openj9/issues/7741	generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all


### PR DESCRIPTION
Re-enable `java/lang/reflect/DefaultStaticTest/DefaultStaticInvokeTest.java`

Signed-off-by: Jason Feng <fengj@ca.ibm.com>