### PR TITLE
Test -Xtune:throughput in mauveLoadTest variations

### DIFF
--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -217,6 +217,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
+			<variation>-Xtune:throughput</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoadTrc -test-args=$(Q)timeLimit=5m$(Q); \
@@ -271,6 +272,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
+			<variation>-Xtune:throughput</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleThrdLoadTrc -test-args=$(Q)timeLimit=5m$(Q); \
@@ -320,6 +322,7 @@
 			<variation>Mode610-OSRG</variation>
 			<variation>Mode612-OSRG</variation>
 			<variation>-Xgcpolicy:gencon -Xgc:dynamicBreadthFirstScanOrdering</variation>
+			<variation>-Xtune:throughput</variation>
 			<!--Note: -Xint modes Mode108, Mode109, Mode550 should be run manually -->
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveSingleInvocLoad -test-args=$(Q)timeLimit=5m$(Q); \


### PR DESCRIPTION
Fixes: eclipse-openj9/openj9/issues/14551
Signed-off-by: Christian Despres <despresc@ibm.com>