### PR TITLE
[JDK18] Re-enable Security Manager Tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -131,8 +131,6 @@ java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java ht
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
 java/lang/reflect/IllegalArgumentsTest.java https://github.com/eclipse-openj9/openj9/issues/14084 generic-all
-java/lang/System/AllowSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/14092 generic-all
-java/lang/System/SecurityManagerWarnings.java https://github.com/eclipse-openj9/openj9/issues/14094 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The below tests have been fixed by eclipse-openj9/openj9#14329:
- `java/lang/System/AllowSecurityManager`
- `java/lang/System/SecurityManagerWarnings`

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>