### PR TITLE
exclude some renaissance tests from arm_linux $ x86-32_windows

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -37,9 +37,9 @@
 				<version>16+</version>
 			</disable>
 			<disable>
-                <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-               <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
-           </disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
 		$(TEST_STATUS)</command>
@@ -58,9 +58,9 @@
 				<version>16+</version>
 			</disable>
 			<disable>
-               <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-              <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
-          </disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
 		$(TEST_STATUS)</command>
@@ -102,9 +102,9 @@
 				<version>16+</version>
 			</disable>
 			<disable>
-               <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-               <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
-           </disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
 		$(TEST_STATUS)</command>
@@ -178,9 +178,9 @@
 				<version>16+</version>
 			</disable>
 			<disable>
-                <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-                <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
-           </disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
 		$(TEST_STATUS)</command>
@@ -198,10 +198,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818964263</comment>
 				<version>16+</version>
 			</disable>
-		  <disable>
-                <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-                <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
-          </disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
 		$(TEST_STATUS)</command>
@@ -231,9 +231,9 @@
 				<version>16+</version>
 			</disable>
 			<disable>
-                <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-                <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
-           </disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \
 		$(TEST_STATUS)</command>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -38,7 +38,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
@@ -59,7 +59,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
@@ -103,7 +103,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
@@ -179,7 +179,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
@@ -200,7 +200,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
@@ -232,7 +232,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
-				<platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -36,6 +36,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818964862</comment>
 				<version>16+</version>
 			</disable>
+			<disable>
+                <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+               <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+           </disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
 		$(TEST_STATUS)</command>
@@ -53,6 +57,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818964098</comment>
 				<version>16+</version>
 			</disable>
+			<disable>
+               <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+              <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+          </disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
 		$(TEST_STATUS)</command>
@@ -93,6 +101,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/2255#issuecomment-788234331</comment>
 				<version>16+</version>
 			</disable>
+			<disable>
+               <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+               <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+           </disable>
 		</disables>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
 		$(TEST_STATUS)</command>
@@ -165,6 +177,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818964531</comment>
 				<version>16+</version>
 			</disable>
+			<disable>
+                <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+                <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+           </disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
 		$(TEST_STATUS)</command>
@@ -182,6 +198,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818964263</comment>
 				<version>16+</version>
 			</disable>
+		  <disable>
+                <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+                <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+          </disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
 		$(TEST_STATUS)</command>
@@ -210,6 +230,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818965117</comment>
 				<version>16+</version>
 			</disable>
+			<disable>
+                <comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
+                <platform>.*x86-32_windows*.|.*arm_linux*.</platform>
+           </disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \
 		$(TEST_STATUS)</command>


### PR DESCRIPTION
Related: https://github.com/adoptium/aqa-tests/issues/3189