### PR TITLE
Add JVM_OPTIONS parameter to perf tests playlist.xml

### DIFF
--- a/perf/bumbleBench/playlist.xml
+++ b/perf/bumbleBench/playlist.xml
@@ -16,7 +16,7 @@
 	<!-- Collections Benchmarks -->
 	<test>
 		<testCaseName>bumbleBench-ArrayListForEachConsumerAnonymousBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachConsumerAnonymousBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachConsumerAnonymousBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -27,7 +27,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-ArrayListForEachConsumerFinalBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachConsumerFinalBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachConsumerFinalBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -38,7 +38,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-ArrayListForEachLambdaBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachLambdaBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachLambdaBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -49,7 +49,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-ArrayListForEachTradBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachTradBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListForEachTradBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -60,7 +60,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-ArrayListRemoveIfLambdaBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListRemoveIfLambdaBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListRemoveIfLambdaBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -71,7 +71,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-ArrayListRemoveIfTradBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListRemoveIfTradBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListRemoveIfTradBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -82,7 +82,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-ArrayListSortCollectionsBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListSortCollectionsBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListSortCollectionsBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -93,7 +93,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-ArrayListSortComparatorBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListSortComparatorBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListSortComparatorBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -104,7 +104,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-ArrayListSortLambdaBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListSortLambdaBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ArrayListSortLambdaBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -115,7 +115,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-HashMapForEachBiConsumerAnonymousBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachBiConsumerAnonymousBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachBiConsumerAnonymousBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -126,7 +126,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-HashMapForEachBiConsumerFinalBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachBiConsumerFinalBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachBiConsumerFinalBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -137,7 +137,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-HashMapForEachLambdaBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachLambdaBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachLambdaBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -148,7 +148,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-HashMapForEachTradBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachTradBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapForEachTradBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -159,7 +159,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-HashMapReplaceAllLambdaBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapReplaceAllLambdaBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapReplaceAllLambdaBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -170,7 +170,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-HashMapReplaceAllTradBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapReplaceAllTradBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HashMapReplaceAllTradBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -182,7 +182,7 @@
 	<!-- Crypto Benchmarks -->
 	<test>
 		<testCaseName>bumbleBench-CipherBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar CipherBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar CipherBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -198,7 +198,7 @@
 				<comment>https://github.com/adoptium/bumblebench/issues/19</comment>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DigestBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DigestBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -209,7 +209,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-EllipticCurveBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar EllipticCurveBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar EllipticCurveBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -220,7 +220,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-GCMBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GCMBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GCMBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -236,7 +236,7 @@
 				<comment>https://github.com/adoptium/bumblebench/issues/19</comment>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HMACBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar HMACBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -247,7 +247,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-KeyExchangeBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar KeyExchangeBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar KeyExchangeBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -258,7 +258,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-RSABench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar RSABench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar RSABench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -269,7 +269,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-SignatureBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SignatureBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SignatureBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -285,7 +285,7 @@
 				<comment>https://github.com/adoptium/bumblebench/issues/18</comment>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SSLSocketBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SSLSocketBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -297,7 +297,7 @@
 	<!-- GPU Benchmarks -->
 	<test>
 		<testCaseName>bumbleBench-BitonicBench-CPU</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar BitonicBench.CPU; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar BitonicBench.CPU; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -308,7 +308,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-BitonicBench-GPULambda</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar BitonicBench.GPULambda; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar BitonicBench.GPULambda; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -319,7 +319,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-DoitgenBench-CPU</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DoitgenBench.CPU; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DoitgenBench.CPU; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -330,7 +330,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-DoitgenBench-GPULambda</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DoitgenBench.GPULambda; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DoitgenBench.GPULambda; \
 		$(TEST_STATUS)</command>
 		<impls>
 			<impl>openj9</impl>
@@ -345,7 +345,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-KmeansBench-CPU</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar KmeansBench.CPU; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar KmeansBench.CPU; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -356,7 +356,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-KmeansBench-GPULambda</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar KmeansBench.GPULambda; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar KmeansBench.GPULambda; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -367,7 +367,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-MatMultBench-CPU</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar MatMultBench.CPU; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar MatMultBench.CPU; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -378,7 +378,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-MatMultBench-GPULambda</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar MatMultBench.GPULambda; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar MatMultBench.GPULambda; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -390,7 +390,7 @@
 	<!-- Humble Benchmarks -->
 	<test>
 		<testCaseName>bumbleBench-DistinctStringsEqualsBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DistinctStringsEqualsBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DistinctStringsEqualsBench; \
 		$(TEST_STATUS)</command>
 		<impls>
 			<impl>openj9</impl>
@@ -405,7 +405,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-NewStringBufferWithCapacityBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar NewStringBufferWithCapacityBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar NewStringBufferWithCapacityBench; \
 		$(TEST_STATUS)</command>
 		<impls>
 			<impl>openj9</impl>
@@ -420,7 +420,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-NewStringBuilderWithCapacityBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar NewStringBuilderWithCapacityBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar NewStringBuilderWithCapacityBench; \
 		$(TEST_STATUS)</command>
 		<impls>
 			<impl>openj9</impl>
@@ -435,7 +435,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-SameStringsEqualsBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SameStringsEqualsBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SameStringsEqualsBench; \
 		$(TEST_STATUS)</command>
 		<impls>
 			<impl>openj9</impl>
@@ -451,7 +451,7 @@
 	<!-- Lambda Benchmarks -->
 	<test>
 		<testCaseName>bumbleBench-DispatchBench-InnerClasses</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DispatchBench.InnerClasses; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar DispatchBench.InnerClasses; \
 		$(TEST_STATUS)</command>
 		<impls>
 			<impl>openj9</impl>
@@ -466,7 +466,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-FibBench-Vanilla</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.Vanilla; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.Vanilla; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -477,7 +477,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-FibBench-InnerClass</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.InnerClass; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.InnerClass; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -488,7 +488,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-FibBench-Lambda</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.Lambda; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.Lambda; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -499,7 +499,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-FibBench-LocalLambda</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.LocalLambda; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.LocalLambda; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -510,7 +510,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-FibBench-DynamicLambda</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.DynamicLambda; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.DynamicLambda; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -521,7 +521,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-FibBench-LocalMethodReferences</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.LocalMethodReferences; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar FibBench.LocalMethodReferences; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -532,7 +532,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-GroupingBench-Serial</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GroupingBench.Serial; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GroupingBench.Serial; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -543,7 +543,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-GroupingBench-Parallel</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GroupingBench.Parallel; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar GroupingBench.Parallel; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -554,7 +554,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-SieveBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SieveBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SieveBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -566,7 +566,7 @@
 	<!-- Math Benchmarks -->
 	<test>
 		<testCaseName>bumbleBench-ExactBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ExactBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar ExactBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -577,7 +577,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-SIMDDoubleMaxMinBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SIMDDoubleMaxMinBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar SIMDDoubleMaxMinBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -589,7 +589,7 @@
 	<!-- String Benchmarks -->
 	<test>
 		<testCaseName>bumbleBench-StringConversionBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringConversionBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringConversionBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -600,7 +600,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-StringHashBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringHashBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringHashBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -611,7 +611,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-StringIndexOfBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringIndexOfBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringIndexOfBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -622,7 +622,7 @@
 	</test>
 	<test>
 		<testCaseName>bumbleBench-StringIndexOfStringBench</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringIndexOfStringBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(TEST_RESROOT)/bumblebench/BumbleBench.jar StringIndexOfStringBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<test>
 		<testCaseName>dacapo-eclipse</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) eclipse; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) eclipse; \
 		$(TEST_STATUS)</command>
 		<versions>
 			<version>8</version>
@@ -29,7 +29,7 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-avrora</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) avrora; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) avrora; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -40,7 +40,7 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-fop</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) fop; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) fop; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -51,7 +51,7 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-h2</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) h2; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) h2; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -69,7 +69,7 @@
 				<impl>openj9</impl>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) jython; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) jython; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -80,7 +80,7 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-luindex</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) luindex; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) luindex; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -96,7 +96,7 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/1888#issuecomment-755015959</comment>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) lusearch-fix; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) lusearch-fix; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -107,7 +107,7 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-pmd</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) pmd; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) pmd; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -118,7 +118,7 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-sunflow</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) sunflow; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) sunflow; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -134,7 +134,7 @@
 				<comment>https://bugs.openjdk.java.net/browse/JDK-8155588</comment>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) tomcat; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) tomcat; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -145,7 +145,7 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-xalan</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) xalan; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) xalan; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -21,7 +21,7 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/1994#issuecomment-705633262</comment>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)akka-uct.json$(Q) akka-uct; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)akka-uct.json$(Q) akka-uct; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -38,7 +38,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -55,7 +55,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -76,7 +76,7 @@
 				<platform>^((?!(x86-64_linux|x86-64_mac|x86-64_windows)).)*$</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)db-shootout.json$(Q) db-shootout; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)db-shootout.json$(Q) db-shootout; \
 		$(TEST_STATUS)</command>
 		<!-- Issue https://github.com/renaissance-benchmarks/renaissance/issues/210 -->
 		<platformRequirements>^arch.ppc</platformRequirements>
@@ -95,7 +95,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -111,7 +111,7 @@
 				<comment>https://github.com/renaissance-benchmarks/renaissance/issues/231</comment>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)finagle-chirper.json$(Q) finagle-chirper; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)finagle-chirper.json$(Q) finagle-chirper; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -122,7 +122,7 @@
 	</test>
 	<test>
 		<testCaseName>renaissance-finagle-http</testCaseName>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)finagle-http.json$(Q) finagle-http; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)finagle-http.json$(Q) finagle-http; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -133,7 +133,7 @@
 	</test>
 	<test>
 		<testCaseName>renaissance-fj-kmeans</testCaseName>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)fj-kmeans.json$(Q) fj-kmeans; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)fj-kmeans.json$(Q) fj-kmeans; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -150,7 +150,7 @@
 				<platform>.*windows.*</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)future-genetic.json$(Q) future-genetic; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)future-genetic.json$(Q) future-genetic; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -167,7 +167,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -184,7 +184,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -195,7 +195,7 @@
 	</test>
 	<test>
 		<testCaseName>renaissance-mnemonics</testCaseName>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)mnemonics.json$(Q) mnemonics; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)mnemonics.json$(Q) mnemonics; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -212,7 +212,7 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -228,7 +228,7 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/1932#issuecomment-708781359</comment>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)naive-bayes.json$(Q) naive-bayes; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)naive-bayes.json$(Q) naive-bayes; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -239,7 +239,7 @@
 	</test>
 	<test>
 		<testCaseName>renaissance-par-mnemonics</testCaseName>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)par-mnemonics.json$(Q) par-mnemonics; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)par-mnemonics.json$(Q) par-mnemonics; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -250,7 +250,7 @@
 	</test>
 	<test>
 		<testCaseName>renaissance-philosophers</testCaseName>
-		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)philosophers.json$(Q) philosophers; \
+		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)philosophers.json$(Q) philosophers; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -267,7 +267,7 @@
 				<platform>x86-64_solaris|sparcv9_solaris</platform>
 			</disable>
 		</disables>
-		<command>$(TEST_ROOT)$(D)perf$(D)run_with_affinity.sh --exec_cmd $(Q)$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)scala-kmeans.json$(Q) scala-kmeans$(Q) --test_root $(TEST_ROOT); \
+		<command>$(TEST_ROOT)$(D)perf$(D)run_with_affinity.sh --exec_cmd $(Q)$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)scala-kmeans.json$(Q) scala-kmeans$(Q) --test_root $(TEST_ROOT); \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
For the bumblebench, dacapo, and renaissance suites, add $(JVM_OPTIONS)
to the commands in the playlist.xml files so that the tests can use
command line arguments for the JVM specified in a test job.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes https://github.com/adoptium/aqa-tests/issues/3342