### PR TITLE
Exclude AdaptorMulticasting mac for openj9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -238,7 +238,7 @@ java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse-openj9/openj9/issues/4473 generic-all
 java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse-openj9/openj9/issues/8063	generic-all
 java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse-openj9/openj9/issues/8065	generic-all
-java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all,linux-s390x
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all,linux-s390x,macosx-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/infrastructure/issues/1173	linux-all,aix-all
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all

--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -232,9 +232,6 @@ java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse-openj9/openj9/issues/4473 generic-all
 java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse-openj9/openj9/issues/8063	generic-all
 java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse-openj9/openj9/issues/8065	generic-all
-java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
-java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
-java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/infrastructure/issues/1173	linux-all,aix-all
 java/nio/channels/AsynchronousChannelGroup/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/AsynchronousChannelGroup/GroupOfOne.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
@@ -250,7 +247,7 @@ java/nio/channels/AsynchronousSocketChannel/Leaky.java https://github.ibm.com/ru
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/Channels/Basic2.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/AdaptorBasic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all,macosx-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ConnectedSend.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
@@ -258,7 +255,7 @@ java/nio/channels/DatagramChannel/Disconnect.java https://github.ibm.com/runtime
 java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x 
+java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
@@ -308,6 +305,7 @@ java/nio/channels/SocketChannel/VectorParams.java https://github.ibm.com/runtime
 java/nio/channels/SocketChannel/Write.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
+java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4679 linux-x64,macosx-all
 
 ############################################################################


### PR DESCRIPTION
- Exclude AdaptorMulticasting mac for openj9
- Related Issue: https://github.ibm.com/runtimes/backlog/issues/684

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>