### PR TITLE
Unexclude working tck targets on z/OS JDK 11

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -514,7 +514,6 @@ public class JavaTestRunner {
 			if ( testsRequireDisplay(tests) ) {
 				if (platform.equals("zos")) {
 					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
-					fileContent += "set jck.env.runtime.testExecute.otherEnvVars LIBPATH=/usr/lpp/tcpip/X11R66/lib" + ";\n";
 				}
 				else {
 					if ( !platform.equals("win") ) {

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -305,14 +305,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-signaturetest</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -382,12 +374,6 @@
 				<platform>x86-64_mac</platform>
   				<impl>hotspot</impl>
 			</disable>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -433,12 +419,6 @@
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
  			</disable>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -534,12 +514,6 @@
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
-			</disable>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/680</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
 			</disable>
 		</disables>
 		<variations>
@@ -824,12 +798,6 @@
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -918,12 +886,6 @@
 				<platform>x86-64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/681</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -983,12 +945,6 @@
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
   			</disable>
-  			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/680</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1057,12 +1013,6 @@
 				<comment>Disabled on all platforms on 17 for backlog/issues/633 (intermittent machine issue). To be run manually</comment>
 				<version>17+</version>
 				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
 			</disable>
 		</disables>
 		<variations>
@@ -1136,12 +1086,6 @@
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
 				<platform>x86-64_mac</platform>
 				<impl>hotspot</impl>
-			</disable>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/679</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
 			</disable>
 		</disables>
 		<variations>


### PR DESCRIPTION
A total of 9 targets have been un-excluded for z/OS JDK 11 in this PR: 
- JDK11 z/OS AWT related segmentation error is resolved (backlog/issues/681). The related test, javax_imageio, now works : Grinder/20309. 
-  We don't need to set `jck.env.runtime.testExecute.otherEnvVars LIBPATH=/usr/lpp/tcpip/X11R66/lib` for z/OS. Removing this makes following targets to work on z/OS: java_applet, java_beans, javax_accessibility, javax_naming, javax_print, javax_sound (please see: Grinder/20330), javax_naming-spi (/Grinder/20334).  
- Fix in .gitattributes.zos file fixes  api-signaturetest (Grinder/20221). 

Re: backlog/issues/679

FYI @JasonFengJ9 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>