### PR TITLE
Use --batch-mode for mvn projects

### DIFF
--- a/external/camel/test.sh
+++ b/external/camel/test.sh
@@ -22,7 +22,7 @@ export MAVEN_OPTS="-Xmx1g"
 
 pwd
 echo "Compile and run camel tests"
-mvn clean install
+mvn --batch-mode clean install
 test_exit_code=$?
 echo "Build camel completed"
 

--- a/external/jacoco/test.sh
+++ b/external/jacoco/test.sh
@@ -19,7 +19,7 @@ echo_setup
 cd org.jacoco.build
 pwd
 echo "Compile and run jacoco tests"
-mvn clean verify
+mvn --batch-mode clean verify
 test_exit_code=$?
 echo "Build jacoco completed"
 

--- a/external/netty/test.sh
+++ b/external/netty/test.sh
@@ -18,5 +18,5 @@ TEST_SUITE=$1
 
 set -e
 echo "Compile and execute netty-test" && \
-mvn clean package
+mvn --batch-mode clean package
 set +e

--- a/external/quarkus/test.sh
+++ b/external/quarkus/test.sh
@@ -25,7 +25,7 @@ export OPENJ9_JAVA_OPTIONS="-Xmx1g"
 pwd
 echo "Compile and run quarkus tests"
 
-./mvnw -pl '!:quarkus-documentation' clean install
+./mvnw --batch-mode -pl '!:quarkus-documentation' clean install
 test_exit_code=$?
 
 find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;

--- a/external/quarkus_quickstarts/test.sh
+++ b/external/quarkus_quickstarts/test.sh
@@ -18,7 +18,7 @@ echo_setup
 
 export MAVEN_OPTS="-Xmx1g"
 echo "Compile and run quarkus_quickstarts tests"
-mvn -pl !:hibernate-orm-quickstart,!:hibernate-orm-panache-quickstart,\
+mvn --batch-mode -pl !:hibernate-orm-quickstart,!:hibernate-orm-panache-quickstart,\
 !:hibernate-search-elasticsearch-quickstart,!:mqtt-quickstart,\
 !:quartz-quickstart,!:security-jdbc-quickstart,!:security-keycloak-authorization-quickstart,\
 !:security-openid-connect-web-authentication-quickstart,\

--- a/external/wildfly/test.sh
+++ b/external/wildfly/test.sh
@@ -31,5 +31,5 @@ export USER=""
 echo "Printing Environment Variables"
 printenv
 
-./mvnw install -DallTests
+./mvnw --batch-mode install -DallTests
 set +e


### PR DESCRIPTION
Disable color formatting in output, which caused some weird information
running tests in docker environment.
Not display "Progress: 125/150kB" style lines to reduce the console
output, which takes up 90% of the log

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>