### PR TITLE
Fix platform value for Windows while setting tck test properties 

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -535,7 +535,7 @@ public class JavaTestRunner {
 				keyword += "&!robot";
 			}
 
-			if ( !platform.equals("win32") && (tests.contains("api/signaturetest") || tests.contains("api/java_io")) ) {
+			if ( !platform.equals("win") && (tests.contains("api/signaturetest") || tests.contains("api/java_io")) ) {
 				fileContent += "set jck.env.testPlatform.xWindows \"No\"" + ";\n";
 			}
 


### PR DESCRIPTION
Resolves /backlog/issues/697

Note: In JavaTestRunner, the `platform` parameter evaluates to 'win' on Windows platforms: https://github.com/adoptium/aqa-tests/blob/master/jck/jtrunner/JavaTestRunner.java#L1219

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>