### PR TITLE
AArch64 macOS: Disable SC_Softmx_JitAot test

### DIFF
--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -108,6 +108,12 @@
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClassesWorkloadTest_Softmx_Increase_JitAot; \
 	$(TEST_STATUS)</command>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14635</comment>
+				<platform>aarch64_mac.*</platform>
+			</disable>
+		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
This commit disables SC_Softmx_JitAot test on OpenJ9 AArch64 macOS for the
time being.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>