### PR TITLE
`make compile` fails due to trying to pulling non-existing branch of `apache/camel-quarkus` repo #2738

### DIFF
--- a/external/camel/test.properties
+++ b/external/camel/test.properties
@@ -2,7 +2,7 @@
  script="camel-test.sh"
  test_command="mvn clean install"
  test_results="testResults"
- tag_version="main"
+ tag_version="master"
  environment_variable="MODE=\"java\""
  debian_packages="git maven"
  debianslim_packages="${debian_packages}"


### PR DESCRIPTION
Fixed the `make compile` fail due to non-existent branch by changing branch name.