### PR TITLE
Unexclude ExceptionInClassInitialization.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -132,7 +132,6 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-te
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
-java/lang/reflect/classInitialization/ExceptionInClassInitialization.java https://github.com/eclipse-openj9/openj9/issues/14080 generic-all
 java/lang/reflect/MethodHandleAccessorsTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
 java/lang/reflect/MethodHandleAccessorsTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
 java/lang/reflect/IllegalArgumentsTest.java https://github.com/eclipse-openj9/openj9/issues/14084 generic-all


### PR DESCRIPTION
Original issue: eclipse-openj9/openj9#14080
Fixed by: eclipse-openj9/openj9#14352
Signed-off-by: Eric Yang <eric.yang@ibm.com>