### PR TITLE
Explicitly delete possible containers

### DIFF
--- a/external/external.sh
+++ b/external/external.sh
@@ -191,8 +191,5 @@ if [ $command_type == "clean" ]; then
 	if [[ ${test} == 'external_custom' ]]; then
 			test="$(echo ${EXTERNAL_CUSTOM_REPO} | awk -F'/' '{print $NF}' | sed 's/.git//g')"
 	fi
-	if [ $reportsrc != "false" ]; then
-		docker rm -f $test-test;
-	fi
-	docker rmi -f adoptopenjdk-$test-test:${JDK_VERSION}-$package-$docker_os-${JDK_IMPL}-$build_type
+	docker rm -f $test-test; docker rmi -f adoptopenjdk-$test-test:${JDK_VERSION}-$package-$docker_os-${JDK_IMPL}-$build_type
 fi


### PR DESCRIPTION
Explicitly delete possible containers no matter if there is the
container or not. Parameter reportsrc will not be necessary for
`external.sh --clean`. Otherwise parameters of `external.sh --clean`
will partly depend on the parameters of `external.sh --run`.

Fix #3452 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>