### PR TITLE
Exclude FFI related tests in JDK18

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -1,0 +1,46 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+############################################################################
+
+# To determine required OS exclusion string see http://hg.openjdk.java.net/code-tools/jtreg/file/6f00c63c0a98/src/share/classes/com/sun/javatest/regtest/config/OS.java
+
+############################################################################
+
+# jdk_foreign
+
+java/foreign/SafeFunctionAccessTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestDowncall.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestIntrinsics.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestNULLAddress.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestNative.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/malloc/TestMixedMallocFree.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+
+java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+java/foreign/TestUpcall.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+java/foreign/TestUpcallException.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+java/foreign/TestUpcallHighArity.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+java/foreign/TestUpcallStructScope.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+
+java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+
+java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002  generic-all
+
+############################################################################


### PR DESCRIPTION
The change is to exclude these test specific to JEP389
(Foreign Linker API) in JDK18 as the feature has not yet
fully implemented.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>