### PR TITLE
Update logic to use Jenkins API to check node status

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -195,19 +195,20 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
                     node {
                         String[] onlineNodes = nodesByLabel(LABEL)
                         for (String onlineNode : onlineNodes) {
-                            def nodeStatus = sh(script: "curl -s ${env.JENKINS_URL}computer/${onlineNode}/api/xml?xpath=/*/idle",
-                                                returnStdout: true,
-                                                returnStatus: false
-                                                ).trim()
-                            if (nodeStatus.contains("true")) {
-                                isNodeIdle = true
-                                break
+                            def currentNode = Jenkins.instance.getNode(onlineNode).getComputer()
+                            if (!currentNode.isOffline()) {
+                                if (currentNode.countBusy() != 0) {
+                                    println "Found an idle node: ${onlineNode}. The program will not start dynamic vm."
+                                    isNodeIdle = true
+                                    break
+                                }
                             }
                         }
                     }
                     if (!isNodeIdle) {
-                       LABEL = LABEL.minus("ci.role.test&&")
-                       LABEL += '&&ci.agent.dynamic'
+                        println "Cannot find any idle nodes. Starting dynamic vm"
+                        LABEL = LABEL.minus("ci.role.test&&")
+                        LABEL += '&&ci.agent.dynamic'
                     }
                 }
             }


### PR DESCRIPTION
Due to permission issue, we cannot use URL to query Jenkins status.
Update logic to use Jenkins API to check node status.

Fixes: https://github.com/adoptium/aqa-tests/issues/3252
Signed-off-by: lanxia <lan_xia@ca.ibm.com>