### PR TITLE
Exclude the failing FFI test suite on macOS in JDK18

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -386,6 +386,8 @@ java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 
+java/foreign/TestFunctionDescriptor.java https://github.com/eclipse-openj9/openj9/issues/14487 macosx-all
+
 ############################################################################
 
 # com_sun_crypto


### PR DESCRIPTION
The change is to add TestFunctionDescriptor detected as failure
on macOS to the exclude file.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>