### PR TITLE
add CURL_OPTS in get.sh

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -432,7 +432,9 @@ def setup() {
 			TEST_IMAGES_REQUIRED = (params.TEST_IMAGES_REQUIRED == false) ? "--test_images_required false" : ""
 			DEBUG_IMAGES_REQUIRED = (params.DEBUG_IMAGES_REQUIRED == false) ? "--debug_images_required false" : ""
 
-			GET_SH_CMD = "./get.sh -s `pwd`/.. -p $PLATFORM -r ${SDK_RESOURCE} ${JDK_VERSION_OPTION} ${JDK_IMPL_OPTION} ${CUSTOMIZED_SDK_URL_OPTION} ${CUSTOMIZED_SDK_SOURCE_URL_OPTION} ${CLONE_OPENJ9_OPTION} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${TKG_REPO_OPTION} ${TKG_BRANCH_OPTION} ${VENDOR_TEST_REPOS} ${VENDOR_TEST_BRANCHES} ${VENDOR_TEST_DIRS} ${VENDOR_TEST_SHAS} ${TEST_IMAGES_REQUIRED} ${DEBUG_IMAGES_REQUIRED}"
+			CURL_OPTS = (params.CURL_OPTS) ? "--curl_opts \"${params.CURL_OPTS}\"" : ""
+
+			GET_SH_CMD = "./get.sh -s `pwd`/.. -p $PLATFORM -r ${SDK_RESOURCE} ${JDK_VERSION_OPTION} ${JDK_IMPL_OPTION} ${CUSTOMIZED_SDK_URL_OPTION} ${CUSTOMIZED_SDK_SOURCE_URL_OPTION} ${CLONE_OPENJ9_OPTION} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${TKG_REPO_OPTION} ${TKG_BRANCH_OPTION} ${VENDOR_TEST_REPOS} ${VENDOR_TEST_BRANCHES} ${VENDOR_TEST_DIRS} ${VENDOR_TEST_SHAS} ${TEST_IMAGES_REQUIRED} ${DEBUG_IMAGES_REQUIRED} ${CURL_OPTS}"
 
 
 			RESOLVED_MAKE = "if [ `uname` = AIX ] || [ `uname` = SunOS ] || [ `uname` = *BSD ]; then MAKE=gmake; else MAKE=make; fi"
@@ -470,16 +472,14 @@ def get_sources_with_authentication() {
 }
 
 def get_sources() {
-	withEnv(['VERBOSE_CURL=SILENT']) {
-		dir('aqa-tests') {
-			if (params.CUSTOMIZED_SDK_URL_CREDENTIAL_ID) {
-				// USERNAME and PASSWORD reference with a withCredentials block will not be visible within job output
-				withCredentials([usernamePassword(credentialsId: "${params.CUSTOMIZED_SDK_URL_CREDENTIAL_ID}", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-					sh "$GET_SH_CMD"
-				}
-			} else {
+	dir('aqa-tests') {
+		if (params.CUSTOMIZED_SDK_URL_CREDENTIAL_ID) {
+			// USERNAME and PASSWORD reference with a withCredentials block will not be visible within job output
+			withCredentials([usernamePassword(credentialsId: "${params.CUSTOMIZED_SDK_URL_CREDENTIAL_ID}", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
 				sh "$GET_SH_CMD"
 			}
+		} else {
+			sh "$GET_SH_CMD"
 		}
 	}
 }

--- a/get.sh
+++ b/get.sh
@@ -37,6 +37,7 @@ RELEASES="latest"
 TYPE="jdk"
 TEST_IMAGES_REQUIRED=true
 DEBUG_IMAGES_REQUIRED=true
+CURL_OPTS="s"
 
 usage ()
 {
@@ -137,6 +138,9 @@ parseCommandLineArgs()
 
 			"--debug_images_required" )
 				DEBUG_IMAGES_REQUIRED="$1"; shift;;
+
+			"--curl_opts" )
+				CURL_OPTS="$1"; shift;;
 
 			"--help" | "-h" )
 				usage; exit 0;;
@@ -264,20 +268,8 @@ fi
 					fi
 				fi
 
-				case "$VERBOSE_CURL" in
-					VERBOSE)
-						curl_verbosity="v"
-						;;
-					NORMAL)
-						curl_verbosity=''
-						;;
-					*)
-						curl_verbosity="s"
-						;;
-				esac
-
-				echo "_ENCODE_FILE_NEW=UNTAGGED curl -OLJSk${curl_verbosity} ${curl_options} $file"
-				_ENCODE_FILE_NEW=UNTAGGED curl -OLJSk${curl_verbosity} ${curl_options} $file
+				echo "_ENCODE_FILE_NEW=UNTAGGED curl -OLJSk${CURL_OPTS} ${curl_options} $file"
+				_ENCODE_FILE_NEW=UNTAGGED curl -OLJSk${CURL_OPTS} ${curl_options} $file
 				download_exit_code=$?
 				count=$(( $count + 1 ))
 			done


### PR DESCRIPTION
Allow user to set CURL_OPTS for debugging purposes.
This param is optional. It sets options for running the curl command. The default value is s.
s - for silent
v - for verbose

Signed-off-by: lanxia <lan_xia@ca.ibm.com>