### PR TITLE
Re-enable java/lang/invoke/LoopCombinatorLongSignatureTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -112,7 +112,6 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/adop
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/invoke/LambdaFormTest.java		https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/invoke/LoopCombinatorTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/LoopCombinatorLongSignatureTest.java	https://github.com/eclipse-openj9/openj9/issues/13094 generic-all
 java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse-openj9/openj9/issues/11366 generic-all
 java/lang/invoke/MethodHandles/privateLookupIn/Driver.java https://github.com/eclipse-openj9/openj9/issues/8571 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse-openj9/openj9/issues/7043	generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -107,7 +107,6 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/adop
 java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/invoke/LambdaFormTest.java		https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/invoke/LoopCombinatorTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/LoopCombinatorLongSignatureTest.java	https://github.com/eclipse-openj9/openj9/issues/13094	generic-all
 java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse-openj9/openj9/issues/11366 generic-all
 java/lang/invoke/MethodHandles/privateLookupIn/Driver.java https://github.com/eclipse-openj9/openj9/issues/8571 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse-openj9/openj9/issues/7043	generic-all


### PR DESCRIPTION
Test fixed by https://github.com/eclipse-openj9/openj9/pull/13285
Related to https://github.com/eclipse-openj9/openj9/issues/13094

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>