### PR TITLE
JDK18 excludes DelegateTest/Finalization/WithClassLoaderName etc.

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -31,6 +31,7 @@ java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
 java/lang/ClassLoader/Assert.java	https://github.com/eclipse-openj9/openj9/issues/6668	macosx-x64
+java/lang/ClassLoader/deadlock/DelegateTest.java	https://github.com/eclipse-openj9/openj9/issues/14133	generic-all
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
@@ -38,9 +39,12 @@ java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-open
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
+java/lang/Object/FinalizationOption.java	https://github.com/eclipse-openj9/openj9/issues/14131	generic-all
+java/lang/Object/InvalidFinalizationOption.java	https://github.com/eclipse-openj9/openj9/issues/14131	generic-all
 java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
+java/lang/StackTraceElement/WithClassLoaderName.java	https://github.com/eclipse-openj9/openj9/issues/14132	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all
 java/lang/StackWalker/DumpStackTest.java	https://github.com/eclipse-openj9/openj9/issues/6680	generic-all
@@ -306,6 +310,7 @@ java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java	https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/util/logging/Logger/getLogger/TestInferCaller.java	https://github.com/eclipse-openj9/openj9/issues/14136	generic-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all


### PR DESCRIPTION
This is part of effort to get `JDK18` green `sanity.openjdk`.

`java/lang/ClassLoader/deadlock/DelegateTest.java` - https://github.com/eclipse-openj9/openj9/issues/14133
`java/lang/Object/FinalizationOption.java` - https://github.com/eclipse-openj9/openj9/issues/14131
`java/lang/Object/InvalidFinalizationOption.java` - https://github.com/eclipse-openj9/openj9/issues/14131
`java/lang/StackTraceElement/WithClassLoaderName.java` - https://github.com/eclipse-openj9/openj9/issues/14132
`java/util/logging/Logger/getLogger/TestInferCaller.java` - https://github.com/eclipse-openj9/openj9/issues/14136

Signed-off-by: Jason Feng <fengj@ca.ibm.com>