### PR TITLE
Re-enabling jdk17 tests that were excluded by issue 248

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -35,7 +35,6 @@ java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-openj9/openj9/issues/3178	generic-all
-java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
 java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
@@ -67,7 +66,6 @@ java/lang/String/concat/WithSecurityManager.java	https://github.com/eclipse-open
 java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse-openj9/openj9/issues/6666	generic-all
 java/lang/String/StringRepeat.java	https://github.com/eclipse-openj9/openj9/issues/6667	generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
-java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
 java/lang/StringBuilder/HugeCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
@@ -127,10 +125,8 @@ java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/a
 java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse-openj9/openj9/issues/7741	generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
-java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/adoptium/temurin-build/issues/248 generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	macosx-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -44,10 +44,6 @@ java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.j
 ############################################################################
 
 # jdk_lang
-java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
-java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
-vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	macosx-all
-java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/adoptium/temurin-build/issues/248 generic-all
 java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
@@ -151,7 +147,6 @@ com/sun/jdi/BreakpointTest.java https://bugs.openjdk.java.net/browse/JDK-8050470
 ############################################################################
 
 # jdk_nio
-java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.com/adoptium/temurin-build/issues/248	generic-all
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593	linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
 java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all


### PR DESCRIPTION
Fixes: #3214

re-try after eclipse foundation validation failure

Signed-off-by: Ying Zhou