### PR TITLE
Map platforms from ProblemList to PLATFORM and support "all_{os}" format in Jenkins

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -113,15 +113,7 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
         PLATFORMS.each { PLATFORM ->
             JDK_VERSIONS.each { JDK_VERSION ->
                 JDK_IMPLS.each { JDK_IMPL ->
-                    def ACTUAL_PLATFORM = PLATFORM
-                    if (PLATFORM == "all") {
-                        ACTUAL_PLATFORM = "ppc64_aix,ppc64le_linux,s390x_linux,x86-64_linux,x86-64_mac,x86-64_windows"
-                        if (JDK_VERSION == "8"){
-                            ACTUAL_PLATFORM = ACTUAL_PLATFORM + ",x86-32_windows"
-                        } else {
-                            ACTUAL_PLATFORM = ACTUAL_PLATFORM + ",aarch64_linux"
-                        }
-                    }
+                    def ACTUAL_PLATFORM = resolvePlatform(PLATFORM, JDK_VERSION)
                     def childParams = []
                     // loop through all the params and change the parameters if needed
                     params.each { param ->
@@ -294,6 +286,31 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
     } else {
         assert false : "Cannot find key PLATFORM: ${params.PLATFORM} in PLATFORM_MAP: ${PLATFORM_MAP}."
     }
+}
+
+private String resolvePlatform(PLATFORM, JDK_VERSION) {
+    println "RESOLVING PLATFORM=$PLATFORM JDK_VERSION=$JDK_VERSION"
+    List<String> all_platforms = ["ppc64_aix", "ppc64le_linux", "s390x_linux", "x86-64_linux", "x86-64_mac", "x86-64_windows"]
+    if (JDK_VERSION == "8") {
+        all_platforms <<= "x86-32_windows"
+    } else {
+        all_platforms <<= "aarch64_linux"
+    }
+
+    if (PLATFORM == "all") {
+        return all_platforms.join(",")
+    }
+
+    // if platform matches "all_{os}" pattern, return all platforms of that OS
+    def match = PLATFORM =~ /(?i)all_(?<os>\w+)/
+    if (match && match.groupCount() > 0) {
+        String matched_os = match.group("os")
+        println "matched_os=$matched_os"
+        return all_platforms.findAll { it.contains(matched_os) }.join(",")
+    }
+
+    // otherwise, return the platform we received as input (no expansion needed)
+    return PLATFORM
 }
 
 def areNodesWithLabelOnline(labelToCheck) {

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -105,7 +105,7 @@ def JDK_VERSIONS = params.JDK_VERSION.trim().split("\\s*,\\s*");
 def JDK_IMPLS = params.JDK_IMPL.trim().split("\\s*,\\s*");
 
 // if multiple JDK_VERSION / JDK_IMPL / PLATFORM are provided, run test jobs in parallel
-if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PLATFORMS.contains("all")) {
+if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PLATFORMS.any { it.contains("all") }) {
     if (SDK_RESOURCE != 'nightly' && SDK_RESOURCE != 'releases') {
         assert false : "Multiple Grinders should run with SDK_RESOURCE=nightly or releases."
     } else {

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -267,6 +267,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
 							stringParam('PLATFORM', "${ARCH_OS}", '''Platform to be tested:
+                                <br/>arm_linux
                                 <br/>aarch64_linux
                                 <br/>ppc64_aix
                                 <br/>ppc64le_linux
@@ -280,6 +281,11 @@ ARCH_OS_LIST.each { ARCH_OS ->
                                 <br/>riscv64_linux
                                 <br/>multiple platforms (comma separated values): x86-64_linux,x86-64_mac
                                 <br/>all platforms: all (this set actually excludes some secondary platforms and varies based on JDK_VERSION/JDK_IMPL selected)
+                                <br/>all OS-constrained platforms (only platforms already supported by "all" can be executed):
+                                <br/>all_linux
+                                <br/>all_mac
+                                <br/>all_windows
+                                <br/>all_aix
                                 <br/>Please refer to PLATFORM_MAP in https://github.com/adoptium/aqa-tests/blob/master/buildenv/jenkins/openjdk_tests<br/>''')
 							stringParam('LABEL', "", "Jenkins node label to run on. Leave this blank for the default value specified in PLATFORM_MAP. Set to node name to run on a particular machine.")
 							stringParam('LABEL_ADDITION', "", "Additional label(s) to append to LABEL. Usually when you want to add a label to the default value.")

--- a/disabledTestParser/generateDisabledTestListJson.py
+++ b/disabledTestParser/generateDisabledTestListJson.py
@@ -87,7 +87,6 @@ def resolve_platform(platform_string, line_number, exclude_list_file):
         else:
             revolved_platform_list.append(transform_platform(plat))
 
-    # flatten list of lists of lists to a set of unique values
     resolved_platforms = set(revolved_platform_list)
     return ','.join(resolved_platforms)
 

--- a/disabledTestParser/generateDisabledTestListJson.py
+++ b/disabledTestParser/generateDisabledTestListJson.py
@@ -1,30 +1,58 @@
-import itertools
 import os
 import json
 import argparse
 import re
+import logging
 
-platform_map = {
-    "linux-aarch64": ["aarch64_linux"],
-    "linux-ppc64le": ["ppc64le_linux"],
-    "linux-arm": ["arm_linux"],
-    "linux-s390x": ["s390x_linux"],
-    "linux-x64": ["x86-64_linux"],
-    "macosx-x64": ["x86-64_mac", "aarch64_mac"],
-    "windows-x64": ["x86-64_windows"],
-    "x86-64_windows": ["x86-64_windows"],
-    "windows-x86": ["x86-32_windows"],
-    "z/OS-s390x": ["s390x_zos"],
+logging.basicConfig(
+    format="%(levelname)s - %(message)s"
+)
+LOG = logging.getLogger()
 
-    "linux-ppc32": ["ppc32_linux"],
-    "linux-ppc64": ["ppc64_linux"],
-    "linux-riscv64": ["riscv64_linux"],
-    "linux-s390": ["s390_linux"],
-    "solaris-sparcv9": ["sparcv9_solaris"],
-    "solaris-x86-64": ["x86-64_solaris"],
-    "alpine-linux-x86-64": ["x86-64_alpine-linux"],
-    "linux-x86-32": ["x86-32_linux"]
+OS_EXCEPTIONS = {
+    "macosx": "mac",
+    "z/os": "zos",
+    "sunos": "solaris",
 }
+
+ARCH_EXCEPTIONS = {
+    "x64": "x86-64",
+    "x86": "x86-32",
+}
+
+
+def transform_platform(os_arch_platform: str) -> str:
+    """
+    Transforms an "os-arch"-formatted platform into
+    an "arch_os"-formatted platform, suitable for consumption by Jenkins.
+
+    :param os_arch_platform: the "os-arch"-formatted platform
+    :return: a Jenkins-suitable platform name
+    """
+
+    # only deal in lower case
+    os_arch_platform = os_arch_platform.lower()
+
+    # split over a dash
+    # EXCEPT if it is preceded by "x86" (because of "x86-32" and "x86-64")
+    # or if it is preceded by "alpine" (because of linux distros like "alpine-linux")
+    split_pattern = re.compile(r"(?<!x86)(?<!alpine)-")
+    split_list = split_pattern.split(os_arch_platform)
+
+    if len(split_list) != 2:
+        raise ValueError(f"Cannot split {os_arch_platform!r} over regex pattern {split_pattern.pattern!r}")
+
+    os_name, arch_name = split_list
+
+    # rename OS if needed
+    if os_name in OS_EXCEPTIONS:
+        os_name = OS_EXCEPTIONS[os_name]
+
+    # rename Arch if needed
+    if arch_name in ARCH_EXCEPTIONS:
+        arch_name = ARCH_EXCEPTIONS[arch_name]
+
+    return f"{arch_name}_{os_name}"
 
 
 def get_jdk_version_and_impl(exclude_list_file):
@@ -42,42 +70,35 @@ def get_jdk_version_and_impl(exclude_list_file):
 def get_tests_from_exclude_file(exclude_list_file):
     # 'exclude tests' are lines that are not empty AND do not start with #
     with open(exclude_list_file, mode='r') as f:
-        return [line for line in f.readlines() if line.strip() not in '' and not line.strip().startswith("#")]
+        return [(ln_num, line) for ln_num, line in enumerate(f.readlines(), 1) if line.strip() not in '' and not line.strip().startswith("#")]
 
 
-def resolve_platform(platform_string):
+def resolve_platform(platform_string, line_number, exclude_list_file):
     revolved_platform_list = []
-    list_of_unresolved_platform_names = [s.strip() for s in platform_string.split(",") if s.strip() not in '']
-    for unresolved_platform_name in list_of_unresolved_platform_names:
-        if unresolved_platform_name == "generic-all":
+    list_of_unresolved_platform_names = [s.strip() for s in platform_string.split(",") if s.strip()]
+    for plat in list_of_unresolved_platform_names:
+        if plat == "generic-all":
             return "all"
-        elif unresolved_platform_name == "linux-all":
-            revolved_platform_list.append([platform_map[s] for s in platform_map.keys() if "linux" in s])
-        elif unresolved_platform_name == "macosx-all":
-            revolved_platform_list.append([platform_map[s] for s in platform_map.keys() if "macosx" in s])
-        elif unresolved_platform_name == "windows-all":
-            revolved_platform_list.append([platform_map[s] for s in platform_map.keys() if "windows" in s])
-        elif unresolved_platform_name == "aix-all":
-            revolved_platform_list.append([["ppc32_aix", "ppc64_aix"]])
-        else:
-            if unresolved_platform_name not in platform_map:
-                print(f"Could not resolve the '{unresolved_platform_name}' to any of the valid platform names")
-                exit(3)
 
-            revolved_platform_list.append([platform_map[unresolved_platform_name]])
+        if "_" in plat:
+            LOG.warning(f'{exclude_list_file}:{line_number} : '
+                        f'assuming {plat!r} already formatted to ARCH_OS; continuing without transformation')
+            revolved_platform_list.append(plat)
+        else:
+            revolved_platform_list.append(transform_platform(plat))
 
     # flatten list of lists of lists to a set of unique values
-    resolved_platforms = set(itertools.chain(*itertools.chain(*revolved_platform_list)))
+    resolved_platforms = set(revolved_platform_list)
     return ','.join(resolved_platforms)
 
 
-def get_test_details(test):
+def get_test_details(test, line_number, exclude_list_file):
     test_details_dict = {}
-    test_tokens = test.split()
+    test_tokens = test.split(maxsplit=2)  # platform list may include spaces; split from the left 2 times max
     test_details_dict["TARGET"] = "jdk_custom"
     test_details_dict["CUSTOM_TARGET"] = test_tokens[0]
     test_details_dict["ISSUE_TRACKER"] = test_tokens[1]
-    test_details_dict["PLATFORM"] = resolve_platform(test_tokens[2])
+    test_details_dict["PLATFORM"] = resolve_platform(test_tokens[2], line_number, exclude_list_file)
     return test_details_dict
 
 
@@ -107,8 +128,8 @@ def main():
     for exclude_list_file in os.listdir(exclude_dir):
         test_list = get_tests_from_exclude_file(os.path.join(exclude_dir, exclude_list_file))
         if len(test_list) > 0:
-            for test in test_list:
-                test_details = get_test_details(test)
+            for line_number, test in test_list:
+                test_details = get_test_details(test, line_number, exclude_list_file)
                 test_details["JDK_VERSION"], test_details["JDK_IMPL"] = get_jdk_version_and_impl(exclude_list_file)
                 problem_list_details.append(test_details)
 

--- a/disabledTestParser/test_generateDisabledTestListJson.py
+++ b/disabledTestParser/test_generateDisabledTestListJson.py
@@ -20,6 +20,9 @@ platform_map = {
     "solaris-x86-64": "x86-64_solaris",
     "alpine-linux-x86-64": "x86-64_alpine-linux",
     "linux-x86-32": "x86-32_linux",
+
+    "linux-all": "all_linux",
+    "macosx-all": "all_mac",
 }
 
 
@@ -27,7 +30,3 @@ class Test(TestCase):
     def test_transform_platform_with_map(self):
         for k, v in platform_map.items():
             self.assertEqual(transform_platform(k), v)
-
-    def test_transform_platform_raises_on_arch_all(self):
-        self.assertRaises()
-

--- a/disabledTestParser/test_generateDisabledTestListJson.py
+++ b/disabledTestParser/test_generateDisabledTestListJson.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+
+from generateDisabledTestListJson import transform_platform
+
+platform_map = {
+    "linux-aarch64": "aarch64_linux",
+    "linux-ppc64le": "ppc64le_linux",
+    "linux-arm": "arm_linux",
+    "linux-s390x": "s390x_linux",
+    "linux-x64": "x86-64_linux",
+    "macosx-x64": "x86-64_mac",
+    "windows-x64": "x86-64_windows",
+    "windows-x86": "x86-32_windows",
+    "z/OS-s390x": "s390x_zos",
+    "linux-ppc32": "ppc32_linux",
+    "linux-ppc64": "ppc64_linux",
+    "linux-riscv64": "riscv64_linux",
+    "linux-s390": "s390_linux",
+    "solaris-sparcv9": "sparcv9_solaris",
+    "solaris-x86-64": "x86-64_solaris",
+    "alpine-linux-x86-64": "x86-64_alpine-linux",
+    "linux-x86-32": "x86-32_linux",
+}
+
+
+class Test(TestCase):
+    def test_transform_platform_with_map(self):
+        for k, v in platform_map.items():
+            self.assertEqual(transform_platform(k), v)
+
+    def test_transform_platform_raises_on_arch_all(self):
+        self.assertRaises()
+


### PR DESCRIPTION
Map platforms from ProblemList to PLATFORM and support "all_{os}" format in Jenkins

Dynamically map platforms from the `ProblemList` exclude files to the `PLATFORM` parameter in Jenkins. In addition, support "all_{os}" format in Jenkins, since we do not have a list to filter through anymore in the Python script.

Fixes https://github.com/adoptium/aqa-tests/issues/2910

### Notes
- When a platform in a `ProblemList` file contains an underscore, the platform is considered to be correctly formatted and a warning is logged in the following format:
```
WARNING - ProblemList_openjdk18.txt:403 : assuming 'ppc64le_linux' already formatted to ARCH_OS; continuing without transformation
WARNING - ProblemList_openjdk18.txt:178 : assuming 'win_64' already formatted to ARCH_OS; continuing without transformation
```
- Platforms of the form `{os}-all` in a `ProblemList` file get mapped to `all_{os}` and are then handled by Jenkins, similarly to when using PLATFORM=all

### JSON output sample
```json
[
    {
        "TARGET": "jdk_custom",
        "CUSTOM_TARGET": "java/lang/ProcessBuilder/Basic.java#id0",
        "ISSUE_TRACKER": "https://github.com/eclipse-openj9/openj9/issues/9032",
        "PLATFORM": "ppc64le_linux,aarch64_linux,all_aix",
        "JDK_VERSION": "11",
        "JDK_IMPL": "openj9"
    },
    {
        "TARGET": "jdk_custom",
        "CUSTOM_TARGET": "java/lang/ProcessBuilder/Basic.java#id1",
        "ISSUE_TRACKER": "https://github.com/eclipse-openj9/openj9/issues/9032",
        "PLATFORM": "ppc64le_linux,aarch64_linux",
        "JDK_VERSION": "11",
        "JDK_IMPL": "openj9"
    },
    {
        "TARGET": "jdk_custom",
        "CUSTOM_TARGET": "java/lang/ProcessBuilder/SkipTest.java",
        "ISSUE_TRACKER": "https://github.com/eclipse-openj9/openj9/issues/4124",
        "PLATFORM": "all_windows",
        "JDK_VERSION": "17",
        "JDK_IMPL": "openj9"
    },
    {
        "TARGET": "jdk_custom",
        "CUSTOM_TARGET": "java/lang/StackTraceElement/PublicConstructor.java",
        "ISSUE_TRACKER": "https://github.com/eclipse-openj9/openj9/issues/6659",
        "PLATFORM": "all",
        "JDK_VERSION": "17",
        "JDK_IMPL": "openj9"
    },
]
```

### Grinder test pipelines
PLATFORM="all", JDK_VERSION=8, JDK_IMPL=hotspot
Same behavior as before
![all_jdk8_hs](https://user-images.githubusercontent.com/50028573/152456186-3ed2745d-29eb-4910-9248-c6b1339ea446.png)
---
PLATFORM="all_windows", JDK_VERSION=8, JDK_IMPL=hotspot
Notice the inclusion of "x86-32_windows"
![all_windows_jdk8_hs](https://user-images.githubusercontent.com/50028573/152456266-3857538c-4386-47cb-a47e-04ff2680fa73.png)
---
PLATFORM="all_mac", JDK_VERSION=18, JDK_IMPL=hotspot
(different screenshot because only a single child job triggered)
![all_mac_jdk18_hs](https://user-images.githubusercontent.com/50028573/152456235-f436a84d-b858-4275-b9ea-e7a4639bae67.png)
---
PLATFORM="all_linux", JDK_VERSION=11, JDK_IMPL=openj9
Notice the inclusion of "aarch64_linux"
![all_linux_jdk11_j9](https://user-images.githubusercontent.com/50028573/152456218-36bb7ed1-f486-43f6-9033-5381148d43f6.png)
---
PLATFORM="all_aix", JDK_VERSION=11, JDK_IMPL=openj9
(different screenshot because only a single child job triggered)
![all_aix_jdk11_j9](https://user-images.githubusercontent.com/50028573/152456141-a4035fa9-c676-49da-b7eb-586fe3d2d856.png)
---
PLATFORM="all_windows,all_linux", JDK_VERSION="8,11", JDK_IMPL=hotspot
Parent job
![top_level](https://user-images.githubusercontent.com/50028573/152456658-e4027d65-3535-45b1-9359-be0f099ab57a.png)
Windows, JDK 8 child
Notice again the inclusion of "x86-32_windows"
![win_jdk8](https://user-images.githubusercontent.com/50028573/152456677-6c71649d-c133-4127-9a16-bee783b11eb6.png)
Windows, JDK 11 child
![win_11](https://user-images.githubusercontent.com/50028573/152456713-7f79cf46-7539-41df-a8f6-04043fdc034e.png)
Linux, JDK 8 child
![linux_8](https://user-images.githubusercontent.com/50028573/152456726-ea99908d-b21e-4a50-90a8-fecf78f53a5b.png)
Linux, JDK 11 child
![linux_11](https://user-images.githubusercontent.com/50028573/152456737-ff237d8c-f097-4e66-be44-af4baa5f8727.png)
---