### PR TITLE
Update JDK18 test exclusion list

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -139,10 +139,24 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-te
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
+java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14079 generic-all
+java/lang/reflect/classInitialization/ExceptionInClassInitialization.java https://github.com/eclipse-openj9/openj9/issues/14080 generic-all
+java/lang/reflect/MethodHandleAccessorsTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
+java/lang/reflect/MethodHandleAccessorsTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
+java/lang/StringBuilder/HugeCapacity.java https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
+java/lang/System/AllowSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/14092 generic-all
+java/lang/System/FileEncodingTest.java https://github.com/eclipse-openj9/openj9/issues/14093 generic-all
+java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/openj9/issues/14094 generic-all
+java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/14095 generic-all
+
 ############################################################################
 
 # jdk_internal
 jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 
 ############################################################################
 
@@ -318,6 +332,7 @@ java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tes
 java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all
 java/util/Random/RandomTestChiSquared.java	https://github.com/eclipse-openj9/openj9/issues/13202	generic-all
 java/util/Random/RandomTestBsi1999.java		https://github.com/eclipse-openj9/openj9/issues/13202	generic-all
+java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java https://github.com/eclipse-openj9/openj9/issues/14178 generic-all
 
 ############################################################################
 
@@ -391,27 +406,7 @@ java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
-
-java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14079 generic-all
-
-java/lang/reflect/classInitialization/ExceptionInClassInitialization.java https://github.com/eclipse-openj9/openj9/issues/14080 generic-all
-
-java/lang/reflect/MethodHandleAccessorsTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
-java/lang/reflect/MethodHandleAccessorsTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
-
-java/lang/StringBuilder/HugeCapacity.java https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
-
-java/lang/System/AllowSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/14092 generic-all
-
-java/lang/System/FileEncodingTest.java https://github.com/eclipse-openj9/openj9/issues/14093 generic-all
-
-java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/openj9/issues/14094 generic-all
-
-java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/14095 generic-all
+############################################################################
 
 # com_sun_crypto
 


### PR DESCRIPTION
Only `SpliteratorTraversingAndSplittingTest` has been excluded:
eclipse-openj9/openj9#14095.

Others have been reordered based upon their category.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>