### PR TITLE
Use -Dfile.encoding=US-ASCII instead of UTF-8 for z/OS 

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -468,7 +468,7 @@ public class JavaTestRunner {
 		}
 		
 		if (platform.contains("zos")) {
-			extraJvmOptions += " -Dfile.encoding=UTF-8";
+			extraJvmOptions += " -Dfile.encoding=US-ASCII";
 		}
 
 		// Set the operating system as 'Windows' for Windows and 'other' for all other operating systems.


### PR DESCRIPTION
Switching to using `US-ASCII` instead of `UTF-8` for tck on z/OS , as suggested by @pshipton in backlog/issues/583. 

The encoding issues that were resolved after using UTF-8 stay resolved with US-ASCII also. So, assuming  

Test : Grinder/20580. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>