### PR TITLE
Specify -XstartOnFirstThread for MacOS JCK tests

### DIFF
--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -80,6 +80,11 @@ ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
   ifeq ($(filter 8 9 10 11 12 13 14 15 16, $(JDK_VERSION)),)
     OTHER_OPTS += -XX:-OpenJ9CommandLineEnv
   endif
+  ifeq (8, $(JDK_VERSION))
+    ifneq (,$(findstring osx, $(SPEC)))
+      OTHER_OPTS += -XstartOnFirstThread
+    endif
+  endif
 endif
 
 # If testsuite is not specified, default to RUNTIME


### PR DESCRIPTION
Required by `api/javax_activation/DataHandler/testlist.html`

related `runtimes/backlog/issues/558`
Grinder - `Test_grinder/job/Grinder/22682`

Signed-off-by: Jason Feng <fengj@ca.ibm.com>