### PR TITLE
Prerequisites for Quarkus 2+ is Java 11.

### DIFF
--- a/external/quarkus_quickstarts/playlist.xml
+++ b/external/quarkus_quickstarts/playlist.xml
@@ -25,5 +25,8 @@
 		<groups>
 			<group>external</group>
 		</groups>
+		<versions>
+			<version>11+</version>
+		</versions>
 	</test>
 </playlist>


### PR DESCRIPTION
Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>