### PR TITLE
AArch64 macOS: Exclude SharedClassesAPI test

### DIFF
--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -31,6 +31,12 @@
 		<command>if ! echo "$(PLATFORM)" | grep -q "win"; then export original_umask_val=`umask` $(AND_IF_SUCCESS) umask 0002 $(AND_IF_SUCCESS) echo umask set to `umask`; fi; \
 	$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClassesAPI; \
 	$(TEST_STATUS)</command>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14390</comment>
+				<platform>aarch64_mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit excludes SharedClassesAPI test on AArch64 macOS for the time
being, because JVMTI support is not fully working yet on that platform.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>