### PR TITLE
LdapDnsProviderTest associated with only one issue

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -347,7 +347,7 @@ sun/util/logging/PlatformLoggerTest.java	https://github.com/adoptium/aqa-tests/i
 # jdk_other
 
 com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/2351 generic-all
-com/sun/jndi/ldap/LdapDnsProviderTest.java https://github.com/adoptium/aqa-tests/issues/2350,https://github.com/adoptium/aqa-tests/issues/2355 generic-all
+com/sun/jndi/ldap/LdapDnsProviderTest.java https://github.com/adoptium/aqa-tests/issues/2355 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -423,7 +423,7 @@ java/util/stream/test/org/openjdk/tests/java/util/stream/MapOpTest.java https://
 # jdk_other
 
 com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/2351 generic-all
-com/sun/jndi/ldap/LdapDnsProviderTest.java https://github.com/adoptium/aqa-tests/issues/2350,https://github.com/adoptium/aqa-tests/issues/2355 generic-all
+com/sun/jndi/ldap/LdapDnsProviderTest.java https://github.com/adoptium/aqa-tests/issues/2355 generic-all
 jdk/lambda/vm/InterfaceAccessFlagsTest.java	https://github.com/adoptium/aqa-tests/issues/126	linux-all
 com/sun/jndi/ldap/RemoveNamingListenerTest.java https://bugs.openjdk.java.net/browse/JDK-8202117 aix-all
 ############################################################################


### PR DESCRIPTION
LdapDnsProviderTest associated with only one issue
This was Updated in AQAvit v0.8.0
Fixes: #3426

Signed-off-by: Abhijeet Jejurkar <abhijeet.jejurkar2@gmail.com>