### PR TITLE
Remove z/OS jdk11 excludes for passing tck targets

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -50,14 +50,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-instrument</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/670</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -94,14 +86,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-reflect</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/666</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -116,14 +100,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-Package</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/666</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -211,14 +187,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-module</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/583</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -270,14 +238,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-SecurityManager</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/666</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -367,14 +327,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-modulegraph</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/667</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -451,14 +403,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_util-ResourceBundle</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -612,14 +556,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_io</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -656,14 +592,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_math</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -965,14 +893,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_crypto</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/683</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1033,14 +953,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_management</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/682</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1181,14 +1093,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_script</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1416,14 +1320,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-org_w3c</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1438,14 +1334,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-org_xml</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1460,14 +1348,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-xinclude</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -122,14 +122,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-classfmt</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/668</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/runtime.xml_schema/playlist.xml
+++ b/jck/runtime.xml_schema/playlist.xml
@@ -43,12 +43,6 @@
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -148,14 +142,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-xml_schema-sunData</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
This PR un-excludes targets that are now working after change was made to the tck11 .gitattributes file for z/OS to instruct Git to only convert the working tree encoding of runtimes tck materials to ibm-1047.  

disabled.extended jck: Grinder/20206. 
disabled.sanity jck: Grinder/20221. 
Additional Grinder, running all targets un-excluded in this PR: Grinder/20249 (pls ignore the failed target, it's not included). 

FYI @JasonFengJ9 