### PR TITLE
Temporarily disable failed external tests for openj9

### DIFF
--- a/external/external_custom/build.xml
+++ b/external/external_custom/build.xml
@@ -30,6 +30,17 @@
 	</target>
 
 	<target name="build">
-		<antcall target="dist" inheritall="true" />
+		<!-- Temporarily disbale for openj9 and ibm due to https://github.com/adoptium/aqa-tests/issues/2903 -->
+		<if>
+			<not>
+				<or>
+					<equals arg1="${JDK_IMPL}" arg2="ibm"  />
+					<equals arg1="${JDK_IMPL}" arg2="openj9" />
+				</or>
+			</not>
+			<then>
+				<antcall target="dist" inheritall="true" />
+			</then>
+		</if>
 	</target>
 </project>

--- a/external/openliberty-mp-tck/playlist.xml
+++ b/external/openliberty-mp-tck/playlist.xml
@@ -82,5 +82,15 @@
 		<groups>
 			<group>external</group>
 		</groups>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/2902</comment>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/2902</comment>
+				<impl>ibm</impl>
+			</disable>
+		</disables>
 	</test>
 </playlist>


### PR DESCRIPTION
- To enable sanity.external pipeline, temporarily disable failed external tests

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>