### PR TITLE
Update JDK18 test exclusion list

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -391,20 +391,10 @@ java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 
-
-java/lang/invoke/7157574/Test7157574.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
-java/lang/invoke/lambda/InheritedMethodTest.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
-java/lang/reflect/DefaultStaticTest/DefaultStaticInvokeTest.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
-
-java/lang/annotation/typeAnnotations/TestExecutableGetAnnotatedType.java https://github.com/eclipse-openj9/openj9/issues/13997 generic-all
-java/lang/annotation/typeAnnotations/GetAnnotatedOwnerType.java https://github.com/eclipse-openj9/openj9/issues/13997 generic-all
-java/lang/annotation/typeAnnotations/TestObjectMethods.java https://github.com/eclipse-openj9/openj9/issues/13997 generic-all
-java/lang/reflect/Parameter/InnerClassToString.java https://github.com/eclipse-openj9/openj9/issues/13997 generic-all
-
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/13998 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14079 generic-all
 


### PR DESCRIPTION
eclipse-openj9/openj9#13996 is fixed via eclipse-openj9/openj9#14125.
eclipse-openj9/openj9#13997 is fixed via eclipse-openj9/openj9#14125.
eclipse-openj9/openj9#13998 is fixed via ibmruntimes/openj9-openjdk-jdk#382.

GetCallerClassTest continues to be excluded since it fails due to
eclipse-openj9/openj9#14097.

Related: https://github.com/eclipse-openj9/openj9/issues/13946

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>