### PR TITLE
(v0.8.0-release) Support zos for AQA releases (#3293)

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -9,10 +9,14 @@ else
     MAKE=make
 fi
 if [ $USE_TESTENV_PROPERTIES == true ]; then
+    testenv_file="./testenv/testenv.properties"
+    if [[ "$PLATFORM" == *"zos"* ]]; then
+        testenv_file="./testenv/testenv_zos.properties"
+    fi
     while read line; do
         export $line
-    done <./testenv/testenv.properties
-    if [ $JDK_IMPL == "openj9" ]; then
+    done <$testenv_file
+    if [ $JDK_IMPL == "openj9" ] || [ $JDK_IMPL == "ibm" ]; then
         repo=JDK${JDK_VERSION}_OPENJ9_REPO
         branch=JDK${JDK_VERSION}_OPENJ9_BRANCH
     else
@@ -25,8 +29,8 @@ if [ $USE_TESTENV_PROPERTIES == true ]; then
 
     export JDK_REPO=$repo2
     export JDK_BRANCH=$branch2
-    echo "Set values based on ./testenv/testenv.properties:"
-    cat ./testenv/testenv.properties
+    echo "Set values based on ${testenv_file}:"
+    cat $testenv_file
     echo ""
     echo "JDK_REPO=${JDK_REPO}"
     echo "JDK_BRANCH=${JDK_BRANCH}"

--- a/get.sh
+++ b/get.sh
@@ -666,7 +666,13 @@ checkOpenJ9RepoSHA()
 
 parseCommandLineArgs "$@"
 if [ "$USE_TESTENV_PROPERTIES" = true ]; then
-	source ./testenv/testenv.properties
+	if [[ "$PLATFORM" == *"zos"* ]]; then
+		echo "load ./testenv/testenv_zos.properties"
+		source ./testenv/testenv_zos.properties
+	else
+		echo "load ./testenv/testenv.properties"
+		source ./testenv/testenv.properties
+	fi
 else
 	> ./testenv/testenv.properties
 fi

--- a/testenv/testenv_zos.properties
+++ b/testenv/testenv_zos.properties
@@ -1,0 +1,12 @@
+TKG_REPO=git@github.com:adoptium/TKG.git
+TKG_BRANCH=master
+OPENJ9_REPO=git@github.com:eclipse-openj9/openj9.git
+OPENJ9_BRANCH=master
+STF_REPO=git@github.com:adoptium/STF.git
+STF_BRANCH=master
+OPENJ9_SYSTEMTEST_REPO=git@github.com:eclipse-openj9/openj9-systemtest.git
+OPENJ9_SYSTEMTEST_BRANCH=master
+ADOPTOPENJDK_SYSTEMTEST_REPO=git@github.com:adoptium/aqa-systemtest.git
+ADOPTOPENJDK_SYSTEMTEST_BRANCH=master
+JDK11_OPENJ9_REPO=git@github.ibm.com:runtimes/openj9-openjdk-jdk11-zos.git
+JDK11_OPENJ9_BRANCH=ibm-jdk11-jcldev

--- a/testenv/testenv_zos.properties
+++ b/testenv/testenv_zos.properties
@@ -9,4 +9,4 @@ OPENJ9_SYSTEMTEST_BRANCH=master
 ADOPTOPENJDK_SYSTEMTEST_REPO=git@github.com:adoptium/aqa-systemtest.git
 ADOPTOPENJDK_SYSTEMTEST_BRANCH=master
 JDK11_OPENJ9_REPO=git@github.ibm.com:runtimes/openj9-openjdk-jdk11-zos.git
-JDK11_OPENJ9_BRANCH=ibm-jdk11-jcldev
+JDK11_OPENJ9_BRANCH=ibm-jdk11-zOS-11.0.14


### PR DESCRIPTION
- cherry-pick: https://github.com/adoptium/aqa-tests/pull/3293
- Set JDK11_OPENJ9_BRANCH=ibm-jdk11-zOS-11.0.14

Signed-off-by: lanxia <lan_xia@ca.ibm.com>