### PR TITLE
Unexclude SpliteratorTraversingAndSplittingTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -311,7 +311,6 @@ java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tes
 java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all
 java/util/Random/RandomTestChiSquared.java	https://github.com/eclipse-openj9/openj9/issues/13202	generic-all
 java/util/Random/RandomTestBsi1999.java		https://github.com/eclipse-openj9/openj9/issues/13202	generic-all
-java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java https://github.com/eclipse-openj9/openj9/issues/14178 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Original issue: eclipse-openj9/openj9#14178
Fixed by: eclipse-openj9/openj9#14430
Signed-off-by: Eric Yang <eric.yang@ibm.com>