### PR TITLE
Skip compile external_custom project if EXTERNAL_CUSTOM_REPO is not set

### DIFF
--- a/external/external_custom/build.xml
+++ b/external/external_custom/build.xml
@@ -9,8 +9,10 @@
 	<!-- set properties for this build -->
 	<property name="TEST" value="external_custom" />
 	<property environment="env" />
-	<property name="EXTERNAL_CUSTOM_REPO" value="${env.EXTERNAL_CUSTOM_REPO}" />
-    <condition property="EXTERNAL_REPO_BRANCH" value="${env.EXTERNAL_REPO_BRANCH}" else="master">
+	<condition property="EXTERNAL_CUSTOM_REPO" value="${env.EXTERNAL_CUSTOM_REPO}" else="">
+		<isset property="env.EXTERNAL_CUSTOM_REPO" />
+	</condition>
+	<condition property="EXTERNAL_REPO_BRANCH" value="${env.EXTERNAL_REPO_BRANCH}" else="master">
 		<isset property="env.EXTERNAL_REPO_BRANCH" />
 	</condition>
 	<condition property="EXTERNAL_TEST_CMD" value="${env.EXTERNAL_TEST_CMD}" else="mvn clean install">
@@ -30,13 +32,9 @@
 	</target>
 
 	<target name="build">
-		<!-- Temporarily disable for openj9 and ibm due to https://github.com/adoptium/aqa-tests/issues/2903 -->
 		<if>
 			<not>
-				<or>
-					<equals arg1="${JDK_IMPL}" arg2="ibm"  />
-					<equals arg1="${JDK_IMPL}" arg2="openj9" />
-				</or>
+				<equals arg1="${EXTERNAL_CUSTOM_REPO}" arg2=""/>
 			</not>
 			<then>
 				<antcall target="dist" inheritall="true" />

--- a/external/external_custom/playlist.xml
+++ b/external/external_custom/playlist.xml
@@ -21,7 +21,7 @@
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag ${DOCKERIMAGE_TAG} --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir external_custom
 		</command>
 		<levels>
-			<level>extended</level>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>external</group>


### PR DESCRIPTION
Skip compile external_custom project if EXTERNAL_CUSTOM_REPO is not set
Move external_custom tests to special level

Fix #3187 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>