### PR TITLE
Update JDK18 test exclusion list

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -43,20 +43,6 @@ java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/
 
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 
-java/lang/reflect/Proxy/nonPublicProxy/DefaultMethodProxy.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/reflect/Proxy/ProxyTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/reflect/Proxy/DefaultMethods.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/invoke/lookup/SpecialStatic.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/invoke/lambda/invokeSpecial/InvokeSpecialMethodTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/invoke/MethodHandlesProxiesTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/invoke/JavaDocExamplesTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/invoke/InvokeDynamicPrintArgs.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/invoke/8177146/TestMethodHandleBind.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/constant/MethodHandleDescTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/invoke/7087570/Test7087570.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/invoke/7196190/GetUnsafeTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-java/lang/invoke/lambda/MetafactoryArgValidationTest.java https://github.com/eclipse-openj9/openj9/issues/13995 generic-all
-
 java/lang/invoke/7157574/Test7157574.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
 java/lang/invoke/lambda/InheritedMethodTest.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
 java/lang/reflect/DefaultStaticTest/DefaultStaticInvokeTest.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
@@ -70,5 +56,22 @@ jdk/internal/reflect/Reflection/GetCallerClassTest.java#id0 https://github.com/e
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
+
+java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14079 generic-all
+
+java/lang/reflect/classInitialization/ExceptionInClassInitialization.java https://github.com/eclipse-openj9/openj9/issues/14080 generic-all
+
+java/lang/reflect/MethodHandleAccessorsTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
+java/lang/reflect/MethodHandleAccessorsTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
+
+java/lang/StringBuilder/HugeCapacity.java https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
+
+java/lang/System/AllowSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/14092 generic-all
+
+java/lang/System/FileEncodingTest.java https://github.com/eclipse-openj9/openj9/issues/14093 generic-all
+
+java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/openj9/issues/14094 generic-all
+
+java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/14095 generic-all
 
 ############################################################################


### PR DESCRIPTION
eclipse-openj9/openj9#13995 has been fixed via eclipse-openj9/openj9#14044.
So, the tests excluded for eclipse-openj9/openj9#13995 have been re-enabled.

Test failures documented in the below issues have been excluded:
- eclipse-openj9/openj9#14079
- eclipse-openj9/openj9#14080
- eclipse-openj9/openj9#14084
- eclipse-openj9/openj9#14091
- eclipse-openj9/openj9#14092
- eclipse-openj9/openj9#14093
- eclipse-openj9/openj9#14094
- eclipse-openj9/openj9#14095

Related: https://github.com/eclipse-openj9/openj9/issues/13946

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>