### PR TITLE
Re-exclude renaissance-* tests in vendor ibm

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -37,6 +37,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
+			<disable>
+				<comment>runtimes/infrastructure/issues/5444</comment>
+				<vendor>ibm</vendor>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)als.json$(Q) als; \
 		$(TEST_STATUS)</command>
@@ -53,6 +57,10 @@
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
+			</disable>
+			<disable>
+				<comment>runtimes/infrastructure/issues/5444</comment>
+				<vendor>ibm</vendor>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)chi-square.json$(Q) chi-square; \
@@ -93,6 +101,10 @@
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
+			</disable>
+			<disable>
+				<comment>runtimes/infrastructure/issues/5444</comment>
+				<vendor>ibm</vendor>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)dec-tree.json$(Q) dec-tree; \
@@ -166,6 +178,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
+			<disable>
+				<comment>runtimes/infrastructure/issues/5444</comment>
+				<vendor>ibm</vendor>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)gauss-mix.json$(Q) gauss-mix; \
 		$(TEST_STATUS)</command>
@@ -182,6 +198,10 @@
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
+			</disable>
+			<disable>
+				<comment>runtimes/infrastructure/issues/5444</comment>
+				<vendor>ibm</vendor>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)log-regression.json$(Q) log-regression; \
@@ -210,6 +230,10 @@
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3189</comment>
 				<platform>x86-32_windows|arm_linux</platform>
+			</disable>
+			<disable>
+				<comment>runtimes/infrastructure/issues/5444</comment>
+				<vendor>ibm</vendor>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)movie-lens.json$(Q) movie-lens; \


### PR DESCRIPTION
Was removed by "Updated disable format" (#2772).

Signed-off-by: Jason Feng <fengj@ca.ibm.com>