### PR TITLE
Do not copy systemtest prereq jars in compliance test builds

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -516,7 +516,7 @@ def buildTest() {
 			}
 
 			try {
-				if (env.BUILD_LIST.startsWith('system') || env.BUILD_LIST.startsWith('jck')) {
+				if (env.BUILD_LIST.startsWith('system')) {
 					//get pre-staged test jars from systemtest.getDependency build before system test compilation
 					timeout(time: 1, unit: 'HOURS') {
 						copyArtifacts fingerprintArtifacts: true, projectName: "systemtest.getDependency", selector: lastSuccessful(), target: 'aqa-tests'


### PR DESCRIPTION
- We no longer need systemtest prereq jars to run tcks. So, we should stop copying them. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>