### PR TITLE
Exclude the new FFI specific test suites in JDK18

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -377,6 +377,18 @@ java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/
 
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 
+java/foreign/TestMemoryAccess.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestNulls.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestSegmentAllocators.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/channels/TestAsyncSocketChannels.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestUpcall.java#async https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestUpcall.java#no_scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestUpcall.java#scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+
+java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj9/openj9/issues/14135 generic-all
+
+
 java/lang/invoke/7157574/Test7157574.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
 java/lang/invoke/lambda/InheritedMethodTest.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
 java/lang/reflect/DefaultStaticTest/DefaultStaticInvokeTest.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all


### PR DESCRIPTION
The change is to exclude all failing FFI specific test suites
newly added in Java 18 given the whole functionalities have
not yet been fully implemented.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>