### PR TITLE
Add filtering script for disabled tests

### DIFF
--- a/scripts/disabled_tests/README.md
+++ b/scripts/disabled_tests/README.md
@@ -220,7 +220,7 @@ optional arguments:
 #### Filter for hotspot; logging in debug mode
 ```shell
 cat 1.json |
-python issue_filter.py --jdk-implementation "HotSpot" -vv  # case do not matter when using format #1
+python issue_filter.py --jdk-implementation "HotSpot" -vv  # case does not matter when using format #1
 ```
 
 #### Filter for macOS on M1, versions 11 and 17 using env. variables; logging in info mode

--- a/scripts/disabled_tests/README.md
+++ b/scripts/disabled_tests/README.md
@@ -171,3 +171,70 @@ ls -1dq openjdk/excludes/ProblemList_openjdk13.txt |
 python scripts/disabled_tests/exclude_parser.py |
 python scripts/disabled_tests/issue_status.py --github-user foobar --github-token abcdefghijklmnopqrst -vv --max-workers 1 > /dev/null
 ```
+
+## `issue_filter.py`
+
+Filter issues stored in JSON files
+
+### Usage
+
+```
+usage: issue_filter.py [-h] [--jdk-version jdk_version] [--jdk-implementation jdk_implementation] [--platform platform] [--infile INFILE] [--outfile OUTFILE] [--verbose]
+
+Filter issues stored in JSON files
+
+Filter expressions can be provided through (in ascending order of priority):
+1. command-line switches
+2. environment variables
+
+Filter expressions can be of any 2 formats:
+1. a comma-separated list of exact matches
+   note: whitespace around commas is considered; case-insensitive
+   e.g.
+   - 11,17,18+
+   - openJ9
+   - aarch64_linux,Aarch64_macos
+2. a regular expression, prefixed with 're:'
+   note: be cautious of escaping rules on your shell when using a backslash '\'
+   e.g.
+   - re:1[4-8]
+   - re:x86\-64.*
+Note: an empty expression is equivalent to not specifying the filter at all
+   e.g.
+   --jdk-version="" is equivalent to not specifying a filter on jdk-version
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --jdk-version jdk_version
+                        Filter for jdk-version [env: AQA_ISSUE_FILTER_JDK_VERSION]
+  --jdk-implementation jdk_implementation
+                        Filter for jdk-implementation [env: AQA_ISSUE_FILTER_JDK_IMPLEMENTATION]
+  --platform platform   Filter for platform [env: AQA_ISSUE_FILTER_PLATFORM]
+  --infile INFILE, -i INFILE
+                        Input file, defaults to stdin
+  --outfile OUTFILE, -o OUTFILE
+                        Output file, defaults to stdout
+  --verbose, -v         Enable info logging level, debug level if -vv
+```
+
+#### Filter for hotspot; logging in debug mode
+```shell
+cat 1.json |
+python issue_filter.py --jdk-implementation "HotSpot" -vv  # case do not matter when using format #1
+```
+
+#### Filter for macOS on M1, versions 11 and 17 using env. variables; logging in info mode
+```shell
+# Environment variables:
+# export AQA_ISSUE_FILTER_PLATFORM=aarch64_macos
+# export AQA_ISSUE_FILTER_JDK_VERSION=11,17
+python issue_filter.py --infile 1.json -v
+```
+
+#### Filter for openj9, versions 12 through 17, and any platform containing "all"
+```shell
+# Environment variables:
+# export AQA_ISSUE_FILTER_JDK_VERSION=re:1[2-7]
+cat 1.json |
+python issue_filter.py --jdk-implementation "OpenJ9" --platform "re:.*all.*"
+```

--- a/scripts/disabled_tests/issue_filter.py
+++ b/scripts/disabled_tests/issue_filter.py
@@ -1,0 +1,195 @@
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import textwrap
+from typing import List, Sequence
+
+from common import models
+
+logging.basicConfig(
+    format="%(levelname)s - %(message)s",
+)
+LOG = logging.getLogger()
+
+# common prefix for environment variables
+ENV_ARG_PREFIX = 'AQA_ISSUE_FILTER_'
+
+
+class Filter:
+    # name of command-line argument for this filter. Overridden by subclasses
+    CLI_ARG_NAME: str
+    # name of the environment variable for this filter. Overridden by subclasses
+    ENV_ARG_NAME: str
+    # name of the property under which the value of the argument will be stored. Overridden by subclasses
+    CLI_METAVAR: str
+
+    # flag to indicate raw regex expressions
+    RE_PREFIX: str = 're:'
+
+    def __init__(self, pattern_source: str, pattern: re.Pattern):
+        self.pattern_source = pattern_source
+        self.pattern = pattern
+
+    def accept(self, issue: models.Scheme) -> bool:
+        """
+        Returns `True` if this filter "matches" the given issue; `False` otherwise
+        """
+        field_value = self.extract_field(issue)
+        return self.pattern.match(field_value) is not None
+
+    def extract_field(self, s: models.Scheme) -> str:
+        """
+        Extract the relevant field value for a filter from an issue scheme
+        """
+        raise NotImplemented
+
+    # extra information regarding filter formats; appended to the command-line help text
+    CLI_EXTRA_HELP_TEXT: str = textwrap.dedent(f"""
+            Filter expressions can be provided through (in ascending order of priority):
+            1. command-line switches
+            2. environment variables
+
+            Filter expressions can be of any 2 formats:
+            1. a comma-separated list of exact matches
+               info: whitespace around commas matters; case-insensitive
+               e.g.
+               - 11,17,18+
+               - openJ9
+               - aarch64_linux,Aarch64_macos
+            2. a regular expression, prefixed with {RE_PREFIX!r}
+               info: be cautious of escaping rules on your shell when using a backslash '\\'
+               e.g.
+               - {RE_PREFIX}1[4-8]
+               - {RE_PREFIX}x86\\-64.*
+            Note: an empty expression is equivalent to not specifying the filter at all
+               e.g.
+               --jdk-version=\"\" is equivalent to not specifying a filter on jdk-version""")
+
+    @classmethod
+    def from_string(cls, string: str):
+        """
+        Construct a `Filter` from a user-provided string
+        """
+        if string.startswith(cls.RE_PREFIX):
+            re_pattern = string[len(cls.RE_PREFIX):]  # remove prefix
+            LOG.debug(f'Using user-provided pattern {re_pattern!r} for {cls.CLI_ARG_NAME}')
+        else:
+            exact_matches = string.split(',')
+            # escape characters that have a significance in regular expressions (like '+', '.', etc.)
+            escaped_matches = [re.escape(m) for m in exact_matches]
+            re_pattern = '(?i)^' + '|'.join(f'({m})' for m in escaped_matches) + '$'
+            LOG.debug(f'Using generated pattern {re_pattern!r} for {cls.CLI_ARG_NAME}')
+
+        compiled_pattern = re.compile(re_pattern)
+        return cls(
+            pattern_source=string,
+            pattern=compiled_pattern
+        )
+
+
+class JdkVersionFilter(Filter):
+    CLI_ARG_NAME = 'jdk-version'
+    ENV_ARG_NAME = ENV_ARG_PREFIX + 'JDK_VERSION'
+    CLI_METAVAR = 'jdk_version'
+
+    def extract_field(self, s: models.Scheme) -> str:
+        return s['JDK_VERSION']
+
+
+class JdkImplementationFilter(Filter):
+    CLI_ARG_NAME = 'jdk-implementation'
+    ENV_ARG_NAME = ENV_ARG_PREFIX + 'JDK_IMPLEMENTATION'
+    CLI_METAVAR = 'jdk_implementation'
+
+    def extract_field(self, s: models.Scheme) -> str:
+        return s['JDK_IMPL']
+
+
+class PlatformFilter(Filter):
+    CLI_ARG_NAME = 'platform'
+    ENV_ARG_NAME = ENV_ARG_PREFIX + 'PLATFORM'
+    CLI_METAVAR = 'platform'
+
+    def extract_field(self, s: models.Scheme) -> str:
+        return s['PLATFORM']
+
+
+def build_filters_from_args_and_env(args):
+    """
+    Construct `Filter` instances corresponding to each filter specified on the command-line
+    """
+    filters = []
+
+    # for all subclasses of `Filter`
+    for filter_klass in Filter.__subclasses__():
+        # get argument value corresponding to that subclass, either from the cli or the env
+        filter_arg = getattr(args, filter_klass.CLI_METAVAR, None) or os.getenv(filter_klass.ENV_ARG_NAME, None)
+
+        if filter_arg:
+            # user provided a value
+            filter_inst = filter_klass.from_string(filter_arg)
+            filters.append(filter_inst)
+        else:
+            LOG.debug(f'No filter applied for {filter_klass.CLI_ARG_NAME}')
+
+    return filters
+
+
+def filter_all_issues(issues: Sequence[models.Scheme], filters: Sequence[Filter]):
+    """
+    Filter issues using filter instances
+    """
+    filtered_issues = []
+    len_issues = len(issues)
+    for i, issue in enumerate(issues):
+        log_prefix = f'{i + 1}/{len_issues}: '
+        if all((objector := f).accept(issue) for f in filters):
+            filtered_issues.append(issue)
+            LOG.debug(log_prefix + 'accepted')
+        else:
+            LOG.info(log_prefix + f'rejected: {objector.CLI_ARG_NAME}={objector.extract_field(issue)!r} '
+                                  f'does not match {objector.pattern_source!r} (re: {objector.pattern.pattern})')
+
+    return filtered_issues
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Filter issues stored in JSON files\n\n" + Filter.CLI_EXTRA_HELP_TEXT,
+                                     allow_abbrev=False, formatter_class=argparse.RawDescriptionHelpFormatter)
+    for filter_klass in Filter.__subclasses__():
+        parser.add_argument(f'--{filter_klass.CLI_ARG_NAME}', type=str, default=None, metavar=filter_klass.CLI_METAVAR,
+                            help=f"Filter for {filter_klass.CLI_ARG_NAME} [env: {filter_klass.ENV_ARG_NAME}]")
+    parser.add_argument('--infile', '-i', type=argparse.FileType('r'), default=sys.stdin,
+                        help='Input file, defaults to stdin')
+    parser.add_argument('--outfile', '-o', type=argparse.FileType('w'), default=sys.stdout,
+                        help='Output file, defaults to stdout')
+    parser.add_argument('--verbose', '-v', action='count', default=0,
+                        help="Enable info logging level, debug level if -vv")
+    args = parser.parse_args()
+
+    if args.verbose == 1:
+        LOG.setLevel(logging.INFO)
+    elif args.verbose == 2:
+        LOG.setLevel(logging.DEBUG)
+
+    LOG.debug("Building filters")
+    filters = build_filters_from_args_and_env(args)
+
+    LOG.debug(f"Loading JSON from {getattr(args.infile, 'name', '<unknown>')}")
+    issues: List[models.Scheme] = json.load(args.infile)
+
+    filtered_issues: List[models.Scheme] = filter_all_issues(issues, filters)
+
+    LOG.debug(f"Outputting JSON to {getattr(args.outfile, 'name', '<unknown>')}")
+    json.dump(
+        obj=filtered_issues,
+        fp=args.outfile,
+        indent=2,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/disabled_tests/tests/data/exclude_out_filtered.json
+++ b/scripts/disabled_tests/tests/data/exclude_out_filtered.json
@@ -1,0 +1,18 @@
+[
+  {
+    "JDK_VERSION": "13",
+    "JDK_IMPL": "hotspot",
+    "TARGET": "jdk_custom",
+    "CUSTOM_TARGET": "java/nio/channels/AsyncCloseAndInterrupt.java",
+    "PLATFORM": "all_linux,all_aix",
+    "ISSUE_TRACKER": "https://github.com/adoptium/aqa-tests/issues/1597"
+  },
+  {
+    "JDK_VERSION": "13",
+    "JDK_IMPL": "hotspot",
+    "TARGET": "jdk_custom",
+    "CUSTOM_TARGET": "jdk/nio/zipfs/ZipFSTester.java",
+    "PLATFORM": "all_mac,ppc64le_linux",
+    "ISSUE_TRACKER": "https://github.com/adoptium/aqa-tests/issues/602"
+  }
+]

--- a/scripts/disabled_tests/tests/test_issue_filter.py
+++ b/scripts/disabled_tests/tests/test_issue_filter.py
@@ -1,0 +1,28 @@
+import json
+import os
+from unittest import TestCase
+
+from issue_filter import JdkVersionFilter, JdkImplementationFilter, PlatformFilter, filter_all_issues
+
+
+class Test(TestCase):
+
+    def test_filter(self):
+        test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        infile = os.path.join(test_data_dir, 'exclude_out.json')
+        expected_out_file = os.path.join(test_data_dir, 'exclude_out_filtered.json')
+
+        with open(infile) as f:
+            issues = json.load(f)
+        with open(expected_out_file) as f:
+            expected = json.load(f)
+
+        filters = [
+            JdkVersionFilter.from_string('13'),
+            JdkImplementationFilter.from_string('hotspot'),
+            PlatformFilter.from_string('re:.*linux.*'),
+        ]
+
+        actual = filter_all_issues(issues, filters)
+
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
Add filtering script for disabled tests

- New `issue_filter.py` script to filter on platforms, jdk versions and implementations
- Filters specified on the command-line or using env variables
  - Env variables are the following: `AQA_ISSUE_FILTER_PLATFORM`, `AQA_ISSUE_FILTER_JDK_VERSION` and `AQA_ISSUE_FILTER_JDK_IMPLEMENTATION`
- More info on usage and syntax [in the README](https://github.com/gervaisj/aqa-tests/blob/aae222d2bf1189e52fd62c7541939fd4aeec2313/scripts/disabled_tests/README.md#usage-3)


Fixes https://github.com/adoptium/aqa-tests/issues/3516

Signed-off-by: Jocelyn Gervais [gervaisj14@outlook.com](mailto:gervaisj14@outlook.com)

### Output sample

- Info (`-v`) mode
```
$ python issue_filter.py --infile tests/data/playlist_out.json --jdk-implementation ibm -v
INFO - 1/4: rejected: jdk-implementation='hotspot' does not match 'ibm' (re: (?i)^(ibm)$)
INFO - 3/4: rejected: jdk-implementation='hotspot' does not match 'ibm' (re: (?i)^(ibm)$)
INFO - 4/4: rejected: jdk-implementation='openj9' does not match 'ibm' (re: (?i)^(ibm)$)
```

- Debug (`-vv`) mode
```
$ python issue_filter.py --infile tests/data/exclude_out.json --jdk-version 13 --platform re:.*linux.* -vv
DEBUG - Building filters
DEBUG - Using generated pattern '(?i)^(13)$' for jdk-version
DEBUG - No filter applied for jdk-implementation
DEBUG - Using user-provided pattern '.*linux.*' for platform
DEBUG - Loading JSON from tests/data/exclude_out.json
DEBUG - 1/4: accepted
INFO - 2/4: rejected: platform='all_windows' does not match 're:.*linux.*' (re: .*linux.*)
DEBUG - 3/4: accepted
INFO - 4/4: rejected: jdk-version='11' does not match '13' (re: (?i)^(13)$)
DEBUG - Outputting JSON to <stdout>
```