### PR TITLE
jck: hardcode jck.env.runtime.url.ftpURL value

### DIFF
--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -62,7 +62,7 @@ ifndef JCK_ROOT
 endif
 
 ifndef CONFIG_ALT_PATH
-  export CONFIG_ALT_PATH:=$(TEST_ROOT)$(D)jck$(D)jtrunner/config/default
+  export CONFIG_ALT_PATH:=$(TEST_ROOT)$(D)jck$(D)jtrunner$(D)config$(D)default
 endif
 
 OTHER_OPTS=

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -62,7 +62,7 @@ ifndef JCK_ROOT
 endif
 
 ifndef CONFIG_ALT_PATH
-  export CONFIG_ALT_PATH:=$(TEST_ROOT)$(D)jck$(D)/jtrunner/config/default
+  export CONFIG_ALT_PATH:=$(TEST_ROOT)$(D)jck$(D)jtrunner/config/default
 endif
 
 OTHER_OPTS=

--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -224,13 +224,13 @@ public class JavaTestRunner {
 
 		testSuiteFolder = "JCK-" + testSuite.toString().toLowerCase() + "-" + jckVersionNo;
 		jckBase = jckRoot + File.separator + testSuiteFolder; 
-		jckPolicyFileFullPath = jckRoot + File.separator + testSuiteFolder + File.separator + "lib" + File.separator + "jck.policy";
-		javatestJarFullPath = jckRoot + File.separator + testSuiteFolder + File.separator + "lib" + File.separator + "javatest.jar";
-		jtliteJarFullPath = jckRoot + File.separator + testSuiteFolder + File.separator + "lib" + File.separator + "jtlite.jar"; 
-		classesFullPath = jckRoot + File.separator + testSuiteFolder + File.separator + "classes";
+		jckPolicyFileFullPath = jckBase + File.separator + "lib" + File.separator + "jck.policy";
+		javatestJarFullPath = jckBase + File.separator + "lib" + File.separator + "javatest.jar";
+		jtliteJarFullPath = jckBase + File.separator + "lib" + File.separator + "jtlite.jar"; 
+		classesFullPath = jckBase + File.separator + "classes";
 		nativesLoc = jckRoot + File.separator + "natives" + File.separator + platform;
 		jtiFile = testRoot + File.separator + "jck" + File.separator + "jtrunner" + File.separator + CONFIG + File.separator + jckVersion + File.separator + testSuite.toLowerCase() + ".jti"; 
-		fileUrl = "file:///" + testSuiteFolder + "/testsuite.jtt";
+		fileUrl = "file:///" + jckBase + "/testsuite.jtt";
 
 		// The first release of a JCK will have an initial excludes (.jtx) file in test-suite/lib - e.g. JCK-runtime-8b/lib/jck8b.jtx.
 		// Updates to the excludes list may subsequently be supplied as a separate file, which supersedes the initial file.

--- a/jck/jtrunner/config/jck11/runtime.jti
+++ b/jck/jtrunner/config/jck11/runtime.jti
@@ -142,7 +142,7 @@ jck.env.runtime.testExecute.verify=-Xfuture
 # jck.env.runtime.url.fileURL example: file\:///home/user/urlfile.txt
 jck.env.runtime.url.fileURL=will_be_set_by_test_automation_at_run_time
 # jck.env.runtime.url.ftpURL example: ftp\://user\:password@xxxx.xxxx.xxxx.com/xxx.txt
-jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.url.ftpURL=ftp\://jckftp\:CqwbpqMpe4Q68kDRXj4mqxM7W@jckservices.adoptium.net/filename.txt
 # jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
 jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.url=Yes

--- a/jck/jtrunner/config/jck17/runtime.jti
+++ b/jck/jtrunner/config/jck17/runtime.jti
@@ -142,7 +142,7 @@ jck.env.runtime.testExecute.verify=-Xfuture
 # jck.env.runtime.url.fileURL example: file\:///home/user/urlfile.txt
 jck.env.runtime.url.fileURL=will_be_set_by_test_automation_at_run_time
 # jck.env.runtime.url.ftpURL example: ftp\://user\:password@xxxx.xxxx.xxxx.com/xxx.txt
-jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.url.ftpURL=ftp\://jckftp\:CqwbpqMpe4Q68kDRXj4mqxM7W@jckservices.adoptium.net/filename.txt
 # jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
 jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.url=Yes

--- a/jck/jtrunner/config/jck18/runtime.jti
+++ b/jck/jtrunner/config/jck18/runtime.jti
@@ -142,7 +142,7 @@ jck.env.runtime.testExecute.verify=-Xfuture
 # jck.env.runtime.url.fileURL example: file\:///home/user/urlfile.txt
 jck.env.runtime.url.fileURL=will_be_set_by_test_automation_at_run_time
 # jck.env.runtime.url.ftpURL example: ftp\://user\:password@xxxx.xxxx.xxxx.com/xxx.txt
-jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.url.ftpURL=ftp\://jckftp\:CqwbpqMpe4Q68kDRXj4mqxM7W@jckservices.adoptium.net/filename.txt
 # jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
 jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.url=Yes

--- a/jck/jtrunner/config/jck8c/runtime.jti
+++ b/jck/jtrunner/config/jck8c/runtime.jti
@@ -196,7 +196,7 @@ jck.env.runtime.url=Yes
 # jck.env.runtime.url.fileURL example: file\:///home/user/urlfile.txt
 jck.env.runtime.url.fileURL=will_be_set_by_test_automation_at_run_time
 # jck.env.runtime.url.ftpURL example: ftp\://user\:password@xxxx.xxxx.xxxx.com/xxx.txt
-jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.url.ftpURL=ftp\://jckftp\:CqwbpqMpe4Q68kDRXj4mqxM7W@jckservices.adoptium.net/filename.txt
 # jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
 jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
 jck.env.simpleOrAdvanced=advanced


### PR DESCRIPTION
without this we get: `Configuration file can not be imported due to question with specified tag "jck.env.runtime.url.httpURL" was not found on path. The path is:jck.intro`
