### PR TITLE
Using gradle defined by spring project

### DIFF
--- a/external/spring/playlist.xml
+++ b/external/spring/playlist.xml
@@ -15,6 +15,12 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
 	<test>
 		<testCaseName>spring_test</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3505#issuecomment-1086270612</comment>
+				<version>17</version>
+			</disable>
+		</disables>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir spring --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 			$(TEST_STATUS); \
 			$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir spring

--- a/external/spring/test.properties
+++ b/external/spring/test.properties
@@ -1,5 +1,4 @@
 github_url="https://github.com/spring-projects/spring-boot.git"
 test_results="testResults"
-gradle_version="5.1"
 ubuntu_packages="git wget unzip"
-tag_version="v2.6.4"
+tag_version="v2.6.6"


### PR DESCRIPTION
Instead of manually setup gradle by test.properties we should use the gradle wrapper set up by project itself. Also update to v2.6.6.

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>