### PR TITLE
Enable java/util/logging/Logger/getLogger/TestInferCaller.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -310,7 +310,6 @@ java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java	https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/util/logging/Logger/getLogger/TestInferCaller.java	https://github.com/eclipse-openj9/openj9/issues/14136	generic-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all


### PR DESCRIPTION
`OpenJ9` PR https://github.com/eclipse-openj9/openj9/pull/14137 has been merged.

closes https://github.com/eclipse-openj9/openj9/issues/14136

Signed-off-by: Jason Feng <fengj@ca.ibm.com>