### PR TITLE
Replaced -java-args with -java-args-execute-initial

### DIFF
--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -238,7 +238,7 @@
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -debug-generation=$(Q)true$(Q) -java-debug-args=$(Q)--enable-preview --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) -java-args=$(Q)--enable-preview --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) -test=HCRLateAttachWorkload; \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -debug-generation=$(Q)true$(Q) -java-debug-args=$(Q)--enable-preview --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) -java-args-execute-initial=$(Q)--enable-preview --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) -test=HCRLateAttachWorkload; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -277,7 +277,7 @@
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args=$(Q)$(JVM_OPTIONS) -Xdisableexcessivegc$(Q) -test=HeapHogLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args-execute-initial=$(Q)-Xdisableexcessivegc$(Q) -test=HeapHogLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -296,7 +296,7 @@
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args=$(Q)$(JVM_OPTIONS) -Xnoclassgc$(Q) -test=ObjectTreeLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args-execute-initial=$(Q)-Xnoclassgc$(Q) -test=ObjectTreeLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
- Replaces `-java-args` with ` -java-args-execute-initial` (an alternative STF command line option to supply jvm options) in STF based system test playlist command lines. This ensures that the extra jvm options passed in from playlist get appended to what are passed in via `-java-args` from SYSTEMTEST_CMD_TEMPLATE (e.g. JVM_OPTIONS).  
- Removes  `$(JVM_OPTIONS)` from playlist command lines as that is passed in via [SYSTEMTEST_CMD_TEMPLATE](https://github.com/adoptium/aqa-tests/blob/master/system/systemtest.mk#L53).
- Resolves https://github.com/adoptium/aqa-tests/issues/3114

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>