### PR TITLE
Fix external Camel tag and Quarkus-quickstarts test

### DIFF
--- a/external/camel/test.properties
+++ b/external/camel/test.properties
@@ -2,7 +2,7 @@
  script="camel-test.sh"
  test_command="mvn clean install"
  test_results="testResults"
- tag_version="master"
+ tag_version="main"
  environment_variable="MODE=\"java\""
  debian_packages="git maven"
  debianslim_packages="${debian_packages}"

--- a/external/quarkus_quickstarts/dockerfile/test.sh
+++ b/external/quarkus_quickstarts/dockerfile/test.sh
@@ -49,7 +49,7 @@ mvn -pl !:hibernate-orm-quickstart,!:hibernate-orm-panache-quickstart,\
 !:security-openid-connect-web-authentication-quickstart,\
 !:security-openid-connect-multi-tenancy-quickstart,!:spring-data-jpa-quickstart,\
 !:vertx-quickstart,!:context-propagation-quickstart,!:getting-started-reactive-rest,\
-!:kafka-quickstart,!:neo4j-quickstart clean install
+!:kafka-quickstart,!:neo4j-quickstart,!:rest-client-quickstart,!:rest-client-multipart-quickstart clean install
 test_exit_code=$?
 echo "Build quarkus_quickstarts completed"
 


### PR DESCRIPTION
- Fix camel test tag issue, Resolves #2901
- Fix quarkus-quickstarts test by skipping rest-client subtest, Resolves #2904

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>