### PR TITLE
Exclude api-java_security on Windows on all tck versions

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -664,37 +664,13 @@
 			<disable>
 				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows|x86-32_windows</platform>
-				<version>11</version>
+				<version>8+</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows|x86-32_windows</platform>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows|x86-32_windows</platform>
-				<version>17</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows|x86-32_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows|x86-32_windows</platform>
-				<version>8</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows|x86-32_windows</platform>
-				<version>17</version>
+				<version>8+</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>


### PR DESCRIPTION
Exclude api-java_security on Windows for tck 8+. 

Details: backlog/issues/488. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>