### PR TITLE
Remove separator and help text parameters from "Rerun in Grinder" link

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -945,8 +945,8 @@ def addGrinderLink() {
 	String url = "${HUDSON_URL}job/Grinder/parambuild/?"
 	int i = 1;
 	def labelValue = ""
-	List<String> separators = [
-	        'TEST_REPO_PARAMS',
+	List<String> separatorAndHelpParameterKeys = [
+			'TEST_REPO_PARAMS',
 			'TEST_REPO_PARAMS_HELP_TEXT',
 			'NON_AQA_TEST_REPOS',
 			'NON_AQA_TEST_REPOS_HELP_TEXT',
@@ -964,7 +964,7 @@ def addGrinderLink() {
 			'POST_RUN_PARAMS_HELP_TEXT'
 	]
 	params.findAll {
-		!separators.contains(it.key)
+		!separatorAndHelpParameterKeys.contains(it.key)
 	}.each { key, value ->
 		value = URLEncoder.encode(value.toString(), "UTF-8")
 		url += "${key}=${value}"

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -945,7 +945,27 @@ def addGrinderLink() {
 	String url = "${HUDSON_URL}job/Grinder/parambuild/?"
 	int i = 1;
 	def labelValue = ""
-	params.each { key, value ->
+	List<String> separators = [
+	        'TEST_REPO_PARAMS',
+			'TEST_REPO_PARAMS_HELP_TEXT',
+			'NON_AQA_TEST_REPOS',
+			'NON_AQA_TEST_REPOS_HELP_TEXT',
+			'PLATFORM_AND_MACHINE',
+			'PLATFORM_AND_MACHINE_HELP_TEXT',
+			'JDK_SELECTION_PARAMS',
+			'JDK_SELECTION_PARAMS_HELP_TEXT',
+			'TEST_SELECTION_PARAMS',
+			'TEST_SELECTION_PARAMS_HELP_TEXT',
+			'TEST_OPTIONS_PARAMS',
+			'TEST_OPTIONS_PARAMS_HELP_TEXT',
+			'TEST_PARALLELIZATION_PARAMS',
+			'TEST_PARALLELIZATION_PARAMS_HELP_TEXT',
+			'POST_RUN_PARAMS',
+			'POST_RUN_PARAMS_HELP_TEXT'
+	]
+	params.findAll {
+		!separators.contains(it.key)
+	}.each { key, value ->
 		value = URLEncoder.encode(value.toString(), "UTF-8")
 		url += "${key}=${value}"
 		if (i != params.size()) {

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -945,30 +945,14 @@ def addGrinderLink() {
 	String url = "${HUDSON_URL}job/Grinder/parambuild/?"
 	int i = 1;
 	def labelValue = ""
-	List<String> separatorAndHelpParameterKeys = [
-			'TEST_REPO_PARAMS',
-			'TEST_REPO_PARAMS_HELP_TEXT',
-			'NON_AQA_TEST_REPOS',
-			'NON_AQA_TEST_REPOS_HELP_TEXT',
-			'PLATFORM_AND_MACHINE',
-			'PLATFORM_AND_MACHINE_HELP_TEXT',
-			'JDK_SELECTION_PARAMS',
-			'JDK_SELECTION_PARAMS_HELP_TEXT',
-			'TEST_SELECTION_PARAMS',
-			'TEST_SELECTION_PARAMS_HELP_TEXT',
-			'TEST_OPTIONS_PARAMS',
-			'TEST_OPTIONS_PARAMS_HELP_TEXT',
-			'TEST_PARALLELIZATION_PARAMS',
-			'TEST_PARALLELIZATION_PARAMS_HELP_TEXT',
-			'POST_RUN_PARAMS',
-			'POST_RUN_PARAMS_HELP_TEXT'
-	]
-	params.findAll {
-		!separatorAndHelpParameterKeys.contains(it.key)
-	}.each { key, value ->
+	def urlParams = params.findAll {
+		// Exclude separator and help text parameters from url
+		!(it.key.endsWith('_PARAMS') || it.key.endsWith('_HELP_TEXT'))
+	}
+	urlParams.each { key, value ->
 		value = URLEncoder.encode(value.toString(), "UTF-8")
 		url += "${key}=${value}"
-		if (i != params.size()) {
+		if (i != urlParams.size()) {
 			url += "&amp;"
 		}
 		i++;

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -237,7 +237,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('JCK_GIT_REPO', ACTUAL_JCK_GIT_REPO, "For JCK test only")
 
 							parameterSeparatorDefinition {
-							    name('NON_AQA_TEST_REPOS')
+							    name('NON_AQA_TEST_REPOS_PARAMS')
 							    separatorStyle(separatorStyleCss)
 							    sectionHeader('Non-AQA Test Repositories')
 							    sectionHeaderStyle(sectionHeaderStyleCss)
@@ -255,7 +255,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('USER_CREDENTIALS_ID', USER_CREDENTIALS_ID, "Optional. User credential ID")
 
 							parameterSeparatorDefinition {
-							    name('PLATFORM_AND_MACHINE')
+							    name('PLATFORM_AND_MACHINE_PARAMS')
 							    separatorStyle(separatorStyleCss)
 							    sectionHeader('Platform and Machine Selection Parameters')
 							    sectionHeaderStyle(sectionHeaderStyleCss)


### PR DESCRIPTION
This resolves https://github.com/adoptium/aqa-tests/issues/2681 by filtering parameters based on a small convention in which parameters suffixed with `_PARAMS` or `_HELP_TEXT` represent separators and help text and thus are filtered out.

Diff of the "Rerun on Grinder" link from grinder 3195 (left; no change) to grinder 3223 (right; with change):
![image](https://user-images.githubusercontent.com/50028573/150657645-af8a38e6-c938-4ca2-a96b-40d7635b07b5.png)
