### PR TITLE
add support for adoptium/jdk11u-fast-startup-incubator project

### DIFF
--- a/buildenv/jenkins/parentsJobPipeline.groovy
+++ b/buildenv/jenkins/parentsJobPipeline.groovy
@@ -29,6 +29,7 @@ node {
 	                            case "corretto": variant = "corretto"; break
 	                            case "dragonwell": variant = "dragonwell"; break;
 	                            case "bisheng": variant = "bisheng"; break;
+	                            case "fast_startup": variant = "fast_startup"; break;
 	                            default: variant = "hs"
 	                        }
 	                        buildConfigurations.keySet().each { key -> 

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -19,7 +19,7 @@
  */
 
 def getBaseJDKImpl(JDK_IMPL) {
-	if (JDK_IMPL == "hotspot" || JDK_IMPL == "sap" || JDK_IMPL == "corretto" || JDK_IMPL == "dragonwell" || JDK_IMPL == "bisheng") {
+	if (JDK_IMPL == "hotspot" || JDK_IMPL == "sap" || JDK_IMPL == "corretto" || JDK_IMPL == "dragonwell" || JDK_IMPL == "bisheng" || JDK_IMPL == "fast_startup") {
 		return "hotspot"
 	}
 	return JDK_IMPL


### PR DESCRIPTION
Hello!

I added fast-startup variant for adoptium build pipline(https://github.com/adoptium/ci-jenkins-pipelines/pull/257) recently, but I noticed there were some errors during buildin&testing (https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-x64-fast_startup_SmokeTests/1/execution/node/76/log/ It seems that we should recognize fast_startup variant as "hotspot", so I prepare this patch to address this problem. I'm not able to test it, please let me know if it can not work ;)

Best regards,
Yi Yang