### PR TITLE
(v0.8.0-release) Re-exclude openjdk tests in JDK17 openj9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -35,7 +35,7 @@ java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-openj9/openj9/issues/3178	generic-all
-java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/eclipse-openj9/openj9/issues/14441	aix-all
+java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/adoptium/temurin-build/issues/248 generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
 java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
@@ -67,6 +67,7 @@ java/lang/String/concat/WithSecurityManager.java	https://github.com/eclipse-open
 java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse-openj9/openj9/issues/6666	generic-all
 java/lang/String/StringRepeat.java	https://github.com/eclipse-openj9/openj9/issues/6667	generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
+java/lang/String/nativeEncoding/StringPlatformChars.java https://github.com/adoptium/temurin-build/issues/248 generic-all
 java/lang/StringBuilder/HugeCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
@@ -126,11 +127,12 @@ java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/op
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+vm/JniInvocationTest.java https://github.com/adoptium/temurin-build/issues/248 macosx-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
-java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14397 macosx-all
+java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/adoptium/temurin-build/issues/248 generic-all
 
 ############################################################################
 


### PR DESCRIPTION

Revert https://github.com/adoptium/aqa-tests/pull/3315 and https://github.com/adoptium/aqa-tests/pull/3271 in v0.8.0-release branch
Signed-off-by: lanxia <lan_xia@ca.ibm.com>