### PR TITLE
[JDK18] Correctly exclude StringBuilder/HugeCapacity

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -72,6 +72,7 @@ java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse-openj9/openj9/
 java/lang/String/StringRepeat.java	https://github.com/eclipse-openj9/openj9/issues/6667	generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
+java/lang/StringBuilder/HugeCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
@@ -143,10 +144,6 @@ java/lang/reflect/MethodHandleAccessorsTest.java#id1 https://github.com/eclipse-
 java/lang/System/AllowSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/14092 generic-all
 java/lang/System/FileEncodingTest.java https://github.com/eclipse-openj9/openj9/issues/14093 generic-all
 java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/openj9/issues/14094 generic-all
-java/lang/StringBuilder/HugeCapacity.java#testLatin1 https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
-java/lang/StringBuilder/HugeCapacity.java#testUtf16 https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
-java/lang/StringBuilder/HugeCapacity.java#testHugeInitialString https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
-java/lang/StringBuilder/HugeCapacity.java#testHugeInitialCharSequence https://github.com/eclipse-openj9/openj9/issues/14091 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Excluding `StringBuilder/HugeCapacity` sub-tests does not work.

So, the `StringBuilder/HugeCapacity` changes in adoptium/aqa-tests#3211 have
been reverted.

The original `StringBuilder/HugeCapacity` exclude change has been re-added.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>