### PR TITLE
Update ProblemList_openjdk17.txt to exclude a runtime_nestmate on windows-x86

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -329,6 +329,5 @@ jdk/incubator/vector/ShortMaxVectorTests.java	https://github.com/adoptium/aqa-te
 ############################################################################
 
 #runtime_nestmate
-runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java
-https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
+runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 


### PR DESCRIPTION
Fix #2997