### PR TITLE
Create ProblemList.openjdk18.txt

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -179,7 +179,6 @@ java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
 java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 linux-s390x
-******
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux_s390x,win_64
 java/nio/channels/FileChannel/LargeGatheringWrite.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64,win_64
 java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64

--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -371,12 +371,12 @@ compiler/graalunit/ReplacementsTest.java https://github.com/adoptium/aqa-tests/i
 compiler/graalunit/UtilTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux_s390x
 
-compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-32
-compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-32
-compiler/c2/irTests/TestPostParseCallDevirtualization.java  https://github.com/adoptium/aqa-tests/issues/3004 windows-32
-compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-32
-compiler/tiered/TieredLevelsTest.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-32
-compiler/vectorapi/TestNoInline.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-32
+compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/irTests/TestPostParseCallDevirtualization.java  https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/tiered/TieredLevelsTest.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/vectorapi/TestNoInline.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 
 
 

--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -305,7 +305,6 @@ com/sun/jdi/OnJcmdTest.java	https://github.com/adoptium/aqa-tests/issues/2837	wi
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/util/concurrent/tck/JSR166TestCase.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
-java/util/regex/NegativeArraySize.java
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -1,0 +1,453 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/XMLEncoder/java_awt_CardLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/java_awt_GridBagLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+#java/beans/XMLEncoder/java_awt_ScrollPane.java	failure on mac is tracked by https://github.com/adoptium/aqa-tests/issues/2848
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/javax_swing_Box.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_BoxLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_Box_Filler.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JButton.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JLayeredPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JSplitPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_OverlayLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_border_TitledBorder.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/Test4631471.java
+java/beans/XMLEncoder/Test4903007.java
+java/beans/PropertyChangeSupport/Test4682386.java
+
+############################################################################
+
+# jdk_lang
+java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
+java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
+vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	macosx-all
+java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/adoptium/temurin-build/issues/248 generic-all
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+#java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
+java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessString.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
+java/lang/reflect/Proxy/ProxyTest.java
+java/lang/ProcessBuilder/Basic.java 
+java/lang/System/FileEncodingTest.java
+java/lang/ProcessBuilder/Basic.java
+java/lang/instrument/IsModifiableClassAgent.java
+
+
+############################################################################
+
+# jdk_management
+com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
+sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+############################################################################
+
+# jdk_other
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
+############################################################################
+
+# jdk_net
+java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
+java/net/InetAddress/BadDottedIPAddress.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/InetAddress/CachedUnknownHostName.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/InetAddress/IPv4Formats.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699	linux-s390x
+java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/SocketPermission/SocketPermissionTest.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/net/SocketPermission/Wildcard.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/Socks/SocksV4Test.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/URL/OpenStream.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/httpclient/ConnectExceptionTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/httpclient/AsFileDownloadTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/StreamingBody.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/http2/ContinuationFrameTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/SpecialHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/http2/BadHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/DigestEchoClientSSL.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/ResponseBodyBeforeError.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/ResponsePublisher.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/MulticastSocket/Promiscuous.java               https://github.com/adoptium/infrastructure/issues/699    linux-s390x
+java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/adoptium/infrastructure/issues/699    linux-s390x
+java/net/MulticastSocket/Test.java                             https://github.com/adoptium/infrastructure/issues/699    linux-s390x
+java/net/CookieHandler/CookieManagerTest.java
+java/net/DatagramPacket/ReuseBuf.java
+java/net/DatagramSocket/GetLocalAddress.java
+java/net/DatagramSocket/PortUnreachable.java
+java/net/DatagramSocket/ReuseAddressTest.java
+java/net/DatagramSocket/Send12k.java
+java/net/DatagramSocket/SendReceiveMaxSize.java
+java/net/DatagramSocket/SendSize.java.SendSize
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java
+java/net/MulticastSocket/B6427403.java
+java/net/MulticastSocket/IPMulticastIF.java
+java/net/ServerSocket/TestLocalAddress.java
+java/net/Socket/CloseAvailable.java
+java/net/Socket/GetLocalAddress.java
+java/net/Socket/InheritTimeout.java
+java/net/Socket/ProxyCons.java
+java/net/Socket/ReadTimeout.java
+java/net/Socket/SetSoLinger.java
+java/net/Socket/SoTimeout.java
+java/net/Socket/asyncClose/AsyncClose.java
+java/net/Socket/asyncClose/BrokenPipe.java
+java/net/Socket/setReuseAddress/Basic.java
+java/net/Socket/setReuseAddress/Restart.java
+java/net/SocketInputStream/SocketTimeout.java
+java/net/Socks/BadProxySelector.java
+java/net/Socks/SocksProxyVersion.java
+java/net/Socket/asyncClose/Race.java
+java/net/httpclient/ManyRequests.java
+java/net/MulticastSocket/NoLoopbackPackets.java
+jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java
+jdk/net/ExtendedSocketOption/DatagramChannelNAPITest.java
+jdk/net/ExtendedSocketOption/DatagramSocketNAPITest.java
+jdk/net/ExtendedSocketOption/SocketChannelNAPITest.java
+jdk/net/ExtendedSocketOption/SocketNAPITest.java
+
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
+java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
+java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
+java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 linux-s390x
+java/nio/channels/Channels/ReadXBytes.java
+java/nio/channels/FileChannel/LargeGatheringWrite.java
+java/net/DatagramSocket/SendReceiveMaxSize.java
+java/nio/channels/DatagramChannel/AfterDisconnect.java
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java
+java/nio/channels/FileChannel/Transfer2GPlus.java
+java/nio/file/Files/probeContentType/Basic.java
+java/nio/Buffer/DirectBufferAllocTest.java
+
+############################################################################
+
+# jdk_io
+
+java/io/File/GetXSpace.java	https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+############################################################################
+
+# jdk_jdi
+com/sun/jdi/JdwpNetProps.java	https://bugs.openjdk.java.net/browse/JDK-8231915 linux-s390x
+com/sun/jdi/JdwpAttachTest.java	https://bugs.openjdk.java.net/browse/JDK-8253940 linux-s390x
+com/sun/jdi/BreakpointTest.java https://bugs.openjdk.java.net/browse/JDK-8050470 linux-s390x
+com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://github.com/adoptium/aqa-tests/issues/3034
+com/sun/jndi/dns/ConfigTests/Timeout.java
+
+############################################################################
+
+# jdk_nio
+java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.com/adoptium/temurin-build/issues/248	generic-all
+java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
+java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/file/Files/InterruptCopy.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
+jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
+java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
+
+java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034
+java/nio/file/spi/SetDefaultProvider.java
+
+############################################################################ 
+
+# jdk_rmi
+############################################################################
+
+# jdk_security
+
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+############################################################################
+
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+sun/tools/jstatd/TestJstatdDefaults.java.
+sun/tools/jstatd/TestJstatdExternalRegistry.java
+sun/tools/jstatd/TestJstatdPort.java
+sun/tools/jstatd/TestJstatdPortAndServer.java
+sun/tools/jstatd/TestJstatdRmiPort.java
+sun/tools/jstatd/TestJstatdServer.java
+
+tools/launcher/HelpFlagsTest.java	https://bugs.openjdk.java.net/browse/JDK-8273235 windows-x86
+tools/jpackage/share/AddLauncherTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AppImagePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/EmptyFolderPackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/IconTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
+#The following 8 tests under tools/jpackage/share/ excluded on linux-aarch64 the tracked issue is https://github.com/adoptium/infrastructure/issues/2291
+tools/jpackage/share/InstallDirTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/LicenseTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiNameTwoPhaseTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/RuntimePackageTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/SimplePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/BasicTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/VendorTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/windows/WinDirChooserTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinInstallerUiTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinL10nTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuGroupTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinPerUserInstallTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinScriptTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutPromptTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUrlTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jlink/JLinkTest.java	https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
+tools/jlink/JLinkReproducible3Test.java	https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
+tools/jlink/CheckExecutable.java
+tools/jlink/JLinkTest.java
+tools/jpackage/windows/WinInstallerIconTest.java
+tools/jpackage/share/AddLShortcutTest.java
+    
+############################################################################
+
+# jdk_jdi
+com/sun/jdi/OnJcmdTest.java	https://github.com/adoptium/aqa-tests/issues/2837	windows-x86
+############################################################################
+
+# jdk_util
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/util/concurrent/tck/JSR166TestCase.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/util/regex/NegativeArraySize.java
+
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+############################################################################
+
+# jdk_foreign
+java/foreign/TestArrays.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayouts.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayoutPaths.java	https://github.com/adoptium/aqa-tests/issues/1701	generic-all
+java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+
+############################################################################
+# jvm_compiler
+
+compiler/graalunit/ApiDirectivesTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/ApiTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/AsmAarch64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/AsmAmd64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/CollectionsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/Core01Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/Core02Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/CoreAarch64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/CoreAmd64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/CoreJdk9Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/DebugTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/EATest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/GraphTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotAarch64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotAmd64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotJdk15Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotJdk9Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotLirTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttBackendTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttBytecodeTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttExceptTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttHotpathTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttHotspotTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttJdkTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLangALTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLangMathALTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLangMathMZTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLangNZTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLoopTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttOptimizeTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttReflectAETest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttReflectFieldGetTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttReflectFieldSetTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttReflectGZTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttThreadsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/LirJttTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/LirTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/LoopTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/NodesTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/OptionsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/PhasesCommonTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/Replacements12Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/Replacements9Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/ReplacementsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/UtilTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/unsafe/UnsafeCopyMemory.java
+
+
+
+############################################################################
+
+# jdk_jfr
+jdk/jfr/event/oldobject/TestAllocationTime.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestHeapDeep.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestG1.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/api/consumer/TestRecordedFrame.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java	https://github.com/adoptium/aqa-tests/issues/2870 windows-x86,linux-arm
+jdk/jfr/event/gc/collection/TestG1ParallelPhases.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestListenerLeak.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestObjectAge.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestReferenceChainLimit.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestThreadLocalLeak.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jmx/streaming/TestClose.java	https://github.com/adoptium/aqa-tests/issues/2865 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestDelegated.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestEnableDisable.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRemoteDump.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRotate.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/3034 
+jdk/jfr/jmx/streaming/TestMetadataEvent.java 
+jdk/jfr/jmx/streaming/TestSetSettings.java
+jdk/jfr/jmx/streaming/TestStart.java
+jdk/jfr/jcmd/TestJcmdDump.java
+jdk/jfr/jmx/TestGetRecordings.java
+    
+###########################################################################
+
+#jdk_vector
+jdk/incubator/vector/Byte512VectorLoadStoreTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ByteMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Int64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/IntMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Short64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ShortMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+
+############################################################################
+
+#runtime_nestmate
+runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
+
+######
+net.adoptium.test.FeatureTests
+javax/imageio/plugins/shared/ImageWriterCompressionTest.java 
+javax/management/remote/mandatory/connection/RMIConnectionIdTest.java
+javax/management/remote/mandatory/notif/RMINotifTest.java
+javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java
+javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java
+javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java
+javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java
+javax/management/remote/mandatory/util/MapNullValuesTest.java
+
+
+############################################################################
+#sun_net
+sun/net/www/http/HttpClient/B8025710.java
+sun/net/www/http/KeepAliveCache/B5045306.java
+sun/net/www/protocol/http/B6299712.java
+sun/net/www/protocol/http/HttpOnly.java
+sun/net/www/protocol/http/NoCache.java
+sun/net/www/protocol/http/ZoneId.java
+sun/net/www/protocol/https/HttpsURLConnection/B6226610.java
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java
+sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java
+sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java
+
+#####################################
+#java_io
+java/io/File/GetXSpace.java.GetXSpace

--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -371,12 +371,12 @@ compiler/graalunit/ReplacementsTest.java https://github.com/adoptium/aqa-tests/i
 compiler/graalunit/UtilTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux_s390x
 
-compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
-compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
-compiler/c2/irTests/TestPostParseCallDevirtualization.java  https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
-compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java   https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
-compiler/tiered/TieredLevelsTest.java   https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
-compiler/vectorapi/TestNoInline.java    https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
+compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-32
+compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-32
+compiler/c2/irTests/TestPostParseCallDevirtualization.java  https://github.com/adoptium/aqa-tests/issues/3004 windows-32
+compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-32
+compiler/tiered/TieredLevelsTest.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-32
+compiler/vectorapi/TestNoInline.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-32
 
 
 

--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -41,9 +41,9 @@ java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tes
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/Test4631471.java
-java/beans/XMLEncoder/Test4903007.java
-java/beans/PropertyChangeSupport/Test4682386.java
+java/beans/XMLEncoder/Test4631471.java  https://github.com/adoptium/aqa-tests/issues/2810 linux-arm
+java/beans/XMLEncoder/Test4903007.java  https://github.com/adoptium/aqa-tests/issues/2810   aix-ppc64
+java/beans/PropertyChangeSupport/Test4682386.java   https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 
 ############################################################################
 
@@ -60,7 +60,7 @@ jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 #java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
@@ -83,11 +83,10 @@ java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://gi
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
-java/lang/reflect/Proxy/ProxyTest.java
-java/lang/ProcessBuilder/Basic.java 
-java/lang/System/FileEncodingTest.java
-java/lang/ProcessBuilder/Basic.java
-java/lang/instrument/IsModifiableClassAgent.java
+
+java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
+java/lang/System/FileEncodingTest.java  https://github.com/adoptium/aqa-tests/issues/1267   aix-ppc64
+ 
 
 
 ############################################################################
@@ -140,40 +139,38 @@ java/net/httpclient/ResponsePublisher.java	https://github.com/adoptium/temurin-b
 java/net/MulticastSocket/Promiscuous.java               https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/net/MulticastSocket/Test.java                             https://github.com/adoptium/infrastructure/issues/699    linux-s390x
-java/net/CookieHandler/CookieManagerTest.java
-java/net/DatagramPacket/ReuseBuf.java
-java/net/DatagramSocket/GetLocalAddress.java
-java/net/DatagramSocket/PortUnreachable.java
-java/net/DatagramSocket/ReuseAddressTest.java
-java/net/DatagramSocket/Send12k.java
-java/net/DatagramSocket/SendReceiveMaxSize.java
-java/net/DatagramSocket/SendSize.java.SendSize
-java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java
-java/net/MulticastSocket/B6427403.java
-java/net/MulticastSocket/IPMulticastIF.java
-java/net/ServerSocket/TestLocalAddress.java
-java/net/Socket/CloseAvailable.java
-java/net/Socket/GetLocalAddress.java
-java/net/Socket/InheritTimeout.java
-java/net/Socket/ProxyCons.java
-java/net/Socket/ReadTimeout.java
-java/net/Socket/SetSoLinger.java
-java/net/Socket/SoTimeout.java
-java/net/Socket/asyncClose/AsyncClose.java
-java/net/Socket/asyncClose/BrokenPipe.java
-java/net/Socket/setReuseAddress/Basic.java
-java/net/Socket/setReuseAddress/Restart.java
-java/net/SocketInputStream/SocketTimeout.java
-java/net/Socks/BadProxySelector.java
-java/net/Socks/SocksProxyVersion.java
-java/net/Socket/asyncClose/Race.java
-java/net/httpclient/ManyRequests.java
-java/net/MulticastSocket/NoLoopbackPackets.java
-jdk/net/ExtendedSocketOption/AsynchronousSocketChannelNAPITest.java
-jdk/net/ExtendedSocketOption/DatagramChannelNAPITest.java
-jdk/net/ExtendedSocketOption/DatagramSocketNAPITest.java
-jdk/net/ExtendedSocketOption/SocketChannelNAPITest.java
-jdk/net/ExtendedSocketOption/SocketNAPITest.java
+###
+java/net/MulticastSocket/B6427403.java  https://github.com/adoptium/infrastructure/issues/699   aix-ppc64
+java/net/MulticastSocket/IPMulticastIF.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux_ppc64le
+java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux_ppc64le
+java/net/CookieHandler/CookieManagerTest.java   https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux_ppc64le
+java/net/DatagramPacket/ReuseBuf.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/DatagramSocket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64, linux_ppc64le
+java/net/DatagramSocket/PortUnreachable.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/DatagramSocket/ReuseAddressTest.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/DatagramSocket/Send12k.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64,linux_ppc64le 
+java/net/DatagramSocket/SendSize.java.SendSize  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/ProxyCons.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/ReadTimeout.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/SetSoLinger.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/SoTimeout.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/asyncClose/AsyncClose.java  https://github.com/adoptium/aqa-tests/issues/827 aix-ppc64, linux_ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/setReuseAddress/Basic.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/setReuseAddress/Restart.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/SocketInputStream/SocketTimeout.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socks/BadProxySelector.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socks/SocksProxyVersion.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/Socket/asyncClose/Race.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/httpclient/ManyRequests.java   https://github.com/adoptium/aqa-tests/issues/2828 aix-ppc64
+java/net/ipv6tests/UdpTest.java.UdpTest https://github.com/adoptium/aqa-tests/issues/2828 linux_s390x
+
 
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
@@ -182,14 +179,14 @@ java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
 java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 linux-s390x
-java/nio/channels/Channels/ReadXBytes.java
-java/nio/channels/FileChannel/LargeGatheringWrite.java
-java/net/DatagramSocket/SendReceiveMaxSize.java
-java/nio/channels/DatagramChannel/AfterDisconnect.java
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java
-java/nio/channels/FileChannel/Transfer2GPlus.java
-java/nio/file/Files/probeContentType/Basic.java
-java/nio/Buffer/DirectBufferAllocTest.java
+******
+java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux_s390x,win_64
+java/nio/channels/FileChannel/LargeGatheringWrite.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64,win_64
+java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
+java/nio/channels/DatagramChannel/AfterDisconnect.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
+java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789   aix-ppc64,win_64
+java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 
 ############################################################################
 
@@ -202,8 +199,8 @@ java/io/File/GetXSpace.java	https://bugs.openjdk.java.net/browse/JDK-8251466 win
 com/sun/jdi/JdwpNetProps.java	https://bugs.openjdk.java.net/browse/JDK-8231915 linux-s390x
 com/sun/jdi/JdwpAttachTest.java	https://bugs.openjdk.java.net/browse/JDK-8253940 linux-s390x
 com/sun/jdi/BreakpointTest.java https://bugs.openjdk.java.net/browse/JDK-8050470 linux-s390x
-com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://github.com/adoptium/aqa-tests/issues/3034
-com/sun/jndi/dns/ConfigTests/Timeout.java
+com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://github.com/adoptium/aqa-tests/issues/2294 linux-arm, linux-aarch64
+   
 
 ############################################################################
 
@@ -223,8 +220,8 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
-java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034
-java/nio/file/spi/SetDefaultProvider.java
+java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux_ppc64le,linux_s390x
+ 
 
 ############################################################################ 
 
@@ -255,16 +252,16 @@ security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.jav
 ############################################################################
 
 # jdk_tools
-sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
-sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
-sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
-sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
-sun/tools/jstatd/TestJstatdDefaults.java.
-sun/tools/jstatd/TestJstatdExternalRegistry.java
-sun/tools/jstatd/TestJstatdPort.java
-sun/tools/jstatd/TestJstatdPortAndServer.java
-sun/tools/jstatd/TestJstatdRmiPort.java
-sun/tools/jstatd/TestJstatdServer.java
+sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
+sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
+sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
+sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
+sun/tools/jstatd/TestJstatdDefaults.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/tools/jstatd/TestJstatdExternalRegistry.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/tools/jstatd/TestJstatdPort.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/tools/jstatd/TestJstatdPortAndServer.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/tools/jstatd/TestJstatdServer.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
 
 tools/launcher/HelpFlagsTest.java	https://bugs.openjdk.java.net/browse/JDK-8273235 windows-x86
 tools/jpackage/share/AddLauncherTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
@@ -294,10 +291,9 @@ tools/jpackage/windows/WinUpgradeUUIDTest.java#id1	https://github.com/adoptium/i
 tools/jpackage/windows/WinUrlTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jlink/JLinkTest.java	https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
 tools/jlink/JLinkReproducible3Test.java	https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
-tools/jlink/CheckExecutable.java
-tools/jlink/JLinkTest.java
-tools/jpackage/windows/WinInstallerIconTest.java
-tools/jpackage/share/AddLShortcutTest.java
+tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-pcc64
+tools/jpackage/windows/WinInstallerIconTest.java    https://github.com/adoptium/infrastructure/issues/2310 windows-x86
+tools/jpackage/share/AddLShortcutTest.java  https://github.com/adoptium/infrastructure/issues/2310 windows-x86
     
 ############################################################################
 
@@ -375,7 +371,15 @@ compiler/graalunit/Replacements12Test.java https://github.com/adoptium/aqa-tests
 compiler/graalunit/Replacements9Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/ReplacementsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/UtilTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
-compiler/unsafe/UnsafeCopyMemory.java
+compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux_s390x
+
+compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
+compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
+compiler/c2/irTests/TestPostParseCallDevirtualization.java  https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
+compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java   https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
+compiler/tiered/TieredLevelsTest.java   https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
+compiler/vectorapi/TestNoInline.java    https://github.com/adoptium/aqa-tests/issues/3004 windows_x86-32
+
 
 
 
@@ -399,12 +403,12 @@ jdk/jfr/jmx/streaming/TestEnableDisable.java	https://github.com/adoptium/aqa-tes
 jdk/jfr/jmx/streaming/TestRemoteDump.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jmx/streaming/TestRotate.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/3034 
-jdk/jfr/jmx/streaming/TestMetadataEvent.java 
-jdk/jfr/jmx/streaming/TestSetSettings.java
-jdk/jfr/jmx/streaming/TestStart.java
-jdk/jfr/jcmd/TestJcmdDump.java
-jdk/jfr/jmx/TestGetRecordings.java
+
+jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/2919 aarch64-linux,linux_ppc64le,linux_s390x
+jdk/jfr/jmx/streaming/TestMetadataEvent.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
+jdk/jfr/jmx/streaming/TestSetSettings.java  https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
+jdk/jfr/jmx/streaming/TestStart.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86
+jdk/jfr/jmx/TestGetRecordings.java  https://github.com/adoptium/aqa-tests/issues/2754   ppc64le_linux
     
 ###########################################################################
 
@@ -416,7 +420,8 @@ jdk/incubator/vector/Int64VectorTests.java	https://github.com/adoptium/aqa-tests
 jdk/incubator/vector/IntMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/Short64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/ShortMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+
+jdk/incubator/vector/Byte256VectorLoadStoreTests.java   https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 
 ############################################################################
 
@@ -424,30 +429,30 @@ jdk/incubator/vector/Byte256VectorLoadStoreTests.java
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 
 ######
-net.adoptium.test.FeatureTests
-javax/imageio/plugins/shared/ImageWriterCompressionTest.java 
-javax/management/remote/mandatory/connection/RMIConnectionIdTest.java
-javax/management/remote/mandatory/notif/RMINotifTest.java
-javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java
-javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java
-javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java
-javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java
-javax/management/remote/mandatory/util/MapNullValuesTest.java
+javax/imageio/plugins/shared/ImageWriterCompressionTest.java  https://github.com/adoptium/aqa-tests/issues/3072 linux-arm  
+############################################################################
+#javax_management
+javax/management/remote/mandatory/connection/RMIConnectionIdTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
+javax/management/remote/mandatory/notif/RMINotifTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java  https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
+javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
+javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
+javax/management/remote/mandatory/util/MapNullValuesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
 
 
 ############################################################################
 #sun_net
-sun/net/www/http/HttpClient/B8025710.java
-sun/net/www/http/KeepAliveCache/B5045306.java
-sun/net/www/protocol/http/B6299712.java
-sun/net/www/protocol/http/HttpOnly.java
-sun/net/www/protocol/http/NoCache.java
-sun/net/www/protocol/http/ZoneId.java
-sun/net/www/protocol/https/HttpsURLConnection/B6226610.java
-sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java
-sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java
-sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java
+sun/net/www/http/HttpClient/B8025710.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/http/KeepAliveCache/B5045306.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/protocol/http/NoCache.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/protocol/http/ZoneId.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
 
 #####################################
-#java_io
-java/io/File/GetXSpace.java.GetXSpace
+


### PR DESCRIPTION
I drilled down to individual failed test cases in JUnit test results and prepared the "ProblemList.openjdk18.txt" file. There were some test cases that were already included in ProblemList.openjdk17 file that I didn't add. 
Note: This file is a work in progress.
Addressing issue: #3019 