### PR TITLE
Enabling org-ietf for all releases except JDK8 CE

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -1219,7 +1219,7 @@
 		<disables>
 			<disable>
 				<comment>backlog/issues/567</comment>
-				<version>8</version>
+				<version>11</version>
 				<impl>ibm</impl>
 			</disable>
 		</disables>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -1219,8 +1219,7 @@
 		<disables>
 			<disable>
 				<comment>backlog/issues/567</comment>
-				<version>11</version>
-				<impl>ibm</impl>
+				<platform>.*zos.*</platform>
 			</disable>
 		</disables>
 	</test>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -1219,10 +1219,7 @@
 		<disables>
 			<disable>
 				<comment>backlog/issues/567</comment>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>backlog/issues/567</comment>
+				<version>8</version>
 				<impl>ibm</impl>
 			</disable>
 		</disables>


### PR DESCRIPTION
This PR enables jck_org_ietf tests for all releases except JDK8 CE.

Fixes  runtimes/backlog/issues/567

Signed-off-by: Pasam Soujanya [psoujany@in.ibm.com](mailto:psoujany@in.ibm.com)