### PR TITLE
added "--add-opens" option to some renaissance benchmarks

### DIFF
--- a/perf/perf.mk
+++ b/perf/perf.mk
@@ -1,4 +1,4 @@
-ADD_OPENS_CMD=""
+ADD_OPENS_CMD:=
 ifneq ($(JDK_VERSION),8)
-	ADD_OPENS_CMD=$(Q)--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED$(Q)
+	ADD_OPENS_CMD=--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED
 endif

--- a/perf/perf.mk
+++ b/perf/perf.mk
@@ -1,4 +1,4 @@
 ADD_OPENS_CMD=""
 ifneq ($(JDK_VERSION),8)
-	ADD_OPENS_CMD=$(Q)--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED$(Q)
+	ADD_OPENS_CMD=$(Q)--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED$(Q)
 endif

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -94,7 +94,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -37,7 +37,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -54,7 +54,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -94,7 +94,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
+		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -166,7 +166,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -183,7 +183,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -211,7 +211,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -33,15 +33,11 @@
 		<testCaseName>renaissance-als</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818964862</comment>
-				<version>16+</version>
-			</disable>
-			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -54,15 +50,11 @@
 		<testCaseName>renaissance-chi-square</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818964098</comment>
-				<version>16+</version>
-			</disable>
-			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -98,15 +90,11 @@
 		<testCaseName>renaissance-dec-tree</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/2255#issuecomment-788234331</comment>
-				<version>16+</version>
-			</disable>
-			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
+		<command>$(JAVA_COMMAND) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -174,15 +162,11 @@
 		<testCaseName>renaissance-gauss-mix</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818964531</comment>
-				<version>16+</version>
-			</disable>
-			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -195,15 +179,11 @@
 		<testCaseName>renaissance-log-regression</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818964263</comment>
-				<version>16+</version>
-			</disable>
-			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -227,15 +207,11 @@
 		<testCaseName>renaissance-movie-lens</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/2500#issuecomment-818965117</comment>
-				<version>16+</version>
-			</disable>
-			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED  -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -13,6 +13,7 @@
 # limitations under the License.
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+	<include>../perf.mk</include>
 	<test>
 		<testCaseName>renaissance-akka-uct</testCaseName>
 		<disables>


### PR DESCRIPTION
Referred to #2500  
--add-opens were required to make the benchmarks run on JDK16+