### PR TITLE
Enable customized Image for external tests

### DIFF
--- a/external/build.xml
+++ b/external/build.xml
@@ -34,6 +34,16 @@
 			<property name="dockerImageTag" value="nightly"/>
 		</else>
 	</if>
+	<if>
+		<isset property="env.EXTRA_DOCKER_ARGS"/>
+		<then>
+			<property name="extra_docker_args" value="${env.EXTRA_DOCKER_ARGS}"/>
+		</then>
+		<else>
+			<property name="extra_docker_args" value=""/>
+		</else>
+	</if>
+	
 	<target name="init">
 		<mkdir dir="${DEST_EXTERNAL}" />
 	</target>
@@ -83,7 +93,7 @@
 	</target>
 
 	<target name="build_image" description="build test dockerfile">
-		<echo message="Executing external.sh --build --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} " />						
+		<echo message="Executing external.sh --build --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} --docker_args ${extra_docker_args} " />
 		<exec executable="bash" failonerror="true">
 			<arg value="${DEST_EXTERNAL}/external.sh"/>
 			<arg value="--build"/>
@@ -95,6 +105,8 @@
 			<arg value="${JDK_VERSION}"/>
 			<arg value="--impl"/>
 			<arg value="${JDK_IMPL}"/>
+			<arg value="--docker_args"/>
+			<arg value="${extra_docker_args}"/>
 		</exec>
 	</target>
 </project>

--- a/external/build_image.sh
+++ b/external/build_image.sh
@@ -29,11 +29,11 @@ if [ $# -ne 8 ] && [ $# -ne 7 ]; then
 	echo "package = ${supported_packages}"
 	echo "build   = ${supported_builds}"
 	echo "testtarget" = "Optional: CMD to pass to ENTRYPOINT script from Dockerfile"
+	echo "buildArg" = "Optional: customized image"
 	exit -1
 fi
 if [ $# -eq 8 ]; then
 	buildArg="--build-arg IMAGE=$8"
-	echo "buildArg is $buildArg"
 fi
 if [[ ${check_external_custom} -eq 0 ]]; then
 	set_test $1

--- a/external/dockerfile_functions.sh
+++ b/external/dockerfile_functions.sh
@@ -81,7 +81,7 @@ print_image_args() {
     local package=$5
     local build=$6
 
-image_name="eclipse-temurin"
+    image_name="eclipse-temurin"
     tag=""
     if [[ "${package}" == "jre" ]]; then
         tag="${version}-jre"
@@ -92,12 +92,13 @@ image_name="eclipse-temurin"
         image_name="ibm-semeru-runtimes"
         tag=open-${tag}
     fi
+    image="${image_name}:${tag}"
 
-    echo -e "ARG IMAGE_NAME=${image_name}" \
+    echo -e "ARG IMAGE=${image}" \
           "\nARG OS=${os}" \
           "\nARG IMAGE_VERSION=nightly" \
           "\nARG TAG=${tag}" \
-          "\nFROM \$IMAGE_NAME:\$TAG\n" >> ${file}
+          "\nFROM \$IMAGE\n" >> ${file}
 }
 
 print_test_tag_arg() {

--- a/external/external.sh
+++ b/external/external.sh
@@ -81,7 +81,6 @@ parseCommandLineArgs() {
 					echo "No EXTRA_DOCKER_ARGS set"; 
 				else 
   					docker_args="$1"; shift;
-  					echo "docker_args is ${docker_args}";
   					parse_docker_args $docker_args;
 				fi;;
 				
@@ -148,12 +147,11 @@ function parse_docker_args() {
 		shift; 
 
 		case "$opt" in
-			"--volumn" | "-v" )
+			"--volume" | "-v" )
 				mountV="-v $1";
 				shift;;
 			"--image" | "-i" )
 				imageArg="$1"; 
-				echo "image is ${imageArg}";
 				shift;;
 			*) echo >&2 "Invalid docker args option: ${opt}"; exit 1;
 		esac


### PR DESCRIPTION
Fix #2645 

Fix #3377 by remove the `-rm` option as the default docker run option

Co-authored-by: Sophia Guo [sophia.gwf@gmail.com](mailto:sophia.gwf@gmail.com)
Co-authored-by: Joan Njeri [njerijoan24@gmail.com](mailto:njerijoan24@gmail.com)
