### PR TITLE
Changing tag version for quarkus tests

### DIFF
--- a/external/camel/test.properties
+++ b/external/camel/test.properties
@@ -2,6 +2,6 @@
  script="camel-test.sh"
  test_command="mvn clean install"
  test_results="testResults"
- tag_version="main"
+ tag_version="2.7.0"
  environment_variable="MODE=\"java\""
  ubuntu_packages="git maven"

--- a/external/quarkus_openshift/test.properties
+++ b/external/quarkus_openshift/test.properties
@@ -1,6 +1,6 @@
 github_url="https://github.com/quarkus-qe/quarkus-openshift-test-suite.git"
 script="test.sh"
 test_results="testResults"
-tag_version="1.3.2.Final"
+tag_version="2.7.2.Final"
 environment_variable="MODE=\"java\""
 ubuntu_packages="git wget"

--- a/external/quarkus_quickstarts/test.properties
+++ b/external/quarkus_quickstarts/test.properties
@@ -8,6 +8,6 @@ test_command="mvn -pl !:hibernate-orm-quickstart,!:hibernate-orm-panache-quickst
 !:vertx-quickstart,!:context-propagation-quickstart,!:getting-started-reactive-rest,\
 !:kafka-quickstart,!:neo4j-quickstart clean install"
 test_results="testResults"
-tag_version="1.3.2.Final"
+tag_version="2.7.2.Final"
 environment_variable="MODE=\"java\""
 ubuntu_packages="git wget maven"


### PR DESCRIPTION
This patch updates quarkus version from 1.3.2 to 2.7.2.

Fixes: #3382 

Signed-off-by: Abeer Waheed <amir2@ualberta.ca>