### PR TITLE
Exclude jck-runtime-api-javax_naming-spi on 8, 17, 18 on x86-64_mac

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -343,6 +343,38 @@
 	<test>
 		<testCaseName>jck-runtime-api-javax_naming-spi</testCaseName>
 		<disables>
+			<disable>
+				<comment>Disabled on osx for backlog/issues/739, in the interim these targets will be run manually</comment><platform>x86-64_mac</platform>
+				<impl>ibm</impl>
+				<version>8</version>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for backlog/issues/739, in the interim these targets will be run manually</comment><platform>x86-64_mac</platform>
+				<impl>openj9</impl>
+				<version>8</version>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for backlog/issues/739, in the interim these targets will be run manually</comment><platform>x86-64_mac</platform>
+				<impl>ibm</impl>
+				<version>17</version>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for backlog/issues/739, in the interim these targets will be run manually</comment><platform>x86-64_mac</platform>
+				<impl>openj9</impl>
+				<version>17</version>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for backlog/issues/739, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<impl>ibm</impl>
+				<version>18</version>
+			</disable>
+			<disable>
+				<comment>Disabled on osx for backlog/issues/739, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<impl>openj9</impl>
+				<version>18</version>
+			</disable>
  			<disable>
 				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
 				<platform>x86-64_mac|aarch64_mac</platform>


### PR DESCRIPTION
- Exclude jck-runtime-api-javax_naming-spi on 8, 17, 18 on x86-64_mac. 
- The target works  fine on 11. 
- Ref: infrastructure/issues/5254, backlog/issues/739.

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>