### PR TITLE
Update ProblemList_openjdk8.txt to exclude Test8167409.sh on aarch64

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -107,6 +107,7 @@ runtime/7110720/Test7110720.sh https://github.com/adoptium/aqa-tests/issues/2818
 compiler/6894807/IsInstanceTest.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/8004051/Test8004051.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
+compiler/criticalnatives/argumentcorruption/Test8167409.sh https://github.com/adoptium/aqa-tests/issues/2984 linux-aarch64
 ############################################################################
 
 # jdk_awt


### PR DESCRIPTION
adding an exclusion statement in ProblemList_openjdk8.txt
Fix #2984