### PR TITLE
Unexclude compiler lang CLSS test on AIX jdk11

### DIFF
--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -30,20 +30,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group1</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -58,20 +44,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group2</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -86,20 +58,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group3</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -114,20 +72,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group4</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -142,20 +86,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group5</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -170,20 +100,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group6</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -198,20 +114,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group7</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -226,20 +128,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group8</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -254,20 +142,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group9</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -282,20 +156,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group10</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix due to RTC: 144784</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
Unexclude compiler lang CLSS test on AIX jdk11, since RTC#144784 is resolved.

FYI @JasonFengJ9 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>