### PR TITLE
update headless check

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -92,7 +92,9 @@ JTREG_BASIC_OPTIONS += $(JTREG_XML_OPTION)
 JTREG_BASIC_OPTIONS += $(EXTRA_JTREG_OPTIONS)
 JTREG_KEY_OPTIONS :=
 VMOPTION_HEADLESS :=
-ifneq ($(PLATFORM),x86-64_alpine-linux) 
+libcVendor = $(shell ldd --version 2>&1 | sed -n '1s/.*\(musl\).*/\1/p')
+
+ifeq ($(libcVendor),musl)
 	JTREG_KEY_OPTIONS := -k:'!headful'
 	VMOPTION_HEADLESS := -Djava.awt.headless=true
 endif


### PR DESCRIPTION
PLATFORM has been overriden by SPEC after compiling stage. Using libc check instead.

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>