### PR TITLE
Excluding tests on windows 32bit

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -358,11 +358,11 @@
 				<impl>openj9</impl>
 			</disable>
  			<disable>
-                       		<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                    		<platform>x86-64_mac</platform>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_mac</platform>
   				<impl>hotspot</impl>
-    			</disable>
-            </disables>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -403,11 +403,11 @@
 				<impl>openj9</impl>
 			</disable>
   			<disable>
-                      		<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                       	 	<platform>x86-64_mac</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_mac</platform>
+				<impl>hotspot</impl>
  			</disable>
-               </disables>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -458,16 +458,21 @@
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-                        	<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                        	<platform>x86-64_mac</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_mac</platform>
+				<impl>hotspot</impl>
 			</disable>
 			<disable>
-                        	<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                        	<platform>x86-64_windows</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-32_windows</platform>
+				<impl>hotspot</impl>
  			</disable>
-               </disables>
+ 			<disable>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_windows</platform>
+				<impl>hotspot</impl>
+ 			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -520,11 +525,11 @@
 				<impl>openj9</impl>
 			</disable>
  			<disable>
-	                       	<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                        	<platform>x86-64_mac</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_mac</platform>
+				<impl>hotspot</impl>
 			</disable>
-                </disables>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -790,11 +795,11 @@
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-                        	<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                        	<platform>x86-64_mac</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_mac</platform>
+				<impl>hotspot</impl>
 			</disable>
-                </disables>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -937,11 +942,11 @@
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-                        	<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                        	<platform>x86-64_mac</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_mac</platform>
+				<impl>hotspot</impl>
   			</disable>
-              </disables>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -996,11 +1001,11 @@
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-                        	<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                        	<platform>x86-64_mac</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_mac</platform>
+				<impl>hotspot</impl>
 			</disable>
-                </disables>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1069,11 +1074,11 @@
 				<impl>openj9</impl>
 			</disable>
  			<disable>
-                       		<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                        	<platform>x86-64_mac</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_mac</platform>
+				<impl>hotspot</impl>
 			</disable>
-                </disables>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1138,16 +1143,21 @@
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-                        	<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                        	<platform>x86-64_mac</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_mac</platform>
+				<impl>hotspot</impl>
 			</disable>
 			<disable>
-                       	 	<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-                        	<platform>x86-64_windows</platform>
-                        	<impl>hotspot</impl>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-32_windows</platform>
+				<impl>hotspot</impl>
 			</disable>
-                </disables>
+			<disable>
+				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
+				<platform>x86-64_windows</platform>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
Some tests that are already excluded on windows 64bit should also
be excluded on windows 32bit for the same reasons.

I've also tidied up some formatting, as tabs seem the rule for this
file, and it seems a few spaces snuck in. Fixed.

Signed-off-by: Adam Farley <adfarley@redhat.com>