### PR TITLE
Consolidate tck test excludes based on latest results and infra issues

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -393,13 +393,13 @@
 		<testCaseName>jck-runtime-api-java_applet</testCaseName>
 		<disables>
 			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
+				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
+				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<impl>openj9</impl>
 			</disable>
   			<disable>
@@ -425,36 +425,10 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254, and on rest for backlog/issues/485. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<version>16+</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win64 on jdk8 due to backlog/issues/504. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>8</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254, and on rest for backlog/issues/485. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<version>16+</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win64 on jdk8 due to backlog/issues/504. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>8</version>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
@@ -785,13 +759,13 @@
 		<testCaseName>jck-runtime-api-javax_accessibility</testCaseName>
 		<disables>
 			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
+				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
+				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
@@ -1110,36 +1084,10 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254, on win for backlog/issues/487 and on others for backlog/issues/484. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254, on win for backlog/issues/487 and on others for backlog/issues/484. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<version>16+</version>
-				<platform>x86-64_mac</platform>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx on jdk8 due to backlog/issues/5254 and on win32 due to backlog/issues/503. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|x86-32_windows</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254, on win for backlog/issues/487 and on others for backlog/issues/484. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254, on win for backlog/issues/487 and on others for backlog/issues/484. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<version>16+</version>
-				<platform>x86-64_mac</platform>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx on jdk8 due to backlog/issues/5254 and on win32 due to backlog/issues/503. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|x86-32_windows</platform>
-				<version>8</version>
 				<impl>openj9</impl>
 			</disable>
 			<disable>


### PR DESCRIPTION
As discussed in backlog/issues/608: 

- Exclude the following targets on AIX on all SDK versions for ibm and openj9  due to backlog/issues/486:  
  - java_applet  
  - javax_accessibility 

- Disable the following targets from all platform and SDK versions for ibm and openj9 due to backlog/issues/484 & backlog/issues/485: 
  - java_awt
  - javax_swing

Related to backlog/issues/608

FYI @JasonFengJ9 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>