### PR TITLE
Disable javax_accessibility due to infrastructure/issues/5254

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -783,12 +783,12 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
+				<platform>x86-64_mac|ppc64_aix|aarch64_mac</platform>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on osx for infrastructure/issues/5254; on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
+				<platform>x86-64_mac|ppc64_aix|aarch64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>


### PR DESCRIPTION
This PR adds excludes for javax_accessibility on aarch64_mac due to infrastructure/issues/5254

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>