### PR TITLE
Add temporary tck 11 excludes for z/OS

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -50,6 +50,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-instrument</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/670</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -64,6 +72,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-invoke</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/583</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -78,6 +94,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-reflect</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/666</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -92,6 +116,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-Package</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/666</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -179,6 +211,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-module</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/583</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -230,6 +270,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-SecurityManager</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/666</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -275,6 +323,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-Class</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/666</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -300,6 +356,17 @@
 				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -315,6 +382,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-modulegraph</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/667</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -332,6 +407,20 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_util-regex</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/667</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -362,6 +451,12 @@
 				<platform>x86-64_mac</platform>
   				<impl>hotspot</impl>
 			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -377,6 +472,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_util-ResourceBundle</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -407,6 +510,12 @@
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
  			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -503,6 +612,12 @@
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/680</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -529,6 +644,12 @@
 				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -544,6 +665,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -683,6 +812,12 @@
 				<version>17</version>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/680</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -784,6 +919,12 @@
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -847,6 +988,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_crypto</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/683</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -871,6 +1020,12 @@
 				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/681</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
 			</disable>
 		</disables>
 		<variations>
@@ -901,6 +1056,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_management</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/682</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -931,6 +1094,12 @@
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
   			</disable>
+  			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/680</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1000,6 +1169,12 @@
 				<version>17+</version>
 				<impl>ibm</impl>
 			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1029,6 +1204,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_script</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1072,6 +1255,12 @@
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
+			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
 			</disable>
 		</disables>
 		<variations>
@@ -1141,6 +1330,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_tools</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1242,6 +1439,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-org_w3c</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1256,6 +1461,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-org_xml</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1270,6 +1483,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-xinclude</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1298,6 +1519,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-serializabletypes</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/667</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -16,6 +16,14 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-runtime-vm-constantpool</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/670</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -90,6 +98,12 @@
 				<platform>x86-32_windows</platform>
 				<version>8</version>
 			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/670</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 	</test>
 	<test>
@@ -108,6 +122,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-classfmt</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/668</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -122,6 +144,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-module</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/583</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/runtime.xml_schema/playlist.xml
+++ b/jck/runtime.xml_schema/playlist.xml
@@ -43,6 +43,12 @@
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -142,6 +148,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-xml_schema-sunData</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- Add temporary tck 11 excludes for jdk 11 z/OS
- Related to backlog/issues/583

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>