### PR TITLE
exclude two security tests in jdk11 for upstream know issue

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -81,6 +81,12 @@ com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk
 
 ############################################################################
 
+# jdk_security4
+sun/security/krb5/auto/ReplayCacheTestProc.java https://bugs.openjdk.java.net/browse/JDK-8258855 linux-all
+sun/security/krb5/auto/rcache_usemd5.sh https://bugs.openjdk.java.net/browse/JDK-8258855 linux-all
+
+###########################################################################
+
 # jdk_jmx
 
 ############################################################################


### PR DESCRIPTION
included this section to exclude the two security tests
############################################################################

jdk_security4
sun/security/krb5/auto/ReplayCacheTestProc.java https://bugs.openjdk.java.net/browse/JDK-8258855 linux-all
sun/security/krb5/auto/rcache_usemd5.sh https://bugs.openjdk.java.net/browse/JDK-8258855 linux-all
Fixes #3065 