### PR TITLE
Updating Kafka project to remove gradle

### DIFF
--- a/external/dockerfile_functions.sh
+++ b/external/dockerfile_functions.sh
@@ -189,27 +189,6 @@ print_sbt_install() {
           "\n" >> ${file}
 }
 
-# Install Gradle
-print_gradle_install() {
-    local file=$1
-    local gradle_version=$2
-
-    echo -e "ARG GRADLE_VERSION=${gradle_version}" \
-          "\nENV GRADLE_VERSION=\$GRADLE_VERSION" \
-          "\nENV GRADLE_HOME /opt/gradle" \
-          "\n\n# Install Gradle" \
-          "\nRUN wget --no-verbose --no-check-certificate --no-cookies https://services.gradle.org/distributions/gradle-\${GRADLE_VERSION}-bin.zip \\" \
-          "\n\t&& wget --no-verbose --no-check-certificate --no-cookies https://services.gradle.org/distributions/gradle-\${GRADLE_VERSION}-bin.zip.sha256 \\" >> ${file}
-
-    echo -e "\t&& echo \"\$(cat gradle-\${GRADLE_VERSION}-bin.zip.sha256) gradle-\${GRADLE_VERSION}-bin.zip\" | sha256sum -c \\" >> ${file}
-
-    echo -e "\t&& unzip gradle-\${GRADLE_VERSION}-bin.zip -d \${GRADLE_HOME} \\" \
-            "\n\t&& ln -s \"\${GRADLE_HOME}/gradle-\${GRADLE_VERSION}/bin/gradle\" /usr/bin/gradle \\" \
-            "\n\t&& rm -f gradle-\${GRADLE_VERSION}-bin.zip \\" \
-            "\n\t&& rm -f gradle-\${GRADLE_VERSION}-bin.zip.sha256" \
-            "\n" >> ${file}
-}
-
 # Install Ivy
 print_ivy_install() {
     local file=$1
@@ -460,10 +439,6 @@ generate_dockerfile() {
 
     if [[ ! -z ${sbt_version} ]]; then
         print_sbt_install ${file} ${sbt_version};
-    fi
-
-    if [[ ! -z ${gradle_version} ]]; then
-        print_gradle_install ${file} ${gradle_version};
     fi
 
     if [[ ! -z ${openssl_version} ]]; then

--- a/external/kafka/test.properties
+++ b/external/kafka/test.properties
@@ -1,4 +1,3 @@
 github_url="https://github.com/apache/kafka.git"
 tag_version="3.1.0"
-gradle_version="5.4"
 ubuntu_packages="git wget unzip"

--- a/external/kafka/test.sh
+++ b/external/kafka/test.sh
@@ -19,7 +19,6 @@ echo_setup
 # Initial command to trigger the execution of kafka test
 set -e
 echo "Building kafka  using gradle"
-gradle -q
 ./gradlew -q jar
 
 echo "Kafka Build - Completed"


### PR DESCRIPTION
This PR removes the print_gradle_install function in dockerfile_function.sh and removes the gradle tag from Kafta project.

Part of https://github.com/adoptium/aqa-tests/issues/3510

Signed-off-by: Abeer Waheed [amir2@ualberta.ca](mailto:amir2@ualberta.ca)