### PR TITLE
Update JDK18 openj9 test exclusion list w/ JDK17 version content

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -16,6 +16,336 @@
 
 ############################################################################
 
+# jdk_awt
+
+############################################################################
+
+# jdk_beans
+
+############################################################################
+
+# jdk_lang
+
+java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+#java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
+java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
+java/lang/ClassLoader/Assert.java	https://github.com/eclipse-openj9/openj9/issues/6668	macosx-x64
+java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
+java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
+java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-openj9/openj9/issues/3178	generic-all
+java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
+java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
+java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
+java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
+java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
+java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
+java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all
+java/lang/StackWalker/DumpStackTest.java	https://github.com/eclipse-openj9/openj9/issues/6680	generic-all
+java/lang/StackWalker/EmbeddedStackWalkTest.java	https://github.com/eclipse-openj9/openj9/issues/3941	generic-all
+java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/StackWalker/ReflectionFrames.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/StackWalker/VerifyStackTrace.java	https://github.com/adoptium/aqa-tests/issues/1273	generic-all
+java/lang/String/CaseConvertSameInstance.java	https://github.com/eclipse-openj9/openj9/issues/6672	generic-all
+java/lang/String/CaseInsensitiveComparator.java	https://github.com/eclipse-openj9/openj9/issues/6665	generic-all
+java/lang/String/CompactString/IndexOf.java		https://github.com/eclipse-openj9/openj9/issues/6673	generic-all
+java/lang/String/concat/CompactStringsInitialCoder.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcat.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatArgCount.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatAssignLHS.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatBoundaries.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatMany.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatManyLongs.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatOrder.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/ImplicitStringConcatShapes.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/StringConcatFactoryInvariants.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/StringConcatFactoryRepeatedConstants.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/concat/WithSecurityManager.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
+java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse-openj9/openj9/issues/6666	generic-all
+java/lang/String/StringRepeat.java	https://github.com/eclipse-openj9/openj9/issues/6667	generic-all
+java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
+java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
+java/lang/StringBuilder/HugeCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/DefaultLoggerFinderTest/DefaultLoggerFinderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/BaseDefaultLoggerFinderTest/BaseDefaultLoggerFinderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/BaseLoggerBridgeTest/BaseLoggerBridgeTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/internal/backend/LoggerFinderBackendTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/Thread/UncaughtExceptions.sh	https://github.com/eclipse-openj9/openj9/issues/6690	generic-all
+java/lang/Thread/UncaughtExceptionsTest.java	https://github.com/eclipse-openj9/openj9/issues/11930	generic-all
+java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse-openj9/openj9/issues/6691	generic-all
+java/lang/Throwable/SuppressedExceptions.java	https://github.com/eclipse-openj9/openj9/issues/6692	generic-all
+java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/annotation/loaderLeak/Main.java	https://github.com/eclipse-openj9/openj9/issues/6701	generic-all
+java/lang/invoke/FindAccessTest.java		https://github.com/eclipse-openj9/openj9/issues/6868	generic-all
+java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse-openj9/openj9/issues/11366 generic-all
+java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse-openj9/openj9/issues/7043	generic-all
+java/lang/invoke/PrivateInvokeTest.java	https://github.com/eclipse-openj9/openj9/issues/7071	generic-all
+java/lang/invoke/SpecialInterfaceCall.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/invoke/VarHandle/AccessMode/OptimalMapSize.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
+java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
+java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse-openj9/openj9/issues/7158	aix-all
+java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse-openj9/openj9/issues/3394	generic-all
+java/lang/ref/CleanerTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/ref/EarlyTimeout.java	https://github.com/eclipse-openj9/openj9/issues/7225	generic-all
+java/lang/ref/FinalizeOverride.java	https://github.com/eclipse-openj9/openj9/issues/9651	generic-all
+java/lang/ref/FinalizerHistogramTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/ref/NullQueue.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/ref/OOMEInReferenceHandler.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/ref/ReachabilityFenceTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse-openj9/openj9/issues/7741	generic-all
+java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all
+java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
+java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/adoptium/temurin-build/issues/248 generic-all
+jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	macosx-all
+jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
+java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
+java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
+############################################################################
+
+# jdk_internal
+jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
+
+############################################################################
+
+# jdk_management
+
+sun/management/HotspotClassLoadingMBean/GetClassInitializationTime.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetClassLoadingTime.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetInitializedClassCount.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetLoadedClassSize.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetMethodDataSize.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetUnloadedClassSize.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagement.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/ManagementFactory/ValidateOpenTypes.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/ManagementFactory/ProxyTypeMapping.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/CollectionUsageThreshold.java  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest2.sh      https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/GarbageCollectorMXBean/GcInfoCompositeType.java  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/CompositeData/MemoryUsageCompositeData.java  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+
+############################################################################
+
+# jdk_net
+
+java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699	linux-s390x
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse-openj9/openj9/issues/4560 generic-all
+java/net/SocketPermission/SocketPermissionTest.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingBinaryPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingBinaryPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPingBinaryClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPingTextClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPongBinaryClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+
+############################################################################
+
+# jdk_io
+
+java/io/CharArrayReader/OverflowInRead.java	https://github.com/adoptium/aqa-tests/issues/1500	generic-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
+java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_nio
+
+java/nio/Buffer/BulkPutBuffer.java https://github.com/eclipse-openj9/openj9/issues/13094 generic-all
+java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse-openj9/openj9/issues/4473 generic-all
+java/nio/Buffer/EqualsCompareTest.java	https://github.com/eclipse-openj9/openj9/issues/13094	generic-all
+java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse-openj9/openj9/issues/8063	generic-all
+java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse-openj9/openj9/issues/8065	generic-all
+java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/infrastructure/issues/1173	linux-all,aix-all
+java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
+java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
+java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse-openj9/openj9/issues/4317 macosx-all
+java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
+jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4679 linux-x64,macosx-all
+
+############################################################################
+
+# jdk_rmi
+
+java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse-openj9/openj9/issues/6749 windows-all
+java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
+java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse-openj9/openj9/issues/7592	generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse-openj9/openj9/issues/8515	generic-all
+java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse-openj9/openj9/issues/3377	generic-all
+java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
+java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse-openj9/openj9/issues/4094 generic-all
+java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
+
+############################################################################
+
+# jdk_security
+
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+############################################################################
+
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_util
+
+java/util/Arrays/TimSortStackSize2.java	https://github.com/eclipse-openj9/openj9/issues/7086	generic-all
+java/util/Arrays/largeMemory/ParallelPrefix.java https://github.com/eclipse-openj9/openj9/issues/4100 linux-ppc64le
+java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse-openj9/openj9/issues/4720 linux-all
+java/util/Spliterator/SpliteratorCollisions.java	https://github.com/eclipse-openj9/openj9/issues/7090	generic-all
+java/util/concurrent/ArrayBlockingQueue/WhiteBox.java 	https://github.com/eclipse-openj9/openj9/issues/5988 	macosx-all
+java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclipse-openj9/openj9/issues/3209	generic-all
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse-openj9/openj9/issues/7125	macosx-all,linux-all,aix-all
+java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
+java/util/logging/CheckZombieLockTest.java	https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all
+java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
+java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all
+java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse-openj9/openj9/issues/3447	generic-all
+java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all
+java/util/Random/RandomTestChiSquared.java	https://github.com/eclipse-openj9/openj9/issues/13202	generic-all
+java/util/Random/RandomTestBsi1999.java		https://github.com/eclipse-openj9/openj9/issues/13202	generic-all
+
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+
+
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ShenandoahGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ZGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ShenandoahGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ZGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/internal/misc/VM/GetNanoTimeAdjustment.java		https://github.com/eclipse-openj9/openj9/issues/7184		generic-all
+jdk/internal/misc/VM/RuntimeArguments.java		https://github.com/eclipse-openj9/openj9/issues/7186		generic-all
+jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/eclipse-openj9/openj9/issues/7245		generic-all
+jdk/internal/reflect/constantPool/ConstantPoolTest.java	https://github.com/eclipse-openj9/openj9/issues/7249		generic-all
+
+sun/misc/SunMiscSignalTest.java		https://github.com/eclipse-openj9/openj9/issues/7264		generic-all
+sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/adoptium/aqa-tests/issues/749 windows-all
+sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse-openj9/openj9/issues/5328		generic-all
+
+vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse-openj9/openj9/issues/7336	generic-all
+############################################################################
+
 # jdk_foreign
 
 java/foreign/SafeFunctionAccessTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
@@ -73,5 +403,7 @@ java/lang/System/FileEncodingTest.java https://github.com/eclipse-openj9/openj9/
 java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/openj9/issues/14094 generic-all
 
 java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/14095 generic-all
+
+# com_sun_crypto
 
 ############################################################################


### PR DESCRIPTION
Copy content from `ProblemList_openjdk17-openj9.txt`.

Note: this is to exclude JDK18 test failures https://github.com/eclipse-openj9/openj9/issues/7249 and others.

fyi @tajila @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>