### PR TITLE
Added Exclusion statement in ProblemList__openjdk8.txt

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -163,6 +163,7 @@ java/lang/ClassLoader/Assert.java	https://github.com/adoptium/aqa-tests/issues/1
 java/lang/Math/HypotTests.java	https://github.com/adoptium/aqa-tests/issues/128	linux-all
 java/lang/ProcessBuilder/Basic.java		https://github.com/adoptium/aqa-tests/issues/1397	aix-all
 java/lang/invoke/MethodHandles/CatchExceptionTest.java  https://bugs.openjdk.java.net/browse/JDK-8146623    linux-s390x
+java/lang/invoke/MethodHandles/CatchExceptionTest.java https://github.com/adoptium/aqa-tests/issues/2986 linux-arm
 
 ############################################################################
 


### PR DESCRIPTION
Added Exclusion statement in  https://github.com/adoptium/aqa-tests/blob/master/openjdk/excludes/ProblemList_openjdk8.txt
This was added in AQAvit v0.8.0
Fixex: #2986

Signed-off-by: Abhijeet Jejurkar <abhijeet.jejurkar2@gmail.com>