### PR TITLE
Fix delimiter for tck sub-test list in splitter.sh

### DIFF
--- a/jck/splitter/splitter.sh
+++ b/jck/splitter/splitter.sh
@@ -54,7 +54,7 @@ split()
 	   for ((j=${indices[$i]}; j<${indices[$i+1]}; j++));
 	   do 
 	      if [[ ${subTests[$j]} != "index.html" ]]; then 
-	         groups[$i]+="$testPathPrefix"/"${subTests[$j]},"
+	         groups[$i]+="$testPathPrefix"/"${subTests[$j]};"
 			 totalCounted=$(($totalCounted+1))
 	      fi 
 	   done


### PR DESCRIPTION
The sub-tests need to be delimited by ';'

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>