### PR TITLE
Exclude spring_test temporarily

### DIFF
--- a/external/spring/playlist.xml
+++ b/external/spring/playlist.xml
@@ -17,6 +17,14 @@
 		<testCaseName>spring_test</testCaseName>
 		<disables>
 			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3540</comment>
+				<impl>hotspot</impl>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3540</comment>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3505#issuecomment-1086270612</comment>
 				<version>17</version>
 			</disable>


### PR DESCRIPTION
- Exclude sprint_test temporarily
- Related Issue: https://github.com/adoptium/aqa-tests/issues/3540

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>