### PR TITLE
Temporarily increase copyArtifact timeout

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -155,7 +155,7 @@ def setupParallelEnv() {
 
 				try {
 					//get pre-staged jars from test.getDependency build
-					timeout(time: 1, unit: 'HOURS') {
+					timeout(time: 2, unit: 'HOURS') {
 						copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'aqa-tests/TKG/lib'
 					}
 				} catch (Exception e) {
@@ -522,7 +522,7 @@ def buildTest() {
 
 			try {
 				//get pre-staged jars from test.getDependency build before test compilation
-				timeout(time: 1, unit: 'HOURS') {
+				timeout(time: 2, unit: 'HOURS') {
 					copyArtifacts fingerprintArtifacts: true, projectName: "test.getDependency", selector: lastSuccessful(), target: 'aqa-tests/TKG/lib'
 				}
 			} catch (Exception e) {
@@ -532,7 +532,7 @@ def buildTest() {
 			try {
 				if (env.BUILD_LIST.startsWith('system')) {
 					//get pre-staged test jars from systemtest.getDependency build before system test compilation
-					timeout(time: 1, unit: 'HOURS') {
+					timeout(time: 2, unit: 'HOURS') {
 						copyArtifacts fingerprintArtifacts: true, projectName: "systemtest.getDependency", selector: lastSuccessful(), target: 'aqa-tests'
 					}
 				}


### PR DESCRIPTION
OpenJ9 farm is having network issues with one of it's
sites. Temp increase as a workaround until issue
can be resolved.

Issue eclipse-openj9/openj9#13966

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>