### PR TITLE
Port RI excludes for AIX encoding tests to OpenJ9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -132,6 +132,8 @@ java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adopt
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/eclipse-openj9/openj9/issues/14441	aix-all
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14397 macosx-all
+java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
+java/lang/System/FileEncodingTest.java  https://github.com/adoptium/aqa-tests/issues/1267   aix-ppc64
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -132,6 +132,8 @@ java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adopt
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/eclipse-openj9/openj9/issues/14441	aix-all
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14397 macosx-all
+java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
+java/lang/System/FileEncodingTest.java  https://github.com/adoptium/aqa-tests/issues/1267   aix-ppc64
 
 ############################################################################
 


### PR DESCRIPTION
```
java/lang/ProcessBuilder/Basic.java
java/lang/System/FileEncodingTest.java
```

related https://github.com/eclipse-openj9/openj9/issues/14472 https://github.com/eclipse-openj9/openj9/issues/14473 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>