### PR TITLE
Add zArtemis platforms

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -46,6 +46,10 @@ def PLATFORM_MAP = [
         'SPEC' : 'linux_390',
         'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux&&hw.bits.32',
     ],
+    's390x_linux_zt' : [
+        'SPEC' : 'linux_390-64_zt',
+        'LABEL' : 'ci.role.test&&hw.arch.zartemis&&sw.os.linux',
+    ],
     's390x_linux' : [
         'SPEC' : 'linux_390-64',
         'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.linux',
@@ -57,6 +61,14 @@ def PLATFORM_MAP = [
     's390x_zos_xl' : [
         'SPEC' : 'zos_390-64',
         'LABEL' : 'ci.role.test&&hw.arch.s390x&&sw.os.zos',
+    ],
+    's390x_zos_zt' : [
+        'SPEC' : 'zos_390-64_zt',
+        'LABEL' : 'ci.role.test&&hw.arch.zartemis&&sw.os.zos',
+    ],
+    's390_zos_zt' : [
+        'SPEC' : 'zos_390_zt',
+        'LABEL' : 'ci.role.test&&hw.arch.zartemis&&sw.os.zos',
     ],
     's390_zos' : [
         'SPEC' : 'zos_390',


### PR DESCRIPTION
Add s390x and z/OS zArtemis platforms to the plaforms map.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>