### PR TITLE
Exclude javax_management & java_rmi from z/OS JDK 11

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -638,6 +638,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-java_rmi</testCaseName>
+		<disables>
+			<disable>
+				<comment>Temporarily disabled on z/OS for backlog/issues/744</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -921,6 +929,14 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_management</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled on z/OS due to backlog/issues/730</comment>
+				<platform>.*zos.*</platform>
+				<impl>ibm</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- Exclude javax_management & java_rmi from z/OS JDK 11
- Details : backlog/issues/744
- Related exclude list updated: backlog/issues/479

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>