### PR TITLE
Revert "Setting customized sdk url and sdk resource as non customized ignores the sdk resource value #2097"

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -369,12 +369,11 @@ def setup() {
 
 			if (params.SDK_RESOURCE == 'nightly' && params.CUSTOMIZED_SDK_URL) {
 				CUSTOMIZED_SDK_URL_OPTION = "-c '${params.CUSTOMIZED_SDK_URL}'"
-			} else if (params.SDK_RESOURCE != 'customized'){
-				CUSTOMIZED_SDK_URL_OPTION = ""
 			} else if (params.CUSTOMIZED_SDK_URL) {
+				SDK_RESOURCE = "customized"
 				CUSTOMIZED_SDK_URL_OPTION = "-c '${params.CUSTOMIZED_SDK_URL}'"
 			} else {
-				error("For customized sdk resource, please provide the sdk url as CUSTOMIZED_SDK_URL")
+				CUSTOMIZED_SDK_URL_OPTION = ""
 			}
 			if (params.CUSTOMIZED_SDK_SOURCE_URL) {
 				SDK_RESOURCE = "customized"


### PR DESCRIPTION
This PR breaks openj9 test builds. This PR can only be delivered after we update both Adoptium and Openj9 upstream pipelines to set the correct `SDK_RESOURCE `.

Reverts adoptium/aqa-tests#3266