### PR TITLE
exclude two security tests in jdk11 for upstream know issue #3065

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -78,6 +78,8 @@ sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adopti
 sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-x64,linux-s390x,linux-ppc64le
+sun/security/krb5/auto/ReplayCacheTestProc.java https://bugs.openjdk.java.net/browse/JDK-8258855 linux-all
+sun/security/krb5/auto/rcache_usemd5.sh https://bugs.openjdk.java.net/browse/JDK-8258855 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
sun/security/krb5/auto/ReplayCacheTestProc.java
sun/security/krb5/auto/rcache_usemd5.sh

https://bugs.openjdk.java.net/browse/JDK-8258855
platform: linux
Fixes #3065