### PR TITLE
Switch to the Adoptium api to get the latest nightly builds testimage

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -227,7 +227,7 @@ getBinaryOpenjdk()
 		info_url="https://api.adoptopenjdk.net/v3/assets/feature_releases/${JDK_VERSION}/${release_type}?architecture=${arch}&heap_size=${heap_size}&image_type=jdk&jvm_impl=${JDK_IMPL}&os=${os}&project=jdk&vendor=adoptopenjdk"
 
 		if [ "$JDK_VERSION" != "8" ] || [ "$JDK_IMPL" != "hotspot" ]; then
-			download_url+=" https://api.adoptopenjdk.net/v3/binary/latest/${JDK_VERSION}/${release_type}/${os}/${arch}/testimage/${JDK_IMPL}/${heap_size}/adoptopenjdk"
+			download_url+=" https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/${release_type}/${os}/${arch}/testimage/${JDK_IMPL}/${heap_size}/adoptium?project=jdk"
 			info_url+=" https://api.adoptopenjdk.net/v3/assets/feature_releases/${JDK_VERSION}/${release_type}?architecture=${arch}&heap_size=${heap_size}&image_type=testimage&jvm_impl=${JDK_IMPL}&os=${os}&project=jdk&vendor=adoptopenjdk"
 		fi
 	else


### PR DESCRIPTION
Fixes [#2931](https://github.com/adoptium/aqa-tests/issues/2931), for which the download_url is updated as requested (with below changes).

from
https://api.adoptopenjdk.net/v3/binary/latest/${JDK_VERSION}/${release_type}/${os}/${arch}/testimage/${JDK_IMPL}/${heap_size}/adoptopenjdk
to
https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/${release_type}/${os}/${arch}/testimage/${JDK_IMPL}/${heap_size}/adoptium?project=jdk


Note: a similar issue [#2909](https://github.com/adoptium/aqa-tests/issues/2909) mentioned the info_url needs to be updated as well (with below changes). Please let me know if we wanna cover that update within this RP.

- change api.adoptopenjdk.net to api.adoptium.net
- change vendor=adoptopenjdk to vendor=eclipse