### PR TITLE
Re-enable java/lang/StackWalker/DumpStackTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -44,7 +44,6 @@ java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all
-java/lang/StackWalker/DumpStackTest.java	https://github.com/eclipse-openj9/openj9/issues/6680	generic-all
 java/lang/StackWalker/EmbeddedStackWalkTest.java	https://github.com/eclipse-openj9/openj9/issues/3941	generic-all
 java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297 generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -43,7 +43,6 @@ java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all
-java/lang/StackWalker/DumpStackTest.java	https://github.com/eclipse-openj9/openj9/issues/6680	generic-all
 java/lang/StackWalker/EmbeddedStackWalkTest.java	https://github.com/eclipse-openj9/openj9/issues/3941	generic-all
 java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297	generic-all

--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -42,7 +42,6 @@ java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all
-java/lang/StackWalker/DumpStackTest.java	https://github.com/eclipse-openj9/openj9/issues/6680	generic-all
 java/lang/StackWalker/EmbeddedStackWalkTest.java	https://github.com/eclipse-openj9/openj9/issues/3941	generic-all
 java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297	generic-all

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -42,7 +42,6 @@ java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all
-java/lang/StackWalker/DumpStackTest.java	https://github.com/eclipse-openj9/openj9/issues/6680	generic-all
 java/lang/StackWalker/EmbeddedStackWalkTest.java	https://github.com/eclipse-openj9/openj9/issues/3941	generic-all
 java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297	generic-all


### PR DESCRIPTION
Fixed by: https://github.com/eclipse-openj9/openj9/pull/3627
Closes: https://github.com/eclipse-openj9/openj9/issues/6680

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>