### PR TITLE
Re-enable hidden frames related tests in JDK18

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -40,7 +40,6 @@ java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/open
 java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
-java/lang/StackTraceElement/WithClassLoaderName.java	https://github.com/eclipse-openj9/openj9/issues/14132	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all
 java/lang/StackWalker/DumpStackTest.java	https://github.com/eclipse-openj9/openj9/issues/6680	generic-all
@@ -112,7 +111,6 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java	https://github.co
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse-openj9/openj9/issues/7158	aix-all
-java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse-openj9/openj9/issues/3394	generic-all
 java/lang/ref/CleanerTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ref/EarlyTimeout.java	https://github.com/eclipse-openj9/openj9/issues/7225	generic-all
 java/lang/ref/FinalizeOverride.java	https://github.com/eclipse-openj9/openj9/issues/9651	generic-all
@@ -132,8 +130,6 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-te
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
-java/lang/reflect/MethodHandleAccessorsTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
-java/lang/reflect/MethodHandleAccessorsTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
 java/lang/reflect/IllegalArgumentsTest.java https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
 java/lang/System/AllowSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/14092 generic-all
 java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/openj9/issues/14094 generic-all


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/3627 Fixed:
- https://github.com/eclipse-openj9/openj9/issues/14132
- https://github.com/eclipse-openj9/openj9/issues/3394
- https://github.com/eclipse-openj9/openj9/issues/14084 (Also depends on
https://github.com/ibmruntimes/openj9-openjdk-jdk18/pull/12)

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>