### PR TITLE
Support openj9 sha without branch

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -484,7 +484,13 @@ getFunctionalTestMaterial()
 			echo "git fetch -q --tags $OPENJ9_REPO +refs/pull/*:refs/remotes/origin/pr/*"
 			git fetch -q --tags $OPENJ9_REPO +refs/pull/*:refs/remotes/origin/pr/*
 			echo "git checkout -q $OPENJ9_SHA"
-			git checkout -q $OPENJ9_SHA
+			if ! git checkout $OPENJ9_SHA; then
+				echo "SHA not yet found. Continue fetching all the branches on origin..."
+				echo "git fetch -q --tags $OPENJ9_REPO +refs/heads/*:refs/remotes/origin/*"
+				git fetch -q --tags $OPENJ9_REPO +refs/heads/*:refs/remotes/origin/*
+				echo "git checkout -q $OPENJ9_SHA"
+				git checkout $OPENJ9_SHA
+			fi
 		fi
 		cd $TESTDIR
 	fi


### PR DESCRIPTION
Currently, we take both OPENJ9_BRANCH and OPENJ9_SHA. However, in testenv.properties, we only output one value - OPENJ9_SHA (adoptium/TKG#255). We will not have branch information. The logic in `get.sh` was highly optimized to have minimal checkout for openj9 repo (i.e., we do not fetch other branches). This causes a problem as it is not able to git clone with sha only (if the sha is from other branches).

This PR adds the support to git clone personal openj9 sha without branch info, so we can consume the OPENJ9_SHA without OPENJ9_BRNACH info.

Related: adoptium/TKG#255
Related: adoptium#2889

Signed-off-by: lanxia lan_xia@ca.ibm.com