### PR TITLE
Add ASGCTBaseTest for openj9/ibm

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -157,6 +157,38 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>ASGCTBaseTest</testCaseName>
+		<variations>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JVM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	$(Q)$(JTREG_HOTSPOT_TEST_DIR)/serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java$(Q); \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>16+</version>
+		</versions>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+		<!-- Currently only supported on Linux x86-64 -->
+		<platformRequirements>os.linux,arch.x86,bits.64</platformRequirements>
+	</test>
+	<test>
 		<testCaseName>jvm_native_sanity</testCaseName>
 		<disables>
 			<disable>


### PR DESCRIPTION
depends on https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/33
related: https://github.com/eclipse-openj9/openj9/issues/12276


Signed-off-by: lanxia <lan_xia@ca.ibm.com>