### PR TITLE
Exclude more failing tests on z/OS tck 11 + Clean up dups in previous excludes

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -77,6 +77,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-api-javax_tools</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -12,7 +12,7 @@
 # limitations under the License.
 ##############################################################################
 ifndef JCK_CUSTOM_TARGET
-JCK_CUSTOM_TARGET ?=api/java_math
+JCK_CUSTOM_TARGET ?=api/java_math/BigInteger
 endif
 
 # Environment variable OSTYPE is set to cygwin if running under cygwin.

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -357,11 +357,6 @@
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
 				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
@@ -408,12 +403,6 @@
 	<test>
 		<testCaseName>jck-runtime-api-java_util-regex</testCaseName>
 		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/667</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
 			<disable>
 				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
 				<platform>.*zos.*</platform>
@@ -687,6 +676,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_math</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- Additional excludes for /backlog/issues/669 for failures observed in the latest extended tck 11 run on z/OS + cleanup of duplications in excludes introduced in https://github.com/adoptium/aqa-tests/pull/3160.
- Custom target updated to only run `api/java_math/BigInteger`. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>