### PR TITLE
Exclude java/nio/channels/FileChannel/Transfer2GPlus.java from jdk17 linux arm32

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -165,7 +165,7 @@ java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java
 jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
-java/nio/channels/FileChannel/Transfer2GPlus.java   https://bugs.openjdk.java.net/browse/JDK-8272095    linux-aarch64
+java/nio/channels/FileChannel/Transfer2GPlus.java   https://bugs.openjdk.java.net/browse/JDK-8272095    linux-arm
 ############################################################################ 
 
 # jdk_rmi

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -165,6 +165,7 @@ java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java
 jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
+java/nio/channels/FileChannel/Transfer2GPlus.java   https://bugs.openjdk.java.net/browse/JDK-8272095    linux-aarch64
 ############################################################################ 
 
 # jdk_rmi


### PR DESCRIPTION
Known upstream issue https://bugs.openjdk.java.net/browse/JDK-8272095

ref https://github.com/adoptium/infrastructure/issues/2374

The same upstream exclusion is required for arm32 as it fails on all of our arm32 linux boxes