### PR TITLE
Update JDK18 test exclude list

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -130,7 +130,6 @@ java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/a
 java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse-openj9/openj9/issues/7741	generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
-java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/adoptium/temurin-build/issues/248 generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	macosx-all
@@ -138,7 +137,6 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-te
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
-java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14079 generic-all
 java/lang/reflect/classInitialization/ExceptionInClassInitialization.java https://github.com/eclipse-openj9/openj9/issues/14080 generic-all
 java/lang/reflect/MethodHandleAccessorsTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
 java/lang/reflect/MethodHandleAccessorsTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all

--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -72,7 +72,6 @@ java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse-openj9/openj9/
 java/lang/String/StringRepeat.java	https://github.com/eclipse-openj9/openj9/issues/6667	generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
-java/lang/StringBuilder/HugeCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
@@ -143,11 +142,13 @@ java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/e
 java/lang/reflect/classInitialization/ExceptionInClassInitialization.java https://github.com/eclipse-openj9/openj9/issues/14080 generic-all
 java/lang/reflect/MethodHandleAccessorsTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
 java/lang/reflect/MethodHandleAccessorsTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
-java/lang/StringBuilder/HugeCapacity.java https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
 java/lang/System/AllowSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/14092 generic-all
 java/lang/System/FileEncodingTest.java https://github.com/eclipse-openj9/openj9/issues/14093 generic-all
 java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/openj9/issues/14094 generic-all
-java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/14095 generic-all
+java/lang/StringBuilder/HugeCapacity.java#testLatin1 https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
+java/lang/StringBuilder/HugeCapacity.java#testUtf16 https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
+java/lang/StringBuilder/HugeCapacity.java#testHugeInitialString https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
+java/lang/StringBuilder/HugeCapacity.java#testHugeInitialCharSequence https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
### Commit 1: [JDK18] Remove duplicates and exclude sub-tests 
-- eclipse-openj9/openj9#14091 is a duplicate of #1297.
-- eclipse-openj9/openj9#14095 is a duplicate of eclipse-openj9/openj9#11930.
-- Individual sub-tests of `StringBuilder/HugeCapacity` are excluded.

Closes: https://github.com/eclipse-openj9/openj9/issues/14091
Closes: https://github.com/eclipse-openj9/openj9/issues/14095

### Commit 2: [JDK18] Re-enable exeCallerAccessTest/CallerAccessTest

Fixed by ibmruntimes/openj9-openjdk-jdk18#4.
Also, adoptium/temurin-build#248 has been closed.
Now, `exeCallerAccessTest/CallerAccessTest` passes with OpenJ9 JDK18.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>