### PR TITLE
Exclude HelpFlagsTest.java on Windows 32bit

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -188,6 +188,8 @@ security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.jav
 
 # jdk_tools
 
+tools/launcher/HelpFlagsTest.java	https://bugs.openjdk.java.net/browse/JDK-8273235	windows-x86
+
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/ProblemList_openjdk16.txt
+++ b/openjdk/excludes/ProblemList_openjdk16.txt
@@ -211,6 +211,7 @@ sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-824
 sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all
 sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all
 sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all
+tools/launcher/HelpFlagsTest.java	https://bugs.openjdk.java.net/browse/JDK-8273235 windows-x86
 tools/jpackage/linux/AppCategoryTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
 tools/jpackage/linux/LinuxBundleNameTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
 tools/jpackage/linux/LinuxResourceTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -191,6 +191,7 @@ sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-824
 sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all
 sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all
 sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all
+tools/launcher/HelpFlagsTest.java	https://bugs.openjdk.java.net/browse/JDK-8273235 windows-x86
 tools/jpackage/linux/AppCategoryTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
 tools/jpackage/linux/LinuxBundleNameTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
 tools/jpackage/linux/LinuxResourceTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64


### PR DESCRIPTION
An anticipated upstream fix should resolve the failure affecting
this test. Basically we're verifying the help output of a pair of
.exe files that (it appears) should be ignored by this test.

Excluding this test until the issue is resolved.

Signed-off-by: Adam Farley <adfarley@redhat.com>