### PR TITLE
Backport all latest stf tck wrapper changes to JavaTestRunner 

### DIFF
--- a/jck/jtrunner/config/default/jcktest.properties
+++ b/jck/jtrunner/config/default/jcktest.properties
@@ -7,8 +7,8 @@
 # The tests default to using 'default' as the config name.  If another name is used it must be
 # supplied to the test at run time - see openjdk.test.jck/docs/README.md for more details.
 
-testhost1name=jckservices.adoptium.net
-testhost1ip=40.121.206.1
+testhost1name=ci.adoptopenjdk.net
+testhost1ip=78.47.239.97
 testhost2name=hg.openjdk.java.net
 testhost2ip=137.254.56.63
 httpurl=http://openjdk.java.net/index.html

--- a/jck/jtrunner/makefile
+++ b/jck/jtrunner/makefile
@@ -26,6 +26,7 @@
 # Figure out current platform
 ###
 OS:=$(shell uname -s | tr "[:upper:]" "[:lower:]")
+ARCH:=$(shell uname -m | tr "[:upper:]" "[:lower:]")
 
 ifneq (,$(findstring cygwin,$(OS)))
 	OS:=win
@@ -33,6 +34,11 @@ endif
 
 ifneq (,$(findstring darwin,$(OS)))
 	OS:=osx
+	# Detect a M1 processor. Needed because uname -m doesn't work when the shell runs in x86_64 emulation
+	ARCH:=$(shell sysctl -n machdep.cpu.brand_string)
+	ifeq ($(ARCH),Apple M1)
+		ARCH:=arm64
+	endif
 endif
 
 ifeq ($(OS),os/390)
@@ -44,6 +50,7 @@ ifneq (,$(findstring win,$(OS)))
 endif
 
 $(info OS is $(OS))
+$(info ARCH is $(ARCH))
 
 ifeq ($(OS),win)
 	DESTDIR=$(OUTDIR)\$(OS)
@@ -93,7 +100,7 @@ endif
 # Following defaults set for Unix environment. For Windows platform following variables are overriden
 LIBPREF=lib
 ifneq (,$(findstring aix,$(OS)))
-	LIBEXT=a
+	LIBEXT=so
 else
 ifneq (,$(findstring osx,$(OS)))
 	LIBEXT=dylib
@@ -145,7 +152,17 @@ LDFLAGS=-shared
 
 ifeq ($(OS),osx)
 	CC=gcc
-	CFLAGS=-fPIC -I$(OSX_PATH) -I$(SRC_PATH)
+	ifeq ($(ARCH),arm64)
+		CFLAGS=-arch arm64 -fPIC -I$(OSX_PATH) -I$(SRC_PATH)
+	else
+		CFLAGS=-fPIC -I$(OSX_PATH) -I$(SRC_PATH)
+	endif
+	LDFLAGS=-shared
+endif
+
+ifeq ($(OS),sunos)
+	CC=cc
+	CFLAGS=-fPIC -m64 -I$(SOLARIS_PATH) -I$(SRC_PATH)
 	LDFLAGS=-shared
 endif
 
@@ -193,7 +210,7 @@ ifeq ($(OS),win)
     endif
 
 	IFLAGS=/I. /I"$(JAVA_HOME)/../include" /I"$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D)include$(D)win32" /I"$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D)include$(D)windows" /I"$(SRCDIR)" /I"$(SRCDIR)$(D)src" /I"$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D)include" /I"$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jvmti$(D)include"
-	CFLAGS=/DWIN32 /D_WINDOWS /LD /MD $(IFLAGS)
+	CFLAGS=/DWIN32 /D_AMD64_ /D_WINDOWS /LD /MD $(IFLAGS)
 	LFLAGS=/NOLOGO /DLL /INCREMENTAL:NO /NODEFAULTLIB:LIBCMTD /OUT:
 	LINK_CMD=$(CMD_PREFIX) link
 	CC=cl
@@ -244,7 +261,17 @@ help:
 
 build:createdir $(OBJS) installjmx
 
-$(LIBPREF)jckjni.$(LIBEXT): jckjni.c 
+ifeq ($(OS),win)
+ifneq (,$(findstring 16,$(SRCDIR)))
+EXTRAJCKJNIDEP=$(SRCDIR)\src\share\lib\jni\include\windows\jckjni_md.h-DIST
+
+$(EXTRAJCKJNIDEP):
+	cp "$(SRCDIR)\src\share\lib\jni\include\windows\jckjni_md.h" "$(EXTRAJCKJNIDEP)"
+	perl -p -i -e 'print "#if (defined(WIN32) || defined(_WIN32))\n#include <synchapi.h>\n#endif\n\n" if $$_ =~ /^#endif.*JCKJNI_MD_H/' "$(SRCDIR)\src\share\lib\jni\include\windows\jckjni_md.h"
+
+endif
+endif
+$(LIBPREF)jckjni.$(LIBEXT): jckjni.c $(EXTRAJCKJNIDEP)
 	cd $(FULLOUTDIR) && $(CC) $(CFLAGS) $(LDFLAGS) $< $(OFLAG)$(FULLOUTDIR)$(VAR)
 	$(JCKJNI)
 


### PR DESCRIPTION
1. Backports https://github.com/adoptium/aqa-systemtest/pull/458 to JavaTestRunner.java.
2. Backports https://github.com/adoptium/aqa-systemtest/pull/447 to JavaTestRunner makefile. 
3. Backports https://github.com/adoptium/aqa-systemtest/pull/445 to JavaTestRunner makefile. 
4. Backports https://github.com/adoptium/aqa-systemtest/pull/458 to JavaTestRunner makefile.
5. Backports https://github.com/adoptium/aqa-systemtest/pull/443 to JavaTestRunner makefile.
5.  Backports https://github.com/adoptium/aqa-systemtest/pull/444 to JavaTestRunner.java
6. Backports https://github.com/adoptium/aqa-systemtest/pull/446 to 
7. Backports https://github.com/adoptium/aqa-systemtest/pull/451 to JavaTestRunner jcktest.properties.

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>