### PR TITLE
Limit graal problem list to jdk11 and jdk16 as graal was removed for jdk16+

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -156,3 +156,8 @@ endif
 ifeq (,$(wildcard $(PROBLEM_LIST_FILE)))
 	PROBLEM_LIST_FILE:=$(PROBLEM_LIST_DEFAULT)
 endif
+
+GRAAL_PROBLEM_LIST_FILE:=
+ifneq ($(filter 11 16, $(JDK_VERSION)),)
+	GRAAL_PROBLEM_LIST_FILE:=-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList-graal.txt$(Q)
+endif

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -157,6 +157,7 @@ ifeq (,$(wildcard $(PROBLEM_LIST_FILE)))
 	PROBLEM_LIST_FILE:=$(PROBLEM_LIST_DEFAULT)
 endif
 
+# ProblemList-graal.txt file only exists in jdk11 and jdk16. Refer to the file only when it is present.
 GRAAL_PROBLEM_LIST_FILE:=
 ifneq ($(filter 11 16, $(JDK_VERSION)),)
 	GRAAL_PROBLEM_LIST_FILE:=-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList-graal.txt$(Q)

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -215,8 +215,8 @@
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
 	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList-graal.txt$(Q) \
 	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${GRAAL_PROBLEM_LIST_FILE} \
 	$(Q)$(JTREG_HOTSPOT_TEST_DIR):hotspot_compiler$(Q); \
 	$(TEST_STATUS)</command>
 		<versions>


### PR DESCRIPTION
Limit graal problem list to jdk11 and jdk16 as graal was removed for jdk16+

Fixes #2845 

Signed-off-by: Sophia Guo sophia.gwf@gmail.com