### PR TITLE
Enable runtime-api-javax_xml target

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -1271,10 +1271,6 @@
 				<comment>backlog/issues/600</comment>
 				<impl>ibm</impl>
 			</disable>
-			<disable>
-				<comment>backlog/issues/600</comment>
-				<impl>hotspot</impl>
-			</disable>
 		</disables>
 	</test>
 	<test>


### PR DESCRIPTION
The jck-runtime-api-javax_xml target can be enabled for temurin-compliance / hotspot (verified via Temurin-compliance Grinder/875 and Grinder/878).  No longer needs to be run as auto-manual.

Signed-off-by: Shelley Lambert <slambert@gmail.com>