### PR TITLE
TestExcessGCLockerCollections.java is available from JDK 11+

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -75,6 +75,7 @@
 	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
 	$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)$(HOTSPOT_CUSTOM_TARGET)$(Q); \
 	$(TEST_STATUS)</command>
+		<version>11+</version>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
TestExcessGCLockerCollections.java is available from JDK 11+

Following failure occurred at JDK8.
```
[2021-10-06T03:44:49.244Z] Error: Cannot find file: /home/jenkins/workspace/Test_openjdk8_j9_extended.openjdk_ppc64le_linux/aqa-tests/TKG/../openjdk/openjdk-jdk/hotspot/test/gc/stress/gclocker/TestExcessGCLockerCollections.java
[2021-10-06T03:44:49.244Z] 
[2021-10-06T03:44:49.244Z] hotspot_custom_0_FAILED
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>