### PR TITLE
Restrict hotspot_custom to hotspot implementation

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -81,6 +81,9 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
 	</test>
 	<test>
 		<testCaseName>hotspot_compiler</testCaseName>


### PR DESCRIPTION
This testcase doesn't apply to `OpenJ9`/`IBM`, and caused consistent failure as following:
```
[2021-10-09T15:35:12.192Z] java.lang.RuntimeException: '\[gc\s*\] .* \(GCLocker Initiated GC\) [1-9][0-9]*M' missing from stdout 
[2021-10-09T15:35:12.192Z] 
[2021-10-09T15:35:12.192Z] 	at jdk.test.lib.process.OutputAnalyzer.stdoutShouldMatch(OutputAnalyzer.java:358)
[2021-10-09T15:35:12.192Z] 	at gc.stress.gclocker.TestExcessGCLockerCollections.main(TestExcessGCLockerCollections.java:182)
[2021-10-09T15:35:12.192Z] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[2021-10-09T15:35:12.192Z] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[2021-10-09T15:35:12.192Z] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[2021-10-09T15:35:12.192Z] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[2021-10-09T15:35:12.192Z] 	at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:312)
[2021-10-09T15:35:12.192Z] 	at java.base/java.lang.Thread.run(Thread.java:884)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>