### PR TITLE
Output generic TEST_JDK_HOME in job.properties

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -471,14 +471,11 @@ def setup() {
 
 def getJobProperties() {
 	def jobProperties = "./aqa-tests/job.properties"
-	if (fileExists("${jobProperties}")) {
-		echo "readProperties file: ${jobProperties}"
-		def properties = readProperties file: "${jobProperties}"
-		if (properties.TEST_JDK_HOME) {
-			env.TEST_JDK_HOME = properties.TEST_JDK_HOME
-			echo "Reset TEST_JDK_HOME to ${TEST_JDK_HOME}"
-		}
-	}
+	echo "readProperties file: ${jobProperties}"
+	def properties = readProperties file: "${jobProperties}"
+	env.TEST_JDK_HOME = properties.TEST_JDK_HOME
+	echo "Reset TEST_JDK_HOME to ${TEST_JDK_HOME}"
+
 }
 
 def get_sources_with_authentication() {

--- a/get.sh
+++ b/get.sh
@@ -587,6 +587,7 @@ testJavaVersion()
 	if [ "$TEST_JDK_HOME" = "" ]; then
 		TEST_JDK_HOME=$SDKDIR/openjdkbinary/j2sdk-image
 	fi
+	echo "TEST_JDK_HOME=${TEST_JDK_HOME}" > ${TESTDIR}/job.properties
 	_java=${TEST_JDK_HOME}/bin/java
 	_release=${TEST_JDK_HOME}/release
 	# Code_Coverage use different _java through searching javac for now, following path will be modified after refining files from BUILD
@@ -631,6 +632,7 @@ testJavaVersion()
 			TEST_JDK_HOME=${java_dir}/../
 			echo "TEST_JDK_HOME=${TEST_JDK_HOME}" > ${TESTDIR}/job.properties
 		else
+			echo "TEST_JDK_HOME=${TEST_JDK_HOME}" > ${TESTDIR}/job.properties
 			echo "Cannot find javac under TEST_JDK_HOME: ${TEST_JDK_HOME}!"
 			exit 1
 		fi


### PR DESCRIPTION
Always output `TEST_JDK_HOME` into job.properties at get.sh, therefore in JenkinsfileBase the `TEST_JDK_HOME` would always be read regardless the condition checks.

Fixes: #3128 

Sign off by: Jerome Ju jeromeqju@gmail.com