### PR TITLE
Update git workflows to use LTS JDK versions

### DIFF
--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: [8, 16]
+        version: [8, 17]
         build_list: ${{ fromJson(needs.getBuildLists.outputs.buildLists) }}
         impl: [hotspot, openj9]
     steps:


### PR DESCRIPTION
This patch updates the directoriesFilesChangePR.yml file to use the LTS version 17 rather than non-LTS version 16.

Fixes: #3156

Signed-off-by: Nadeen Mohamed <nadeen@ualberta.ca>