### PR TITLE
Remove excludes for lang/EXPR tests

### DIFF
--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -183,21 +183,7 @@
 		</groups>
 	</test>
 	<test>
-	<testCaseName>jck-compiler-lang-EXPR-group1</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
+		<testCaseName>jck-compiler-lang-EXPR-group1</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -212,20 +198,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group2</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -240,20 +212,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group3</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -268,20 +226,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group4</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -296,20 +240,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group5</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -324,20 +254,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group6</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -352,20 +268,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group7</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -380,20 +282,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group8</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -408,20 +296,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group9</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -436,20 +310,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group10</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win and ppc64le due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64le_linux|x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- Remove excludes for backlog/issues/487 as the `compiler/lang/EXPR` tests have now been broken down into smaller sub-groups and are no longer timing out. 
- Note this will re-introduce  `compiler/lang/EXPR` (group 1..10) tests on Windows and ppc64le weekly tck builds. 

FYI @JasonFengJ9 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>