### PR TITLE
Use xlc16 for running JCK tests on AIX

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -774,7 +774,7 @@ public class JavaTestRunner {
 			}
 
 			fileContent += "concurrency " + concurrencyString + ";\n";
-			fileContent += "timeoutfactor 4" + ";\n";							// All Devtools tests take less than 1h to finish.
+			fileContent += "timeoutfactor 40" + ";\n";							// All Devtools tests take less than 1h to finish.
 
 			if (platform.equals("win")) {
 				// On Windows set the testplatform.os to Windows and set systemRoot, but do not

--- a/jck/jtrunner/config/jck8c/runtime.jti
+++ b/jck/jtrunner/config/jck8c/runtime.jti
@@ -232,4 +232,4 @@ jck.priorStatus.status=
 jck.tests.needTests=No
 jck.tests.tests=
 jck.tests.treeOrFile=tree
-jck.timeout.timeout=1
+jck.timeout.timeout=10

--- a/jck/jtrunner/makefile
+++ b/jck/jtrunner/makefile
@@ -167,7 +167,7 @@ ifeq ($(OS),sunos)
 endif
 
 ifeq ($(OS),aix)
-	CC=/opt/IBM/xlC/13.1.3/bin/xlc
+	CC=/opt/IBM/xlC/16.1.0/bin/xlc
 	CFLAGS=-qstaticinline -q$(BitMode) -I$(UNIX_PATH) -I$(OSX_PATH) -I$(SRC_PATH)
 	LDFLAGS=-G -q$(BitMode)
 endif


### PR DESCRIPTION
Required for our new AIX machines. We should verify whether this will cause a problem for IBM before merging this. Worst case we can put in a switch so it can use either one that's available on the system.