### PR TITLE
Moved unzip jtreg.jar command into if statement

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -68,14 +68,14 @@
 							<copy file="custom_jtreg.tar.gz" tofile="${jtregTar}.tar.gz"/>
 					</then>
 				</if>
+				<exec executable="gzip" failonerror="true">
+					<arg line="-d ${jtregTar}.tar.gz" />
+				</exec>
 			</then>
 			<else>
    				<copy file="${LIB_DIR}/${jtregTar}.tar.gz" tofile="${jtregTar}.tar.gz"/>
 			</else>
 		</if>
-		<exec executable="gzip" failonerror="true">
-			<arg line="-d ${jtregTar}.tar.gz" />
-		</exec>
 		<if>
 			<contains string="${SPEC}" substring="zos" />
 			<then>


### PR DESCRIPTION
Was previously trying to unzip this file even if it already existed
from a previous `make compile` command

Signed-off-by: Amanda Nguyen <amanda6@ualberta.ca>

Fixes #2879 