### PR TITLE
Add timeout for RELATED_NODES testing

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -207,14 +207,16 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
 
             if (params.RELATED_NODES) {
                 if (areNodesWithLabelOnline(params.RELATED_NODES)) {
-                    node(params.RELATED_NODES) {
-                        echo "On RELATED_NODES: ${params.RELATED_NODES}"
-                        node(LABEL) {
-                            echo "On main node"
-                            runTest()
-                            echo "Done with main node"
-                        }
-                        echo "Done with RELATED_NODES: ${params.RELATED_NODES}"
+                    timeout(activity: true, time: 1, unit: 'HOURS'){
+                        node(params.RELATED_NODES) {
+                           echo "On RELATED_NODES: ${params.RELATED_NODES}"
+                           node(LABEL) {
+                               echo "On main node"
+                               runTest()
+                               echo "Done with main node"
+                            }
+                            echo "Done with RELATED_NODES: ${params.RELATED_NODES}"
+                        } 
                     }
                 } else {
                     assert false : "Cannot find RELATED_NODES: ${params.RELATED_NODES}."


### PR DESCRIPTION
Added a timeout check for waiting for RELATED_NODES
If RELATED Node is available within the time limit, the build should proceed; if RELATED Node is not available within the time limit, the build should be aborted.
Related: https://github.com/adoptium/aqa-tests/issues/2841

Co-authored-by: lanxia [lan_xia@ca.ibm.com](mailto:lan_xia@ca.ibm.com)
Co-authored-by: Azah Norbline [azahnorbline@gmail.com](mailto:azahnorbline@gmail.com)