### PR TITLE
(v0.9.1-release) Exclude TreeTest in jdk_lang for aix and win (#3550)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -41,6 +41,7 @@ java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/open
 java/lang/ProcessBuilder/Basic.java#id0		https://github.com/eclipse-openj9/openj9/issues/9032	linux-aarch64,aix-all,linux-ppc64le
 java/lang/ProcessBuilder/Basic.java#id1		https://github.com/eclipse-openj9/openj9/issues/9032	linux-aarch64,linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
+java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -40,6 +40,7 @@ java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
 java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
+java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all

--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -39,6 +39,7 @@ java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
 java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
+java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all


### PR DESCRIPTION
- Exclude TreeTest in jdk_lang for aix and win

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>