### PR TITLE
Exclude the FFI specific test suites on the 64-bit platforms

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -389,6 +389,9 @@ java/foreign/TestUpcallStructScope.java https://github.com/eclipse-openj9/openj9
 java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
+
+java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+
 ############################################################################
 
 # com_sun_crypto

--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -388,6 +388,8 @@ java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issue
 
 java/foreign/TestFunctionDescriptor.java https://github.com/eclipse-openj9/openj9/issues/14487 macosx-all
 
+java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+
 ############################################################################
 
 # com_sun_crypto

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -386,6 +386,8 @@ java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 
+java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+
 ############################################################################
 
 # com_sun_crypto


### PR DESCRIPTION
The change is to exclude the FFI specific test suites that are
intended for the 32-bit platforms.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>