### PR TITLE
Undo excludes for openjdk-build#893

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -114,15 +114,6 @@ java/net/SocketPermission/Wildcard.java	https://github.com/adoptium/aqa-tests/is
 java/net/Socks/SocksV4Test.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
 java/net/URL/OpenStream.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
 java/net/httpclient/ConnectExceptionTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/httpclient/AsFileDownloadTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/InvalidInputStreamSubscriptionRequest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/StreamingBody.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/http2/ContinuationFrameTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/SpecialHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/http2/BadHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/DigestEchoClientSSL.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/ResponseBodyBeforeError.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/ResponsePublisher.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
 java/net/ipv6tests/B6521014.java	https://github.com/adoptium/aqa-tests/issues/1524	macosx-all
 sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/adoptium/aqa-tests/issues/760 windows-all
 com/sun/net/httpserver/bugs/B6361557.java	https://github.com/adoptium/aqa-tests/issues/1272	windows-all


### PR DESCRIPTION
Removal of the excludes made via the issue https://github.com/adoptium/temurin-build/issues/893.

This had excluded the test case changed in 11.0.14.1 on Linux platforms, but a fix appears to have gone into 11.0.7 so we can re-enable. I've verified the individual SpecialHeaders test case on xLinux and it passes - I'm running the whole of java_net with this exclusion and expect them to pass too, so I'm submitting this PR.

I'll look at a separate PR for 17+ later, but I haven't verified those yet.

Signed-off-by: Stewart X Addison <sxa@redhat.com>