### PR TITLE
Fixing triggerGrinder.groovy.

### DIFF
--- a/buildenv/jenkins/triggerGrinder.groovy
+++ b/buildenv/jenkins/triggerGrinder.groovy
@@ -1,38 +1,27 @@
 #!groovy
 
-def json_path = args.size() ? args[0] : "disabledTestParser/output.json."
+def json_path = args.size() ? args[0] : "disabledTestParser/output.json"
 def json = readJSON file: json_path
-def jenkins_url = "https://ci.adoptopenjdk.net/job/Grinder/buildWithParameters"
 
 /**
  This runs when we have found a job w/ git_issue_status = closed.
  Collects all parameters and runs grinder
  */
 def run_grinder(map) {
-  def list = []
+  def childParams = []
   def queryString
 
   map.each { k, v ->
-    list.add(k + "=" + v)
+    if (k!="ISSUE_TRACKER_STATUS" && k!="ISSUE_TRACKER") {
+        childParams << string(name: "${k}", value: "${v}")
+    }
   }
 
-  queryString = list.join("&")
-  url = jenkins_url + "/?" + queryString
+  for (e in childparams) {
+    println e
+  }
 
-  // The Grinder trigger will look something like this,
-  // but it requires tokens which I do not have yet.
-  // def url = new URL(jenkins_url + "/?" + queryString)
-  // def connection = url.openConnection()
-  // connection.with {
-  //     doOutput = true
-  //     requestMethod = 'POST'
-  //     outputStream.withWriter { writer ->
-  //         writer << queryString
-  //     }
-  //     println content.text
-  // }
-
-  println url
+  build job: Grinder, parameters: childParams, propagate: false
 }
 
 /**

--- a/disabledTestParser/output.json
+++ b/disabledTestParser/output.json
@@ -1,0 +1,20 @@
+[
+    {
+        "JDK_VERSION": 17,
+        "JDK_IMPL": "hotspot",
+        "TARGET": "jdk_custom",
+        "CUSTOM_TARGET": "java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java",
+        "ISSUE_TRACKER": "https://github.com/adoptium/temurin-build/issues/248",
+        "PLATFORM": "all",
+        "ISSUE_TRACKER_STATUS": "closed"
+    },
+    {
+        "JDK_VERSION": 16,
+        "JDK_IMPL": "openj9",
+        "TARGET": "jdk_custom",
+        "CUSTOM_TARGET": "java/lang/ClassLoader/Assert.java",
+        "ISSUE_TRACKER": "https://github.com/eclipse-openj9/openj9/issues/6668",
+        "PLATFORM": "x86-64_mac",
+        "ISSUE_TRACKER_STATUS": "open"
+    }
+]


### PR DESCRIPTION
The tests are now started without the use of URL.
Fixes adoptium/aqa-tests #2702. 

Signed-off-by: Abeer Waheed <amir2@ualberta.ca>