### PR TITLE
Remove (_mixed)? from excludes in tck playlists

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -84,13 +84,13 @@
 		<disables>
 			<disable>
 				<comment>Temporarily disabled on aix on JDK8 for test setup issue: backlog/issues/506</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>8</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Temporarily disabled on aix on JDK8 for test setup issue: backlog/issues/506</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>8</version>
 				<impl>openj9</impl>
 			</disable>

--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -33,13 +33,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -61,13 +61,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -89,13 +89,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -117,13 +117,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -145,13 +145,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -173,13 +173,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -201,13 +201,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -229,13 +229,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -257,13 +257,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -285,13 +285,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix(_mixed)?</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -333,7 +333,7 @@
 			</disable>
 			<disable>
 				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux(_mixed)?|x86-64_windows(_mixed)?</platform>
+				<platform>ppc64le_linux|x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -621,13 +621,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -820,13 +820,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -292,12 +292,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -349,12 +349,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
  			<disable>
@@ -394,12 +394,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
   			<disable>
@@ -436,7 +436,7 @@
 			</disable>
 			<disable>
 				<comment>Disabled on win64 on jdk8 due to backlog/issues/504. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>8</version>
 				<impl>ibm</impl>
 			</disable>
@@ -453,7 +453,7 @@
 			</disable>
 			<disable>
 				<comment>Disabled on win64 on jdk8 due to backlog/issues/504. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>8</version>
 				<impl>openj9</impl>
 			</disable>
@@ -485,13 +485,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?|ppc64_aix(_mixed)?</platform>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<version>8</version>
 				<impl>ibm</impl>
 			</disable>
@@ -503,13 +503,13 @@
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?|ppc64_aix(_mixed)?</platform>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<version>8</version>
 				<impl>openj9</impl>
 			</disable>
@@ -542,12 +542,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -671,25 +671,25 @@
 		<disables>
 			<disable>
 				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>8</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>8</version>
 				<impl>openj9</impl>
 			</disable>
@@ -753,13 +753,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx and win for backlog/issues/489. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?|x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_windows|x86-64_mac</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx and win for backlog/issues/489. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?|x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_windows|x86-64_mac</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
@@ -781,12 +781,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
@@ -874,12 +874,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -928,12 +928,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
@@ -987,12 +987,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
@@ -1060,12 +1060,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?</platform>
+				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
  			<disable>
@@ -1116,7 +1116,7 @@
 			</disable>
 			<disable>
 				<comment>Disabled on osx on jdk8 due to backlog/issues/5254 and on win32 due to backlog/issues/503. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?|x86-32_windows(_mixed)?</platform>
+				<platform>x86-64_mac|x86-32_windows</platform>
 				<version>8</version>
 				<impl>ibm</impl>
 			</disable>
@@ -1133,7 +1133,7 @@
 			</disable>
 			<disable>
 				<comment>Disabled on osx on jdk8 due to backlog/issues/5254 and on win32 due to backlog/issues/503. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac(_mixed)?|x86-32_windows(_mixed)?</platform>
+				<platform>x86-64_mac|x86-32_windows</platform>
 				<version>8</version>
 				<impl>openj9</impl>
 			</disable>

--- a/jck/runtime.xml_schema/playlist.xml
+++ b/jck/runtime.xml_schema/playlist.xml
@@ -33,13 +33,13 @@
 		<disables>
 			<disable>
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows(_mixed)?</platform>
+				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>


### PR DESCRIPTION
Remove `(_mixed)?` from the `<platform>` values in excludes in tck playlists as we no longer need it. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>