### PR TITLE
Skip UI tests on aarch64_mac

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -371,7 +371,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac<</platform>
+				<platform>.*mac</platform>
   				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -416,7 +416,7 @@
 			</disable>
   			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac<</platform>
+				<platform>.*mac</platform>
 				<impl>hotspot</impl>
  			</disable>
 		</disables>
@@ -445,7 +445,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac<</platform>
+				<platform>.*mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
@@ -512,7 +512,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac<</platform>
+				<platform>.*mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -371,7 +371,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
   				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -416,7 +416,7 @@
 			</disable>
   			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
  			</disable>
 		</disables>
@@ -445,7 +445,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
@@ -512,7 +512,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -795,7 +795,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -942,7 +942,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
   			</disable>
 		</disables>
@@ -1001,7 +1001,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
@@ -1084,7 +1084,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -1127,7 +1127,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac</platform>
+				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -371,7 +371,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac.*<</platform>
+				<platform>.*mac<</platform>
   				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -416,7 +416,7 @@
 			</disable>
   			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac.*<</platform>
+				<platform>.*mac<</platform>
 				<impl>hotspot</impl>
  			</disable>
 		</disables>
@@ -445,7 +445,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac.*<</platform>
+				<platform>.*mac<</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
@@ -512,7 +512,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac.*<</platform>
+				<platform>.*mac<</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -795,7 +795,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac.*</platform>
+				<platform>.*mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -942,7 +942,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac.*</platform>
+				<platform>.*mac</platform>
 				<impl>hotspot</impl>
   			</disable>
 		</disables>
@@ -1001,7 +1001,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac.*</platform>
+				<platform>.*mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
@@ -1084,7 +1084,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac.*</platform>
+				<platform>.*mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -1127,7 +1127,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>.*mac.*</platform>
+				<platform>.*mac</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -371,7 +371,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>.*mac.*<</platform>
   				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -416,7 +416,7 @@
 			</disable>
   			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>.*mac.*<</platform>
 				<impl>hotspot</impl>
  			</disable>
 		</disables>
@@ -445,7 +445,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>.*mac.*<</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
@@ -512,7 +512,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>.*mac.*<</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -795,7 +795,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -942,7 +942,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
   			</disable>
 		</disables>
@@ -1001,7 +1001,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
@@ -1084,7 +1084,7 @@
 			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
@@ -1127,7 +1127,7 @@
 			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
+				<platform>.*mac.*</platform>
 				<impl>hotspot</impl>
 			</disable>
 			<disable>


### PR DESCRIPTION
This was originally implemented in https://github.com/adoptium/aqa-tests/pull/2886 but appears to have been lost in the recent refactor.