### PR TITLE
Update ProblemList_openjdk8-openj9.txt

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -311,7 +311,6 @@ com/sun/jdi/RedefineCrossEvent.java	https://github.com/adoptium/aqa-tests/issues
 java/util/Arrays/ParallelPrefix.java	https://github.com/adoptium/aqa-tests/issues/830	linux-all
 java/util/Arrays/TimSortStackSize2.java		https://github.com/eclipse-openj9/openj9/issues/7223		generic-all
 java/util/Calendar/CalendarRegression.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-java/util/Calendar/JapanEraNameCompatTest.java https://bugs.openjdk.java.net/browse/JDK-8218781 generic-all
 java/util/Locale/LocaleProviders.sh	https://github.com/adoptium/aqa-tests/issues/1261	windows-all
 java/util/Spliterator/SpliteratorCollisions.java		https://github.com/eclipse-openj9/openj9/issues/1131	generic-all
 java/util/SplittableRandom/SplittableRandomTest.java	https://github.com/adoptium/aqa-tests/issues/830	linux-ppc64le


### PR DESCRIPTION
Closes #3014 

The Identified JBS issues (i.e. https://bugs.openjdk.java.net/browse/JDK-8218781) in line 314 of ProblemList_openjdk8-openj9.txt with status "CLOSED" passed all test, no failed test for all platforms and has been excluded from the problem list.