### PR TITLE
Disable api-javax_print on tck 18

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -603,7 +603,6 @@
 			<version>8</version>
 			<impl>openj9</impl>
 			</disable>
-
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -993,12 +992,12 @@
 			</disable>
 			<disable>
 				<comment>Disabled on all platforms on 17 for backlog/issues/633 (intermittent machine issue). To be run manually</comment>
-				<version>17</version>
+				<version>17+</version>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on all platforms on 17 for backlog/issues/633 (intermittent machine issue). To be run manually</comment>
-				<version>17</version>
+				<version>17+</version>
 				<impl>ibm</impl>
 			</disable>
 		</disables>


### PR DESCRIPTION
- Like we did for 17, disable api-javax_print on tck 18 due to backlog/issues/633 (intermittent machine issue). Added to list of 18 tcks to be run manually (/backlog/issues/653). 
- Cleans up unnecessary blank line.

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>

FYI @JasonFengJ9 