### PR TITLE
Enable FileEncodingTest FinalizationOption & InvalidFinalizationOption

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -39,8 +39,6 @@ java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-open
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
-java/lang/Object/FinalizationOption.java	https://github.com/eclipse-openj9/openj9/issues/14131	generic-all
-java/lang/Object/InvalidFinalizationOption.java	https://github.com/eclipse-openj9/openj9/issues/14131	generic-all
 java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
@@ -142,7 +140,6 @@ java/lang/reflect/classInitialization/ExceptionInClassInitialization.java https:
 java/lang/reflect/MethodHandleAccessorsTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
 java/lang/reflect/MethodHandleAccessorsTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
 java/lang/System/AllowSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/14092 generic-all
-java/lang/System/FileEncodingTest.java https://github.com/eclipse-openj9/openj9/issues/14093 generic-all
 java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/openj9/issues/14094 generic-all
 
 ############################################################################


### PR DESCRIPTION
Re-enable following tests:
```
java/lang/System/FileEncodingTest.java
java/lang/Object/FinalizationOption.java
java/lang/Object/InvalidFinalizationOption.java
```

Depends on ~https://github.com/eclipse-openj9/openj9/pull/14285~ ~https://github.com/eclipse-openj9/openj9/pull/14307~

Related https://github.com/eclipse-openj9/openj9/issues/14233 https://github.com/eclipse-openj9/openj9/issues/14093
https://github.com/eclipse-openj9/openj9/issues/14131

Signed-off-by: Jason Feng <fengj@ca.ibm.com>