### PR TITLE
Enable minimix 3h test in special.system

### DIFF
--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -48,6 +48,25 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>MiniMix_3h</testCaseName>
+		<variations>
+			<variation>Mode551</variation>
+			<variation>Mode110-CS</variation>
+		</variations>
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -test-args=$(Q)timeLimit=3h$(Q) -java-args-execute-initial=$(ADD_OPENS_CMD);\
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>ClassLoadingTest_5m</testCaseName>
 		<variations>
 			<variation>Mode150</variation>


### PR DESCRIPTION
This PR is related to : backlog/issues/597 
- Enables MiniMix 3hrs target in special.system 
- Mode551, for testing with : `-Xgcpolicy:balanced, -XX:+UseCompressedOops , -Xjit` 
- Mode150-CS, for testing with : `-Xgcpolicy:gencon, -Xgc:concurrentScavenge, -Xjit, -XX:+UseCompressedOops` 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>