### PR TITLE
Clarify `PLATFORM=all` description

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -279,7 +279,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
                                 <br/>sparcv9_solaris
                                 <br/>riscv64_linux
                                 <br/>multiple platforms (comma separated values): x86-64_linux,x86-64_mac
-                                <br/>all platforms: all (actual platforms will change based on JDK_VERSION/JDK_IMPL)
+                                <br/>all platforms: all (this set actually excludes some secondary platforms and changes based on JDK_VERSION/JDK_IMPL selected)
                                 <br/>Please refer to PLATFORM_MAP in https://github.com/adoptium/aqa-tests/blob/master/buildenv/jenkins/openjdk_tests<br/>''')
 							stringParam('LABEL', "", "Jenkins node label to run on. Leave this blank for the default value specified in PLATFORM_MAP. Set to node name to run on a particular machine.")
 							stringParam('LABEL_ADDITION', "", "Additional label(s) to append to LABEL. Usually when you want to add a label to the default value.")

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -279,7 +279,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
                                 <br/>sparcv9_solaris
                                 <br/>riscv64_linux
                                 <br/>multiple platforms (comma separated values): x86-64_linux,x86-64_mac
-                                <br/>all platforms: all (this set actually excludes some secondary platforms and changes based on JDK_VERSION/JDK_IMPL selected)
+                                <br/>all platforms: all (this set actually excludes some secondary platforms and varies based on JDK_VERSION/JDK_IMPL selected)
                                 <br/>Please refer to PLATFORM_MAP in https://github.com/adoptium/aqa-tests/blob/master/buildenv/jenkins/openjdk_tests<br/>''')
 							stringParam('LABEL', "", "Jenkins node label to run on. Leave this blank for the default value specified in PLATFORM_MAP. Set to node name to run on a particular machine.")
 							stringParam('LABEL_ADDITION', "", "Additional label(s) to append to LABEL. Usually when you want to add a label to the default value.")


### PR DESCRIPTION
This resolves https://github.com/adoptium/aqa-tests/issues/2227 by clarifying the description of the `all` platform, notably pointing out how some secondary platforms are excluded and the selected JDK version also changes the platforms.

The "2nd part" of the issue does not apply anymore (no `_XL` platforms are included). See https://github.com/adoptium/aqa-tests/issues/2227#issuecomment-1019375666 for more details.