### PR TITLE
Exclude OpenJDK18 tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -41,6 +41,34 @@ java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 
-java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002  generic-all
+java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
+
+java/lang/reflect/Proxy/nonPublicProxy/DefaultMethodProxy.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/reflect/Proxy/ProxyTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/reflect/Proxy/DefaultMethods.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/invoke/lookup/SpecialStatic.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/invoke/lambda/invokeSpecial/InvokeSpecialMethodTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/invoke/MethodHandlesProxiesTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/invoke/JavaDocExamplesTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/invoke/InvokeDynamicPrintArgs.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/invoke/8177146/TestMethodHandleBind.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/constant/MethodHandleDescTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/invoke/7087570/Test7087570.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/invoke/7196190/GetUnsafeTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+java/lang/invoke/lambda/MetafactoryArgValidationTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
+
+java/lang/invoke/7157574/Test7157574.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
+java/lang/invoke/lambda/InheritedMethodTest.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
+java/lang/reflect/DefaultStaticTest/DefaultStaticInvokeTest.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
+
+java/lang/annotation/typeAnnotations/TestExecutableGetAnnotatedType.java https://github.com/eclipse-openj9/openj9/issues/13997 generic-all
+java/lang/annotation/typeAnnotations/GetAnnotatedOwnerType.java https://github.com/eclipse-openj9/openj9/issues/13997 generic-all
+java/lang/annotation/typeAnnotations/TestObjectMethods.java https://github.com/eclipse-openj9/openj9/issues/13997 generic-all
+java/lang/reflect/Parameter/InnerClassToString.java https://github.com/eclipse-openj9/openj9/issues/13997 generic-all
+
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
 
 ############################################################################


### PR DESCRIPTION
Tests failures documented in the below issues have been excluded:
1) https://github.com/eclipse-openj9/openj9/issues/13995
2) https://github.com/eclipse-openj9/openj9/issues/13996
3) https://github.com/eclipse-openj9/openj9/issues/13997
4) https://github.com/eclipse-openj9/openj9/issues/13998

Parent issue: https://github.com/eclipse-openj9/openj9/issues/13946

The tests will be re-enabled once they are fixed.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>