### PR TITLE
Alpine Linux - additional steps to force headless only

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -485,7 +485,7 @@ public class JavaTestRunner {
 				robotAvailable = "Yes";
 			} else if (platform.contains("alpine-linux")) {
 				libPath = "LD_LIBRARY_PATH";
-				robotAvailable = "Yes";
+				robotAvailable = "No";
 				// Run only headless tests on Alpine Linux
 				keyword += "&!headful";
 			} else if (platform.contains("linux")) {
@@ -527,12 +527,10 @@ public class JavaTestRunner {
 			}
 
 			if ( testsRequireDisplay(tests) ) {
-				if (platform.equals("zos")) {
+				if (platform.equals("zos") || platform.equals("alpine-linux")) {
 					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
-				} else if (platform.equals("alpine-linux")) {
-					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
-					// fileContent += "set jck.env.testPlatform.xWindows No" + ";\n";
-				} else {
+				}
+				else {
 					if ( !platform.equals("win") ) {
 						fileContent += "set jck.env.testPlatform.headless No" + ";\n";
 						fileContent += "set jck.env.testPlatform.xWindows Yes" + ";\n";
@@ -651,7 +649,9 @@ public class JavaTestRunner {
 
 			// The jplisLivePhase and Robot available settings are rejected if placed higher up in the .jtb file
 			if ( tests.contains("api/java_awt") || tests.contains("api/javax_swing") || tests.equals("api") ) {
-				fileContent += "set jck.env.runtime.awt.robotAvailable " + robotAvailable + ";\n";
+				if ( robotAvailable == "Yes" ) {
+					fileContent += "set jck.env.runtime.awt.robotAvailable " + robotAvailable + ";\n";
+				}
 			}
 			if ( tests.equals("api/java_lang") || tests.contains("api/java_lang/instrument") || tests.equals("api") ) {
 				fileContent += "set jck.env.runtime.jplis.jplisLivePhase Yes;\n";

--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -529,8 +529,10 @@ public class JavaTestRunner {
 			if ( testsRequireDisplay(tests) ) {
 				if (platform.equals("zos")) {
 					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
-				}
-				else {
+				} else if (platform.equals("alpine-linux")) {
+					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
+					// fileContent += "set jck.env.testPlatform.xWindows No" + ";\n";
+				} else {
 					if ( !platform.equals("win") ) {
 						fileContent += "set jck.env.testPlatform.headless No" + ";\n";
 						fileContent += "set jck.env.testPlatform.xWindows Yes" + ";\n";


### PR DESCRIPTION
It seems that the awt and swing tests require this to be set for headless builds