### PR TITLE
Update to test target names

### DIFF
--- a/external/derby/README.md
+++ b/external/derby/README.md
@@ -14,7 +14,7 @@ To run any AQA tests locally, you follow the same pattern:
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/derby` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make derby-test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make derby_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
 When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 

--- a/external/derby/playlist.xml
+++ b/external/derby/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>derby_test_junit_all</testCaseName>
+		<testCaseName>derby_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir derby --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir derby

--- a/external/elasticsearch/playlist.xml
+++ b/external/elasticsearch/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>elasticsearch_test_openj9_jdk8</testCaseName>
+		<testCaseName>elasticsearch_test</testCaseName>
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/1720</comment>

--- a/external/example-test/playlist.xml
+++ b/external/example-test/playlist.xml
@@ -17,7 +17,7 @@
 		TestKitGen can produce the equivalent make command lines to be executed in the build 
 	-->
 	<test>
-		<testCaseName>example-test</testCaseName>
+		<testCaseName>example_test</testCaseName>
 		<command>docker run --rm $(EXTRA_DOCKER_ARGS) adoptopenjdk-example-test:latest ; \
 			$(TEST_STATUS); \
 			docker rmi -f adoptopenjdk-example-test

--- a/external/lucene-solr/playlist.xml
+++ b/external/lucene-solr/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>lucene_solr_nightly_smoketest</testCaseName>
+		<testCaseName>lucene-solr_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir lucene-solr --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir lucene-solr

--- a/external/openliberty-mp-tck/README.md
+++ b/external/openliberty-mp-tck/README.md
@@ -14,7 +14,7 @@ To run any AQA tests locally, you follow the same pattern:
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/openliberty-mp-tck` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make openliberty_microprofile_tck*` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make openliberty-mp-tck_test*` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
 When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 

--- a/external/openliberty-mp-tck/README.md
+++ b/external/openliberty-mp-tck/README.md
@@ -14,7 +14,7 @@ To run any AQA tests locally, you follow the same pattern:
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/openliberty-mp-tck` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make openliberty-mp-tck_test*` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make openliberty-mp-tck_test` (When you defined BUILD_LIST to point to a directory in openjdk-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
 When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the openjdk-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 

--- a/external/openliberty-mp-tck/playlist.xml
+++ b/external/openliberty-mp-tck/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>openliberty_microprofile_tck_jdk8_j9</testCaseName>
+		<testCaseName>openliberty-mp-tck_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir openliberty-mp-tck --reportsrc /testResults/surefire-reports --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir openliberty-mp-tck

--- a/external/payara-mp-tck/playlist.xml
+++ b/external/payara-mp-tck/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>payara_microprofile_tck</testCaseName>
+		<testCaseName>payara-mp-tck_test</testCaseName>
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/1160</comment>

--- a/external/quarkus/playlist.xml
+++ b/external/quarkus/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>quarkus_java_test</testCaseName>
+		<testCaseName>quarkus_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir quarkus --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir quarkus

--- a/external/quarkus_quickstarts/README.md
+++ b/external/quarkus_quickstarts/README.md
@@ -15,7 +15,7 @@ To run any AQA tests locally, you follow the same pattern:
 6. `cd TKG`
 7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/quarkus_quickstart` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
 8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
-9. `make quarkus_quickstart_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+9. `make quarkus_quickstarts_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
 
 When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
 

--- a/external/spring/playlist.xml
+++ b/external/spring/playlist.xml
@@ -27,7 +27,7 @@
                 </groups>
         </test>
 	<test>
-		<testCaseName>spring-test</testCaseName>
+		<testCaseName>spring_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir spring --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 			$(TEST_STATUS); \
 			$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir spring

--- a/external/thorntail-mp-tck/playlist.xml
+++ b/external/thorntail-mp-tck/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>thorntail_microprofile_tck</testCaseName>
+		<testCaseName>thorntail-mp-tck_test</testCaseName>
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/1855#issuecomment-707773303</comment>

--- a/external/tomee/playlist.xml
+++ b/external/tomee/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>tomee_test_j9</testCaseName>
+		<testCaseName>tomee_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir tomee --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir tomee

--- a/external/wycheproof/playlist.xml
+++ b/external/wycheproof/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>WycheproofTests</testCaseName>
+		<testCaseName>Wycheproof_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir wycheproof --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir wycheproof

--- a/external/wycheproof/playlist.xml
+++ b/external/wycheproof/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>Wycheproof_test</testCaseName>
+		<testCaseName>wycheproof_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir wycheproof --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir wycheproof


### PR DESCRIPTION
update to external tests' TestNameCase in the playlist.xml
From analysis ,the few  passing tests seem to have this naming convention
and some have not been
when run with the current upstream master ,
https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2694/console this grinder came up with error cannot find the following tests [wycheproof_test] in TESTLIST in the playlist.xml .

this PR corrects the errors in documentation and the playlist.xml for some external tests.
grinder after troubleshooting the issue finds the wycheproof in the TESTLIST under the common_functions.sh and playlist.xml
https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2707/console

Fixes #3157 