### PR TITLE
Clean the function parse_tag() in external/external.sh

### DIFF
--- a/external/external.sh
+++ b/external/external.sh
@@ -125,12 +125,7 @@ function parse_tag() {
     		package=jre
 		;;
 	esac
-	# set BUILD_TYPE
-	case $tag in
-   		*-slim*|*_slim*) 
-   			build_type=slim
-   		;;
-	esac
+	
 	# set DOCKER_OS
 	case $tag in
 	

--- a/external/external.sh
+++ b/external/external.sh
@@ -133,20 +133,7 @@ function parse_tag() {
 	esac
 	# set DOCKER_OS
 	case $tag in
-   		*alpine*) 
-	   		docker_os=alpine;;
-   		*debianslim*) 
-	   		docker_os=debianslim;;
-		*debian*) 
-	   		docker_os=debian;;
-		*centos*) 
-	   		docker_os=centos;;
-		*clefos*) 
-	   		docker_os=clefos;;
-		*ubi-minimal*) 
-	   		docker_os=ubi-minimal;;
-		*ubi*) 
-	   		docker_os=ubi;;
+	
 		*ubuntu*|*latest*|*nightly*) 
 	   		docker_os=ubuntu;;
    		*) echo "Unable to recognize DOCKER_OS from DOCKERIMAGE_TAG = $tag!";;


### PR DESCRIPTION
External tests was been updated to run with docker images provided by adoptium, function parse_tag() in external/external.sh has also  been cleaned up.

grinder run https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2981/console
Fixes #3186 