### PR TITLE
Correct wrong OSNAME-ARCH in problemlist*.txt #2908

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -27,7 +27,7 @@
 # jdk_lang
 
 java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	x86-64_windows
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	windows-x86
 #java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
 java/lang/ClassLoader/Assert.java 	https://github.com/eclipse-openj9/openj9/issues/6668 	macosx-x64

--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -27,7 +27,7 @@
 # jdk_lang
 
 java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	windows-x86
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	windows-x64
 #java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
 java/lang/ClassLoader/Assert.java 	https://github.com/eclipse-openj9/openj9/issues/6668 	macosx-x64

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -48,7 +48,7 @@ compiler/jsr292/RedefineMethodUsedByMultipleMethodHandles.java	https://github.co
 compiler/loopopts/UseCountedLoopSafepoints.java	https://github.com/adoptium/aqa-tests/issues/116	generic-all
 compiler/loopopts/TestImpossibleIV.java	https://github.com/adoptium/aqa-tests/issues/116	generic-all
 compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tests/issues/2671 linux-ppc64le,aix-all,arm-linux,windows-x86
+compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tests/issues/2671 linux-ppc64le,aix-all,linux-arm,windows-x86
 compiler/6894807/IsInstanceTest.java https://github.com/adoptium/adoptium/issues/58 aix-all
 compiler/types/correctness/OffTest.java	1https://github.com/adoptium/aqa-tests/issues/16	generic-all
 gc/TestVerifySilently.java	https://github.com/adoptium/aqa-tests/issues/116	generic-all


### PR DESCRIPTION
When merged this pull request fixes #2908 by correcting OSNAME-ARCH in the following problemlist*.txt files:
- aqa-tests/openjdk/excludes/ProblemList_openjdk8.txt
- aqa-tests/openjdk/excludes/ProblemList_openjdk11-openj9.txt

Changes made:
- Updates `arm-linux` to `linux-arm` on Line 51
- Updated `x86-64_windows` to `windows-x64` on Line 30

