### PR TITLE
Update to test target names

### DIFF
--- a/external/quarkus/playlist.xml
+++ b/external/quarkus/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>quarkus_java_test</testCaseName>
+		<testCaseName>quarkus_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir quarkus --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir quarkus

--- a/external/spring/playlist.xml
+++ b/external/spring/playlist.xml
@@ -27,7 +27,7 @@
                 </groups>
         </test>
 	<test>
-		<testCaseName>spring-test</testCaseName>
+		<testCaseName>spring_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir spring --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 			$(TEST_STATUS); \
 			$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir spring

--- a/external/wycheproof/playlist.xml
+++ b/external/wycheproof/playlist.xml
@@ -27,7 +27,7 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>WycheproofTests</testCaseName>
+		<testCaseName>wycheproof_test</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir wycheproof --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir wycheproof


### PR DESCRIPTION
From closed pull https://github.com/adoptium/aqa-tests/pull/3158
update to external tests' TestNameCase in the playlist.xml
From analysis ,the few passing tests seem to have this naming convention
and some have not been
when run with the current upstream master ,
https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2694/console this grinder came up with error cannot find the following tests [wycheproof_test] in TESTLIST in the playlist.xml .

this PR corrects the errors in documentation and the playlist.xml for some external tests.
grinder after troubleshooting the issue finds the wycheproof in the TESTLIST under the common_functions.sh and playlist.xml
https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/2707/console

Fixes #3157