### PR TITLE
Re-enable java/lang/invoke/CompileThresholdBootstrapTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -93,7 +93,6 @@ java/lang/invoke/AccessControlTest.java	https://github.com/adoptium/aqa-tests/is
 java/lang/invoke/ArrayConstructorTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/invoke/CallerSensitiveAccess.java	https://github.com/eclipse-openj9/openj9/issues/6768	generic-all
 java/lang/invoke/ClassSpecializerTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/CompileThresholdBootstrapTest.java	https://github.com/eclipse-openj9/openj9/issues/13094	generic-all
 java/lang/invoke/DefineClassTest.java		https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/invoke/defineHiddenClass/BasicTest.java	https://github.com/eclipse-openj9/openj9/issues/10345	generic-all
 java/lang/invoke/defineHiddenClass/LambdaNestedInnerTest.java	https://github.com/eclipse-openj9/openj9/issues/10345	generic-all


### PR DESCRIPTION
Re-enable `java/lang/invoke/CompileThresholdBootstrapTest.java`

Related to https://github.com/eclipse-openj9/openj9/issues/13094

Signed-off-by: Jason Feng <fengj@ca.ibm.com>