### PR TITLE
Exclude java/lang/String/StringRepeat.java on windows32 with jdk17

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -79,6 +79,7 @@ java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://gi
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
+java/lang/String/StringRepeat.java#id1 https://bugs.openjdk.java.net/browse/JDK-8221400 windows-x86
 ############################################################################
 
 # jdk_management


### PR DESCRIPTION
excluding : adding one exclusion statements in https://github.com/adoptium/aqa-tests/blob/master/openjdk/excludes/ProblemList_openjdk17.txt (it should belong to jdk_lang section, like just after Line 81 ).

java/lang/String/StringRepeat.java#id1 https://bugs.openjdk.java.net/browse/JDK-8221400 windows-x86
Fixes #3002