### PR TITLE
Enable java_lang-invoke & serializabletypes on JDK 11 z/OS

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -64,14 +64,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-invoke</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/583</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1316,14 +1308,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-serializabletypes</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/667</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
Enable java_lang-invoke & serializabletypes on JDK 11 z/OS as they are now working after the .gitattributes.zos update for jdk 11 (test: Grinder/20344). 

Resolves: backlog/issues/667

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>