### PR TITLE
Re-enable test fixed by OJDK MH

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -90,7 +90,6 @@ java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://gi
 java/lang/annotation/loaderLeak/Main.java	https://github.com/eclipse-openj9/openj9/issues/6701	generic-all
 java/lang/invoke/FindAccessTest.java		https://github.com/eclipse-openj9/openj9/issues/6868	generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse-openj9/openj9/issues/11366 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse-openj9/openj9/issues/7043	generic-all
 java/lang/invoke/PrivateInvokeTest.java	https://github.com/eclipse-openj9/openj9/issues/7071	generic-all
 java/lang/invoke/SpecialInterfaceCall.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
@@ -123,7 +122,6 @@ java/lang/ref/ReachabilityFenceTest.java	https://github.com/adoptium/aqa-tests/i
 java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse-openj9/openj9/issues/7741	generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all

--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -89,7 +89,6 @@ java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://gi
 java/lang/annotation/loaderLeak/Main.java	https://github.com/eclipse-openj9/openj9/issues/6701	generic-all
 java/lang/invoke/FindAccessTest.java		https://github.com/eclipse-openj9/openj9/issues/6868	generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse-openj9/openj9/issues/11366 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse-openj9/openj9/issues/7043	generic-all
 java/lang/invoke/PrivateInvokeTest.java	https://github.com/eclipse-openj9/openj9/issues/7071	generic-all
 java/lang/invoke/SpecialInterfaceCall.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
@@ -121,7 +120,6 @@ java/lang/ref/ReachabilityFenceTest.java	https://github.com/adoptium/aqa-tests/i
 java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse-openj9/openj9/issues/7741	generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -89,7 +89,6 @@ java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://gi
 java/lang/annotation/loaderLeak/Main.java	https://github.com/eclipse-openj9/openj9/issues/6701	generic-all
 java/lang/invoke/FindAccessTest.java		https://github.com/eclipse-openj9/openj9/issues/6868	generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/MethodHandles/classData/ClassDataTest.java https://github.com/eclipse-openj9/openj9/issues/11366 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse-openj9/openj9/issues/7043	generic-all
 java/lang/invoke/PrivateInvokeTest.java	https://github.com/eclipse-openj9/openj9/issues/7071	generic-all
 java/lang/invoke/SpecialInterfaceCall.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
@@ -121,7 +120,6 @@ java/lang/ref/ReachabilityFenceTest.java	https://github.com/adoptium/aqa-tests/i
 java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse-openj9/openj9/issues/7741	generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all


### PR DESCRIPTION
Fixed tests:
java/lang/reflect/Proxy/ProxyForMethodHandle.java
https://github.com/eclipse-openj9/openj9/issues/7741

java/lang/invoke/MethodHandles/classData/ClassDataTest.java
https://github.com/eclipse-openj9/openj9/issues/11366

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>