### PR TITLE
Pass -Dfile.encoding=UTF-8 for z/OS

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -466,6 +466,10 @@ public class JavaTestRunner {
 			concurrency = Runtime.getRuntime().availableProcessors() + 1;
 			concurrencyString = String.valueOf(concurrency);
 		}
+		
+		if (platform.contains("zos")) {
+			extraJvmOptions += " -Dfile.encoding=UTF-8";
+		}
 
 		// Set the operating system as 'Windows' for Windows and 'other' for all other operating systems.
 		// If 'other' is specified when executing on Windows, then Windows specific settings such

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -275,14 +275,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang-Class</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/666</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -536,14 +528,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_lang</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/669</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -682,12 +666,6 @@
 				<platform>x86-64_windows|x86-32_windows</platform>
 				<version>17</version>
 				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/680</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
 			</disable>
 		</disables>
 		<variations>

--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -136,14 +136,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-vm-module</testCaseName>
-		<disables>
-			<disable>
-				<comment>Temporarily disabled on z/OS for backlog/issues/583</comment>
-				<platform>.*zos.*</platform>
-				<impl>ibm</impl>
-				<version>11</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
Pass `-Dfile.encoding=UTF-8` as extra argument while on z/OS. This resolves some encoding issues making the following targets green on z/OS: 

- jck-runtime-api-java_lang-Class
- jck-runtime-api-java_lang
- jck-runtime-api-java_security
- jck-runtime-vm-module

Partially resolves : backlog/issues/669, 680.

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>