### PR TITLE
Remove EXTRA_OPTIONS parameter

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -362,7 +362,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
 							choiceParam('TEST_FLAG', ['', 'JITAAS', 'AOT'], "Optional. Only set to JITAAS/AOT for JITAAS/AOT feature testing.")
-							stringParam('EXTRA_OPTIONS', EXTRA_OPTIONS, "Use this to append options to the test command")
+							stringParam('EXTRA_OPTIONS', "", "Use this to append options to the test command")
 							stringParam('JVM_OPTIONS', "", "Use this to replace the test original command line options")
 							stringParam('BUILD_IDENTIFIER', "", "build identifier")
 							stringParam('ITERATIONS',"1", '''Optional. Number of times to repeat execution of make target. <br/>


### PR DESCRIPTION
https://github.com/adoptium/aqa-tests/pull/3309 removed EXTRA_OPTIONS, but it missed the some reference.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>