### PR TITLE
Add sw.os.mac label for xmac and amac

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -7,7 +7,7 @@ def PLATFORM_MAP = [
     ],
     'aarch64_mac' : [
         'SPEC' : 'osx_aarch64',
-        'LABEL' : 'ci.role.test&&sw.os.osx&&hw.arch.aarch64',
+        'LABEL' : 'ci.role.test&&hw.arch.aarch64&&(sw.os.osx||sw.os.mac)',
     ],
     'aarch64_linux' : [
         'SPEC' : 'linux_aarch64',
@@ -89,7 +89,7 @@ def PLATFORM_MAP = [
     ],
     'x86-64_mac' : [
         'SPEC' : 'osx_x86-64',
-        'LABEL' : 'ci.role.test&&hw.arch.x86&&sw.os.osx',
+        'LABEL' : 'ci.role.test&&hw.arch.x86&&(sw.os.osx||sw.os.mac)',
     ],
     'x86-64_windows' : [
         'SPEC' : 'win_x86-64',


### PR DESCRIPTION
sw.os.osx is not as correct now so we should
migrate to sw.os.mac. A future change can remove
the orignal label once all farms are updated.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>