### PR TITLE
updating tag_version to the lucene solr test.properties file

### DIFF
--- a/external/lucene-solr/test.properties
+++ b/external/lucene-solr/test.properties
@@ -1,7 +1,7 @@
 github_url="https://github.com/apache/lucene-solr.git"
 script="lucene-solr-test.sh"
 home_path="\${WORKDIR}"
-tag_version="releases/lucene-solr/8.5.1"
+tag_version="releases/lucene-solr/8.11.1"
 ant_version="1.10.6"
 ivy_version="2.5.0"
 ubuntu_packages="git wget tar"


### PR DESCRIPTION
updating tag_version="releases/lucene-solr/8.11.1" to the [lucene-solr/test.properties](https://github.com/adoptium/aqa-tests/blob/master/external/lucene-solr/test.properties#L4) file

Related issue: #3393 

Signed-off-by: Ying Zhou