### PR TITLE
Temporarily disable OAuthTest due to eclipse-openj9/openj9/issues/13892

### DIFF
--- a/system/security/playlist.xml
+++ b/system/security/playlist.xml
@@ -9,9 +9,9 @@
 		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
 	$(TEST_STATUS)</command>
 		<levels>
-                        <level>sanity</level>
-                        <level>extended</level>
-                        <level>special</level>
+			<level>sanity</level>
+			<level>extended</level>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>system</group>
@@ -27,6 +27,16 @@
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
 		<testCaseName>OAuthTest</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/13892</comment>
+				<impl>ibm</impl>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/13892</comment>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=OAuthTest; $(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
- Temporarily disable OAuthTest on IBM and OpenJ9 due to eclipse-openj9/openj9/issues/13892

FYI @pshipton 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>