### PR TITLE
Disable deferred wipeout before the build and cleanws after build even the build failed

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -801,7 +801,7 @@ def testBuild() {
 
 			if (!params.KEEP_WORKSPACE) {
 				// cleanWs() does not work in some cases, so set opts below
-				cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
+				cleanWs disableDeferredWipeout: true, deleteDirs: true
 				// clean up remaining core files
 				if (PLATFORM.contains("mac")) {
 					sh "find /cores -name '*core*' -print 2>/dev/null -exec rm -f {} \\; || true"

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -251,7 +251,7 @@ if (JDK_VERSIONS.size() > 1 || JDK_IMPLS.size() > 1 || PLATFORMS.size() >1 || PL
 def runTest() {
     try {
         timeout(time: 1, unit: 'HOURS') {
-            cleanWs()
+            cleanWs disableDeferredWipeout: true, deleteDirs: true
         }
         if (params.PLATFORM.contains('zos')) {
             /* Ensure correct CC env */


### PR DESCRIPTION
Deferred wipeout means that deletion takes places asynchronously to
reduce the build time. If the disk space is low there is no reason to use
this feature as it actually asks for more disk space.

Cleanws at post stage for all build status. Only keep workspace if the parameter KEEP_WORKSPACE is set

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>