### PR TITLE
Fix ProcessBuilder command line arguments in JavaTestRunner for agent subprocess 

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -830,12 +830,14 @@ public class JavaTestRunner {
 				javatestAgentCmd.add(pathToJava);
 				javatestAgentCmd.add("-Djavatest.security.allowPropertiesAccess=true");
 				javatestAgentCmd.add("-Djava.security.policy=" + jckPolicyFileFullPath);
-				javatestAgentCmd.add(addModules);
-				javatestAgentCmd.add("-classpath");
+				if (!addModules.equals("")) {
+					javatestAgentCmd.add(addModules);
+				}
+				javatestAgentCmd.add("-classpath"); 
 				javatestAgentCmd.add(classPath);
 				javatestAgentCmd.add("com.sun.javatest.agent.AgentMain");
-				javatestAgentCmd.add(" -passive");
-				javatestAgent = startSubProcess("javatestAgent",javatestAgentCmd);
+				javatestAgentCmd.add("-passive");
+				javatestAgent = startSubProcess("com.sun.javatest.agent.AgentMain",javatestAgentCmd);
 
 				// We only need RMI registry and RMI activation daemon processes for tests under api/java_rmi
 				if (tests.contains("api/java_rmi") && 


### PR DESCRIPTION
-  Added a check to only append `addModules` to the ProcessBuilder command for AgentMain when `addModules` is not empty. Otherwise the agent process doesn't launch. 

- This fixes the "Error accessing agent: java.net.ConnectException: Connection refused" error while running tcks that need javatest agent. It also resolves the "Error: Could not find or load main class" error that are seen in many tck runs. 

Resolves : backlog/issues/612
Resolves : backlog/issues/644

FYI @JasonFengJ9 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>