### PR TITLE
Re-enable java/lang/invoke/MethodHandlesPermuteArgumentsTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -159,7 +159,6 @@ vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	m
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse-openj9/openj9/issues/11783 generic-all
 java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse-openj9/openj9/issues/10648 generic-all
-java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse-openj9/openj9/issues/11822 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -156,7 +156,6 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-te
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse-openj9/openj9/issues/11783 generic-all
 java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse-openj9/openj9/issues/10648 generic-all
-java/lang/invoke/MethodHandlesPermuteArgumentsTest.java https://github.com/eclipse-openj9/openj9/issues/11822 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
 ############################################################################


### PR DESCRIPTION
Re-enable `java/lang/invoke/MethodHandlesPermuteArgumentsTest.java`

Related to https://github.com/eclipse-openj9/openj9/issues/11822

Signed-off-by: Jason Feng <fengj@ca.ibm.com>