### PR TITLE
OpenJ9 AArch64: Stop excluding java/util/stream/stream/CountLargeTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -314,7 +314,6 @@ java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-ope
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java 	https://github.com/eclipse-openj9/openj9/issues/4613 	generic-all
-java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java	https://github.com/eclipse-openj9/openj9/issues/9040	linux-aarch64
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse-openj9/openj9/issues/3447	generic-all
 java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all

--- a/openjdk/excludes/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk15-openj9.txt
@@ -315,7 +315,6 @@ java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tes
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all
-java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java	https://github.com/eclipse-openj9/openj9/issues/9040	linux-aarch64
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse-openj9/openj9/issues/3447	generic-all
 java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all

--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -336,7 +336,6 @@ java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tes
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all
-java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java	https://github.com/eclipse-openj9/openj9/issues/9040	linux-aarch64
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse-openj9/openj9/issues/3447	generic-all
 java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -334,7 +334,6 @@ java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tes
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all
-java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java	https://github.com/eclipse-openj9/openj9/issues/9040	linux-aarch64
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse-openj9/openj9/issues/3447	generic-all
 java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all


### PR DESCRIPTION
The following test used to timeout with OpenJ9 for AArch64, and it was
excluded by #1710, #1947, and #2243.

- java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java

This commit removes its entries from the exclude lists.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>