### PR TITLE
Capture openjdk repo and sha in testenv.properties

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -324,6 +324,7 @@
 			</else>
 		</if>
 		<checkGitRepoSha repoDir="openjdk-jdk" />
+		<addTestenvProperties repoDir="openjdk-jdk" repoName="JDK${env.JDK_VERSION}"/>
 	</target>
 	
 	<target name="openjdk-jdk.check">


### PR DESCRIPTION
Related: https://github.com/adoptium/aqa-tests/issues/2916 #2347
Depends: https://github.com/adoptium/TKG/pull/256 

Signed-off-by: lanxia <lan_xia@ca.ibm.com>