### PR TITLE
Fix display check on mac

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -604,10 +604,6 @@ def runTest( ) {
 			RUNTEST_CMD = "${TARGET} ${CUSTOM_OPTION}"
 			for (int i = 1; i <= ITERATIONS; i++) {
 				echo "ITERATION: ${i}/${ITERATIONS}"
-				//if (PLATFORM.contains("mac")) {
-				//	env.AWT_FORCE_HEADFUL=true
-				//	echo "env.AWT_FORCE_HEADFUL is ${env.AWT_FORCE_HEADFUL}"
-				//} else 
 				if (env.SPEC.startsWith('aix')) {
 					sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX -secIP 000 :0 &"
 					env.DISPLAY = "unix:0"

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -604,6 +604,10 @@ def runTest( ) {
 			RUNTEST_CMD = "${TARGET} ${CUSTOM_OPTION}"
 			for (int i = 1; i <= ITERATIONS; i++) {
 				echo "ITERATION: ${i}/${ITERATIONS}"
+				//if (PLATFORM.contains("mac")) {
+				//	env.AWT_FORCE_HEADFUL=true
+				//	echo "env.AWT_FORCE_HEADFUL is ${env.AWT_FORCE_HEADFUL}"
+				//} else 
 				if (env.SPEC.startsWith('aix')) {
 					sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX -secIP 000 :0 &"
 					env.DISPLAY = "unix:0"

--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -536,7 +536,7 @@ public class JavaTestRunner {
 					if ( !platform.equals("win") ) {
 						fileContent += "set jck.env.testPlatform.headless No" + ";\n";
 						fileContent += "set jck.env.testPlatform.xWindows Yes" + ";\n";
-						if ( !platform.equals("osx") ) {
+						if ( !platform.equals("osx") ) { 
 							String display = System.getenv("DISPLAY");
 							if ( display == null ) {
 								System.out.println("Error: DISPLAY must be set to run tests " + tests + " on " + platform);

--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -536,13 +536,15 @@ public class JavaTestRunner {
 					if ( !platform.equals("win") ) {
 						fileContent += "set jck.env.testPlatform.headless No" + ";\n";
 						fileContent += "set jck.env.testPlatform.xWindows Yes" + ";\n";
-						String display = System.getenv("DISPLAY");
-						if ( display == null ) {
-							System.out.println("Error: DISPLAY must be set to run tests " + tests + " on " + platform);
-							return false; 
-						}
-						else {
-							fileContent += "set jck.env.testPlatform.display " + display + ";\n";
+						if ( !platform.equals("osx") ) {
+							String display = System.getenv("DISPLAY");
+							if ( display == null ) {
+								System.out.println("Error: DISPLAY must be set to run tests " + tests + " on " + platform);
+								return false; 
+							}
+							else {
+								fileContent += "set jck.env.testPlatform.display " + display + ";\n";
+							}
 						}
 					}
 				}

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -343,16 +343,6 @@
 	<test>
 		<testCaseName>jck-runtime-api-javax_naming-spi</testCaseName>
 		<disables>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>openj9</impl>
-			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
 				<platform>x86-64_mac|aarch64_mac</platform>
@@ -388,16 +378,6 @@
 	<test>
 		<testCaseName>jck-runtime-api-java_applet</testCaseName>
 		<disables>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
-				<impl>openj9</impl>
-			</disable>
   			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
 				<platform>x86-64_mac|aarch64_mac</platform>
@@ -460,38 +440,14 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<version>16+</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
+				<platform>ppc64_aix</platform>
 				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<version>16+</version>
 				<impl>openj9</impl>
 			</disable>
  			<disable>
@@ -761,12 +717,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
+				<platform>ppc64_aix</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
+				<platform>ppc64_aix</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
@@ -859,18 +815,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_imageio</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -914,16 +858,6 @@
 	<test>
 		<testCaseName>jck-runtime-api-javax_naming</testCaseName>
 		<disables>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>openj9</impl>
-			</disable>
 			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
 				<platform>x86-64_mac|aarch64_mac</platform>
@@ -1050,16 +984,6 @@
 	<test>
 		<testCaseName>jck-runtime-api-javax_sound</testCaseName>
 		<disables>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>openj9</impl>
-			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
 				<platform>x86-64_mac|aarch64_mac</platform>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -378,6 +378,16 @@
 	<test>
 		<testCaseName>jck-runtime-api-java_applet</testCaseName>
 		<disables>
+			<disable>
+				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac|ppc64_aix</platform>
+				<impl>ibm</impl>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac|ppc64_aix</platform>
+				<impl>openj9</impl>
+			</disable>
   			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
 				<platform>x86-64_mac|aarch64_mac</platform>
@@ -440,14 +450,38 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64_aix</platform>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
+				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<version>8</version>
+				<impl>ibm</impl>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<version>16+</version>
+				<impl>ibm</impl>
+			</disable>
+			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64_aix</platform>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<version>11</version>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<version>8</version>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<version>16+</version>
 				<impl>openj9</impl>
 			</disable>
  			<disable>
@@ -717,12 +751,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64_aix</platform>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64_aix</platform>
+				<platform>x86-64_mac|ppc64_aix</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
@@ -815,6 +849,18 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_imageio</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<impl>ibm</impl>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- env.DISPLAY is not required to be set on Mac. The check for it in JavaTestRunner has been bypassed for Mac in this PR. 
- 3 targets that work on Mac have been un-excluded. 

Related to : infrastructure/issues/5254

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>