### PR TITLE
Add proper error message when no XML report found

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -41,6 +41,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
+import java.io.FileNotFoundException;
 
 public class JavaTestRunner {
 	private static String testJdk;
@@ -999,6 +1000,11 @@ public class JavaTestRunner {
 			fw.close();
 			System.out.println(resultSummary.toString());
 			return true; 
+		} catch (FileNotFoundException e) {
+			System.out.println("No javatest XML result file found. Please check if the "
+					+ "test failed before generating the XML report");
+			e.printStackTrace(); 
+			return false; 
 		} catch (SAXParseException err) {
 			System.out.println ("Error processing XML JCK output report" + err.getMessage ());
 			err.printStackTrace();


### PR DESCRIPTION
- Adds a catch block for the FIleNotFoundException thrown when no XML report is found, due to test failing before reaching the stage where javatest harness can generate an XML report. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>