### PR TITLE
Exclude javax_net and javax_rmi from z/OS JDK 11

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -931,6 +931,12 @@
 				<impl>ibm</impl>
 				<platform>.*zos.*</platform>
 			</disable>
+			<disable>
+				<comment>Disabled on z/OS due to backlog/issues/744</comment>
+				<version>11</version>
+				<impl>ibm</impl>
+				<platform>s390x_zos</platform>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -987,6 +993,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_rmi</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled on z/OS due to backlog/issues/744</comment>
+				<version>11</version>
+				<impl>ibm</impl>
+				<platform>s390x_zos</platform>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- Exclude javax_net and javax_rmi from z/OS JDK 11
- backlog/issues/744

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>