### PR TITLE
Skip UI tests on aarch64_mac

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -359,7 +359,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
   				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -404,7 +404,7 @@
 			</disable>
   			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
  			</disable>
 		</disables>
@@ -459,7 +459,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
@@ -526,7 +526,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -796,7 +796,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -943,7 +943,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
   			</disable>
 		</disables>
@@ -1002,7 +1002,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -1075,7 +1075,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -1144,7 +1144,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -359,7 +359,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
+				<platform>.*mac.*</platform>
   				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -404,7 +404,7 @@
 			</disable>
   			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
  			</disable>
 		</disables>
@@ -459,7 +459,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
@@ -526,7 +526,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -796,7 +796,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -943,7 +943,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
   			</disable>
 		</disables>
@@ -1002,7 +1002,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -1075,7 +1075,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -1144,7 +1144,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>


### PR DESCRIPTION
Skips the same tests that were skipped on intel in https://github.com/adoptium/aqa-tests/pull/2728