### PR TITLE
Fix tck Windows native build logic  

### DIFF
--- a/jck/build.xml
+++ b/jck/build.xml
@@ -49,29 +49,26 @@
 	<!-- Look for either version 10.0 or 14.0 in the default installation location.  -->
 	<!-- To use a different location property rtb.vcvarsall_filename needs to be set on the command line for the build.  -->
 	<!-- The vcvarsall.bat file argument amd64 is added if the javac being used to compile the java classes is a 64 bit java. -->
-
-	<target name="setup-windows-compiler" unless="setup_windows_compiler_run">
-		<property name="setup_windows-compiler_run" value="true"/>
-		<property name="vs14_vcvarsall_filename" location="c:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat"/>
-		<available file="${vs14_vcvarsall_filename}" property="vs14_available"/>
-		<property name="vs10_vcvarsall_filename" location="c:\\Program Files (x86)\\Microsoft Visual Studio 10.0\\VC\\vcvarsall.bat"/>
-		<available file="${vs10_vcvarsall_filename}" property="vs10_available"/>
-		<condition property="vcvarsall_filename" value="${vs14_vcvarsall_filename}">
-			<isset property="vs14_available"/>
-		</condition>
-		<condition property="vcvarsall_filename" value="${vs10_vcvarsall_filename}">
-			<isset property="vs10_available"/>
-		</condition>
-		<condition property="windows_native_compiler_present" value="true">
-			<isset property="vcvarsall_filename"/>
-			</condition>
-		<condition property="vcvarsall_bits_arg" value="amd64" else="">
-			<equals arg1="${java_bits}" arg2="64" trim="true"/>
-		</condition>
-		<condition property="setup_windows_build_env" value='call "${vcvarsall_filename}" ${vcvarsall_bits_arg} &amp;&amp;' else="">
-			<equals arg1="${is_windows}" arg2="true"/>
-		</condition>
-	</target>
+	<property name="vs14_vcvarsall_filename" location="c:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat"/>
+	<available file="${vs14_vcvarsall_filename}" property="vs14_available"/>
+	<property name="vs10_vcvarsall_filename" location="c:\\Program Files (x86)\\Microsoft Visual Studio 10.0\\VC\\vcvarsall.bat"/>
+	<available file="${vs10_vcvarsall_filename}" property="vs10_available"/>
+	<condition property="vcvarsall_filename" value="${vs14_vcvarsall_filename}">
+		<isset property="vs14_available"/>
+	</condition>
+	<condition property="vcvarsall_filename" value="${vs10_vcvarsall_filename}">
+		<isset property="vs10_available"/>
+	</condition>
+	<condition property="windows_native_compiler_present" value="true">
+		<isset property="vcvarsall_filename"/>
+	</condition>
+	
+	<condition property="vcvarsall_bits_arg" value="amd64" else="">
+		<equals arg1="${sun.arch.data.model}" arg2="64" trim="true"/>
+	</condition>
+	<condition property="setup_windows_build_env" value='call "${vcvarsall_filename}" ${vcvarsall_bits_arg} &amp;&amp;' else="">
+		<equals arg1="${is_windows}" arg2="true"/>
+	</condition>
 	
 	<condition property="can_build_jck_natives_windows" value="true">
 		<and>
@@ -207,7 +204,7 @@
 		</if> 
 	</target>
 	
-	<target name="build-jck-natives" depends="setup-windows-compiler, setup-native-build-command, build-natives-windows, build-natives-unix"> 
+	<target name="build-jck-natives" depends="setup-native-build-command, build-natives-windows, build-natives-unix"> 
 	</target>
 		
 	<target name="setup-native-build-command">

--- a/jck/jtrunner/makefile
+++ b/jck/jtrunner/makefile
@@ -212,6 +212,7 @@ ifeq ($(OS),win)
 	IFLAGS=/I. /I"$(JAVA_HOME)/../include" /I"$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D)include$(D)win32" /I"$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D)include$(D)windows" /I"$(SRCDIR)" /I"$(SRCDIR)$(D)src" /I"$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D)include" /I"$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jvmti$(D)include"
 	CFLAGS=/DWIN32 /D_AMD64_ /D_WINDOWS /LD /MD $(IFLAGS)
 	LFLAGS=/NOLOGO /DLL /INCREMENTAL:NO /NODEFAULTLIB:LIBCMTD /OUT:
+	LDFLAGS=
 	LINK_CMD=$(CMD_PREFIX) link
 	CC=cl
 	LIBPREF=
@@ -261,8 +262,9 @@ help:
 
 build:createdir $(OBJS) installjmx
 
+# We need the extra include for 16+
 ifeq ($(OS),win)
-ifneq (,$(findstring 16,$(SRCDIR)))
+ifeq ($(shell test $(JDK_VERSION) -gt 15; echo $$?),0)
 EXTRAJCKJNIDEP=$(SRCDIR)\src\share\lib\jni\include\windows\jckjni_md.h-DIST
 
 $(EXTRAJCKJNIDEP):


### PR DESCRIPTION
- Fixes the `UnsatisfiedLinkError` in native tck on Windows (details in backlog/issues/637) by using  `${sun.arch.data.model}` to extract bitmode - which causes correct flag (`amd64`) to be passed to visual studio.  
- Cleans up `openjdk-tests/jck/build.xml` : Removed `setup-windows-compiler` target and moved the conditional properties therein outside. This ensures the right flags get evaluate correctly (e.g. `can_build_jck_natives_windows`) - lack of which was causing native compilation step to not execute. 
- Cleans up jck/makefile : (a) Added [Windows tck natives fudge](https://github.com/adoptium/aqa-systemtest/pull/447/files) to 16+ (previously only added for 16, but it's needed for 16+). (b) Cleared `LDFLAGS` to avoid compile warning on Windows for unsupported option `-shared`.   

FYI @JasonFengJ9 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>