### PR TITLE
Clarify logging around TCK excludes files

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -237,6 +237,14 @@ public class JavaTestRunner {
 		// A known failures list (.kfl) file is optional.
 		// The automation here adds any files found (initial or updates) as 'custom' files. 
 		initialJtxFullPath = jckBase + "/lib/" + jckVersion + ".jtx";
+		File initialJtxFile = new File(initialJtxFullPath);
+
+		if (initialJtxFile.exists()) {
+			System.out.println("Using initial excludes list file " + initialJtxFullPath);
+		} else {
+			System.out.println("Unable to find initial excludes list file " + initialJtxFullPath);
+			initialJtxFullPath = "";
+		}
 
 		// Look for an update to the initial excludes file
 		if (jckVersion.contains("jck6") || jckVersion.contains("jck7")) {
@@ -250,10 +258,10 @@ public class JavaTestRunner {
 		jtxFullPath = jckRoot + File.separator + jtxRelativePath; 
 		File jtxFile = new File(jtxFullPath); 
 		
-		if (jtxFile.exists()) { 
-			System.out.println("Using excludes list file " + jtxFullPath);
+		if (jtxFile.exists()) {
+			System.out.println("Using additional excludes list file " + jtxFullPath);
 		} else {
-			System.out.println("Unable to find excludes list file " + jtxFullPath);
+			System.out.println("Unable to find additional excludes list file " + jtxFullPath);
 			jtxFullPath = "";
 		}
 

--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -247,16 +247,11 @@ public class JavaTestRunner {
 		}
 
 		// Look for an update to the initial excludes file
-		if (jckVersion.contains("jck6") || jckVersion.contains("jck7")) {
-			jtxRelativePath = "excludes/jdk" + jckVersionNo + ".jtx";
-			kflRelativePath = "excludes/jdk" + jckVersionNo + ".kfl";
-		} else {
-			jtxRelativePath = "excludes/jck" + jckVersionNo + ".jtx";
-			kflRelativePath = "excludes/jck" + jckVersionNo + ".kfl";
-		}
-		
+		jtxRelativePath = "excludes/" + jckVersion + ".jtx";
+		kflRelativePath = "excludes/" + jckVersion + ".kfl";
+
 		jtxFullPath = jckRoot + File.separator + jtxRelativePath; 
-		File jtxFile = new File(jtxFullPath); 
+		File jtxFile = new File(jtxFullPath);
 		
 		if (jtxFile.exists()) {
 			System.out.println("Using additional excludes list file " + jtxFullPath);
@@ -267,7 +262,7 @@ public class JavaTestRunner {
 
 		// Look for a known failures list file
 		kflFullPath = jckRoot + File.separator + kflRelativePath;
-		File kflFile = new File(kflFullPath); 
+		File kflFile = new File(kflFullPath);
 		
 		if (kflFile.exists()) { 
 			System.out.println("Using known failures list file " + kflFullPath);


### PR DESCRIPTION
Currenty the test harness looks for an initial excludes file and the also attempts to detect an additional one. If the additional one doesn't exist then a misleading warning is shown that states `Unable to find excludes list file`.

This PR adds a check for the initial excludes file but also clarifies the logging