### PR TITLE
Re-enable tests excluded by issue 248 on jdk18

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -35,7 +35,6 @@ java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-openj9/openj9/issues/3178	generic-all
-java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
 java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
@@ -68,7 +67,6 @@ java/lang/String/concat/WithSecurityManager.java	https://github.com/eclipse-open
 java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse-openj9/openj9/issues/6666	generic-all
 java/lang/String/StringRepeat.java	https://github.com/eclipse-openj9/openj9/issues/6667	generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
-java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
 java/lang/StringBuilder/HugeCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
@@ -130,7 +128,6 @@ java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/op
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	macosx-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all

--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -48,10 +48,6 @@ java/beans/PropertyChangeSupport/Test4682386.java   https://github.com/adoptium/
 ############################################################################
 
 # jdk_lang
-java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
-java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
-vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	macosx-all
-java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/adoptium/temurin-build/issues/248 generic-all
 java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
@@ -204,7 +200,6 @@ com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://github.com/a
 ############################################################################
 
 # jdk_nio
-java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.com/adoptium/temurin-build/issues/248	generic-all
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593	linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
 java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all


### PR DESCRIPTION
Re-enabled tests excluded by https://github.com/adoptium/temurin-build/issues/248. Partial fix of: #3214

This patch re-enables JDK 18 test excluded by https://github.com/adoptium/temurin-build/issues/248.

## Hotspot
grinder https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/3184/testReport/
grinder (mac) https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/3168/testReport/
### `jdk_lang`
![image](https://user-images.githubusercontent.com/50028573/150645249-989f1d83-1109-45e3-a39b-943413e8be9d.png)
![image](https://user-images.githubusercontent.com/50028573/150645266-37b50a4f-d28a-4c73-ae7e-ca9c03c5b885.png)
![image](https://user-images.githubusercontent.com/50028573/150645283-b7ce442f-3610-405d-ac5d-372df912b711.png)
### `jdk_nio`
![image](https://user-images.githubusercontent.com/50028573/150645496-c613982f-db13-42ee-89c9-cfdc30444f1c.png)
### `jdk_tools` (wrongly categorized as `jdk_lang`; mac only)
![image](https://user-images.githubusercontent.com/50028573/150645321-82f5e71a-a916-4150-bb5b-efe1feb0abfa.png)

## OpenJ9
grinder (mac) https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/3180/testReport/
### `jdk_lang`
(`java/lang/ClassLoader/nativeLibrary/NativeLibraryTest` fails but executes. Same behavior for JDK11 on https://github.com/adoptium/aqa-tests/pull/3255)
![image](https://user-images.githubusercontent.com/50028573/150645530-cd6afda6-d583-4d85-a851-7088ae0e4f9e.png)
![image](https://user-images.githubusercontent.com/50028573/150645549-94278a64-711d-4cef-b09b-ad2e783ed070.png)
### `jdk_tools` (wrongly categorized as `jdk_lang`; mac only)
Cannot verify execution of `vm/JniInvocationTest` (for now) since `jdk_tools` is disabled on `openj9`.
`playlist.xml`:
```
		<testCaseName>jdk_tools</testCaseName>
		<disables>
			<disable>
				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
				<impl>openj9</impl>
			</disable>
```
