### PR TITLE
Exclude 2 vector tests on win32

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -324,12 +324,12 @@ jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests
 ###########################################################################
 
 #jdk_vector
-jdk/incubator/vector/Byte512VectorLoadStoreTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte512VectorLoadStoreTests.java	https://github.com/adoptium/aqa-tests/issues/2874 windows-x86,linux-arm
 jdk/incubator/vector/Byte64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/ByteMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/Int64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/IntMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/Byte256VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte256VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm,windows-x86
 jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/Short64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/ShortMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm


### PR DESCRIPTION

Excluding 2 vector tests on win -x86 -32 for jdk17
jdk/incubator/vector/Byte256VectorLoadStoreTests.java
jdk/incubator/vector/Byte512VectorLoadStoreTests.java

Fixes #3278 