### PR TITLE
Disable vm-jvmti tck test from Windows on 8 and 11

### DIFF
--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -65,6 +65,32 @@
 		<groups>
 			<group>jck</group>
 		</groups>
+		<disables>
+			<disable>
+				<comment>backlog/issues/607</comment>
+				<impl>ibm</impl>
+				<platform>x86-64_windows</platform>
+				<version>8+</version>
+			</disable>
+			<disable>
+				<comment>backlog/issues/607</comment>
+				<impl>openj9</impl>
+				<platform>x86-64_windows</platform>
+				<version>8+</version>
+			</disable>
+			<disable>
+				<comment>backlog/issues/607</comment>
+				<impl>ibm</impl>
+				<platform>x86-32_windows</platform>
+				<version>8</version>
+			</disable>
+			<disable>
+				<comment>backlog/issues/607</comment>
+				<impl>openj9</impl>
+				<platform>x86-32_windows</platform>
+				<version>8</version>
+			</disable>
+		</disables>
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-overview</testCaseName>


### PR DESCRIPTION
- Related to : backlog/issues/607

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>