### PR TITLE
Exclude the failing FFI test suites on other platforms in JDK18

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -388,6 +388,9 @@ java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/
 
 java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj9/openj9/issues/14135 generic-all
 
+java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
+java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
+
 
 java/lang/invoke/7157574/Test7157574.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all
 java/lang/invoke/lambda/InheritedMethodTest.java https://github.com/eclipse-openj9/openj9/issues/13996 generic-all


### PR DESCRIPTION
The change is to add the failing FFI test suites detected
on other platforms to the exclude file.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>