### PR TITLE
AIX: Ensure X VFB process is stopped after tests are complete

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -631,6 +631,9 @@ def post(output_name) {
 			else {
 				output_name = output_name.replace("/","_")
 			}
+			if (SPEC.startsWith('aix')) {
+				sh "VFBPID=$(ps -fu jenkins | grep vfb | awk '{print\$2}'); if [ ! -z "$VFBPID" ]; then echo Killing VFB process $VFBPID; kill $VFBPID; fi"
+			}
 			def tar_cmd = "tar -cf"
 			// Use pigz if we can as it is faster - 2> hides fallback message
 			def tar_cmd_suffix = "| (pigz -9 2>/dev/null || gzip -9)"


### PR DESCRIPTION
In two minds on this ... Tempted to also add it to the point just before it starts up a new one. It's possible that the problems we've been seeing with the leftover processes are related to situations where the test run is aborted part way through, in which case this block may not get run, but I'll leave it for reviewers to determine whether this is a reasonable course of action to try or not ...

May fix https://github.com/adoptium/infrastructure/issues/2297

Signed-off-by: Stewart X Addison <sxa@redhat.com>