### PR TITLE
Support other issue or bug tracker when parsing problem list #2906

### DIFF
--- a/disabledTestParser/ProblemList.json
+++ b/disabledTestParser/ProblemList.json
@@ -3,13 +3,13 @@
     "JDK_IMPL" : "hotspot",
     "TARGET" : "jdk_custom",
     "CUSTOM_TARGET" : "java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java",
-    "GIT_ISSUE" : "https://github.com/adoptium/temurin-build/issues/248",
+    "ISSUE_TRACKER" : "https://github.com/adoptium/temurin-build/issues/248",
     "PLATFORM" : "all"
     },{
     "JDK_VERSION" : 16,
     "JDK_IMPL" : "openj9",
     "TARGET" : "jdk_custom",
     "CUSTOM_TARGET" : "java/lang/ClassLoader/Assert.java",
-    "GIT_ISSUE" : "https://github.com/eclipse-openj9/openj9/issues/6668",
+    "ISSUE_TRACKER" : "https://github.com/eclipse-openj9/openj9/issues/6668",
     "PLATFORM" : "x86-64_mac"
 }]

--- a/disabledTestParser/generateDisabledTestListJson.py
+++ b/disabledTestParser/generateDisabledTestListJson.py
@@ -76,7 +76,7 @@ def get_test_details(test):
     test_tokens = test.split()
     test_details_dict["TARGET"] = "jdk_custom"
     test_details_dict["CUSTOM_TARGET"] = test_tokens[0]
-    test_details_dict["GIT_ISSUE"] = test_tokens[1]
+    test_details_dict["ISSUE_TRACKER"] = test_tokens[1]
     test_details_dict["PLATFORM"] = resolve_platform(test_tokens[2])
     return test_details_dict
 

--- a/disabledTestParser/issue_status.py
+++ b/disabledTestParser/issue_status.py
@@ -4,7 +4,7 @@ import requests
 
 def json_parser(json_obj):
     jsonLoad = json.loads(json_obj)
-    return jsonLoad["GIT_ISSUE"]
+    return jsonLoad["ISSUE_TRACKER"]
 
 def find_state(query_url):
     params = {'accept': 'application/vnd.github.v3+json',
@@ -27,7 +27,7 @@ def main():
         repo_issueUrl = git_issue_url.replace("https://github.com/", "")
         final_url = base_url + repo_issueUrl
         state = find_state(final_url)
-        j["GIT_ISSUE_STATUS"] = state  
+        j["ISSUE_TRACKER_STATUS"] = state  
     
     with open('output.json', 'w', encoding='utf-8') as f:
         json.dump(data, f, ensure_ascii=False, indent=4)


### PR DESCRIPTION
In Adoptium we also we also exclude test by openjdk bug tracker in Adoptium/aqa-tests. Probably azure devops also has its bug trackers or other vendors may have their own bug trackers.

To support that we need to update GIT_ISSUE to ISSUE_TRACKER when generating problem list.

Those following lines need to update GIT_ISSUE to ISSUE_TRACKER

https://github.com/adoptium/aqa-tests/blob/master/disabledTestParser/generateDisabledTestListJson.py#L80
https://github.com/adoptium/aqa-tests/blob/master/disabledTestParser/ProblemList.json#L6
https://github.com/adoptium/aqa-tests/blob/master/disabledTestParser/ProblemList.json#L13
The following line needs to update GIT_ISSUE_STATUS to ISSUE_TRACKER_STATUS

https://github.com/adoptium/aqa-tests/blob/master/disabledTestParser/issue_status.py#L30

Fixes #2906