### PR TITLE
Excluding KeyFactoryGetKeySpecForInvalidSpec on OpenJCEPlus

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -261,6 +261,7 @@ java/security/KeyPairGenerator/FinalizeHalf.java    https://github.com/eclipse-o
 java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java	https://github.com/adoptium/aqa-tests/issues/2790	generic-all
 java/security/Signature/ResetAfterException.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
+java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 
 ############################################################################
 


### PR DESCRIPTION
Below test is implemented to run on Oracle provides but not on OpenJCEPlus provider. Hence excluding this test on z/OS as we have OpenJCEPlus only on z/OS builds.

For more info on the exclusion, please refer runtimes/openj9-openjdk-jdk11-zos/issues/1019