### PR TITLE
(v0.9.1-release) Pass Java option to not capture command line in OpenJ9 & Specify -XstartOnFirstThread for MacOS JCK tests (#3559)

### DIFF
--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -80,6 +80,11 @@ ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
   ifeq ($(filter 8 9 10 11 12 13 14 15 16, $(JDK_VERSION)),)
     OTHER_OPTS += -XX:-OpenJ9CommandLineEnv
   endif
+  ifeq (8, $(JDK_VERSION))
+    ifneq (,$(findstring osx, $(SPEC)))
+      OTHER_OPTS += -XstartOnFirstThread
+    endif
+  endif
 endif
 
 # If testsuite is not specified, default to RUNTIME

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -76,6 +76,10 @@ ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
   ifneq (8, $(JDK_VERSION))
     OTHER_OPTS += --enable-preview
   endif
+  # if JDK_VERSION >= 17
+  ifeq ($(filter 8 9 10 11 12 13 14 15 16, $(JDK_VERSION)),)
+    OTHER_OPTS += -XX:-OpenJ9CommandLineEnv
+  endif
 endif
 
 # If testsuite is not specified, default to RUNTIME
@@ -84,11 +88,11 @@ ifeq (,$(findstring testsuite, $(JCK_CUSTOM_TARGET)))
 endif
 
 define JCK_CMD_TEMPLATE_JRE
-$(JRE_COMMAND) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(OTHER_OPTS) -cp $(TEST_ROOT)/jck/jtrunner/bin JavaTestRunner resultsRoot=$(REPORTDIR) testRoot=$(TEST_ROOT)
+$(JRE_COMMAND) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavaTestRunner resultsRoot=$(REPORTDIR) testRoot=$(TEST_ROOT)
 endef
 
 define JCK_CMD_TEMPLATE
-$(JAVA_COMMAND) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(OTHER_OPTS) -cp $(TEST_ROOT)/jck/jtrunner/bin JavaTestRunner resultsRoot=$(REPORTDIR) testRoot=$(TEST_ROOT)
+$(JAVA_COMMAND) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavaTestRunner resultsRoot=$(REPORTDIR) testRoot=$(TEST_ROOT)
 endef
 
 ifeq ($(USE_JRE),1)


### PR DESCRIPTION
Cherry-pick https://github.com/adoptium/aqa-tests/pull/3544
Pass Java option to not capture command line in OpenJ9 (https://github.com/adoptium/aqa-tests/pull/3544)
Fixes some test errors caused by capturing the command line in an
environment variable.

Add quotes around OTHER_OPTS when passed to Java commands in makefile
so more than one opt can be included.

https://github.com/adoptium/aqa-tests/pull/3559
Required by api/javax_activation/DataHandler/testlist.html

This is required to use v0.9.1-release for OpenJ9 0.32 release builds.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>