### PR TITLE
Rename architecture label for _zt specs

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -48,7 +48,7 @@ def PLATFORM_MAP = [
     ],
     's390x_linux_zt' : [
         'SPEC' : 'linux_390-64_zt',
-        'LABEL' : 'ci.role.test&&hw.arch.zartemis&&sw.os.linux',
+        'LABEL' : 'ci.role.test&&hw.arch.znext&&sw.os.linux',
     ],
     's390x_linux' : [
         'SPEC' : 'linux_390-64',
@@ -64,11 +64,11 @@ def PLATFORM_MAP = [
     ],
     's390x_zos_zt' : [
         'SPEC' : 'zos_390-64_zt',
-        'LABEL' : 'ci.role.test&&hw.arch.zartemis&&sw.os.zos',
+        'LABEL' : 'ci.role.test&&hw.arch.znext&&sw.os.zos',
     ],
     's390_zos_zt' : [
         'SPEC' : 'zos_390_zt',
-        'LABEL' : 'ci.role.test&&hw.arch.zartemis&&sw.os.zos',
+        'LABEL' : 'ci.role.test&&hw.arch.znext&&sw.os.zos',
     ],
     's390_zos' : [
         'SPEC' : 'zos_390',


### PR DESCRIPTION
Rename label to arch.znext for _zt specs

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>