### PR TITLE
Re-enable GetCallerClassTests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -144,9 +144,7 @@ java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/
 # jdk_internal
 jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
-jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Re-enable GetCallerClassTests

Depends on https://github.com/eclipse-openj9/openj9/pull/14357

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>