### PR TITLE
Re-enable java/lang/invoke/VarHandles/VarHandleTestExact.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -160,7 +160,6 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-te
 java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse-openj9/openj9/issues/11783 generic-all
 java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse-openj9/openj9/issues/10648 generic-all
 java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse-openj9/openj9/issues/11822 generic-all
-java/lang/invoke/VarHandles/VarHandleTestExact.java https://github.com/eclipse-openj9/openj9/issues/11256 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -157,7 +157,6 @@ java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java ht
 java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse-openj9/openj9/issues/11783 generic-all
 java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse-openj9/openj9/issues/10648 generic-all
 java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse-openj9/openj9/issues/11822 generic-all
-java/lang/invoke/VarHandles/VarHandleTestExact.java https://github.com/eclipse-openj9/openj9/issues/11256 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
 ############################################################################


### PR DESCRIPTION
Re-enable `java/lang/invoke/VarHandles/VarHandleTestExact.java`

Related to https://github.com/eclipse-openj9/openj9/issues/11256

Signed-off-by: Jason Feng <fengj@ca.ibm.com>