### PR TITLE
archive AQAvit files in artifactory

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -74,12 +74,19 @@ def setupEnv() {
 	env.EXTERNAL_TEST_CMD=params.EXTERNAL_TEST_CMD ? params.EXTERNAL_TEST_CMD : "mvn clean install"
 	env.DYNAMIC_COMPILE=params.DYNAMIC_COMPILE ? params.DYNAMIC_COMPILE : false
 	env.BUILD_LIST = params.BUILD_LIST ? params.BUILD_LIST : ""
-	env.TAP_NAME = "${JOB_NAME}.tap"
 	env.USE_JRE=params.USE_JRE ? params.USE_JRE : false
 	env.RERUN_LINK = ""
 	env.FAILED_TEST_TARGET = ""
 
 	ITERATIONS = params.ITERATIONS ? "${params.ITERATIONS}".toInteger() : 1
+
+	if (JOB_NAME.contains("Grinder")) {
+		def currentDate = new Date()
+		def currentDateTime = currentDate.format("yyyyMMddHHmmss", TimeZone.getTimeZone('UTC'))
+		env.TAP_NAME = "${JOB_NAME}_${currentDateTime}.tap"
+	} else {
+		env.TAP_NAME = "${JOB_NAME}.tap"
+	}
 
 	if (params.CODE_COVERAGE) {
 		// GCOV strips # num from folder path in BUILD pipeline, e.g., /home/jenkins/workspace/Build_JDK11_x86-64_linux_Personal/build/linux-x86_64-normal-server-release/vm
@@ -692,6 +699,7 @@ def post(output_name) {
 			archiveFile("aqa-tests/TKG/SHA.txt", true)
 			archiveFile("aqa-tests/TKG/AQACert.log", true)
 			archiveFile("**/*.tap", true)
+			archiveAQAvitFiles()
 
 			if (env.BUILD_LIST.startsWith('jck')) {
 				xunit (
@@ -888,6 +896,24 @@ def getJenkinsDomain() {
 	return domainName
 }
 
+def archiveAQAvitFiles() {
+	if (params.USE_TESTENV_PROPERTIES && !JOB_NAME.contains("_testList_")) {
+		if (params.ARTIFACTORY_SERVER) {
+			def currentDate = new Date()
+			def currentDateTime = currentDate.format("yyyyMMddHHmmss", TimeZone.getTimeZone('UTC'))
+			def uploadDir = "AQAvit/${JDK_IMPL}/${ADOPTOPENJDK_BRANCH}/${JDK_VERSION}/${PLATFORM}/${currentDateTime}"
+			uploadToArtifactory("${env.WORKSPACE}/**/*.tap", uploadDir)
+
+			// TODO: Donot need to archive SHA.txt and AQACert.log once the following issues are resolved:
+			// https://github.com/adoptium/TKG/issues/314
+			// https://github.com/adoptium/TKG/issues/313
+			// https://github.com/adoptium/TKG/issues/312
+			uploadToArtifactory("${env.WORKSPACE}/**/SHA.txt", uploadDir)
+			uploadToArtifactory("${env.WORKSPACE}/**/AQACert.log", uploadDir)
+		}
+	}
+}
+
 // If forceStoreOnJenkins set to true, archive on Jenkins.
 // If forceStoreOnJenkins set to false, archive on Artifactory if ARTIFACTORY_SERVER is provided. Otherwise, archive on Jenkins
 def archiveFile(filename, forceStoreOnJenkins) {
@@ -901,7 +927,7 @@ def archiveFile(filename, forceStoreOnJenkins) {
 	}
 }
 
-def uploadToArtifactory(pattern) {
+def uploadToArtifactory(pattern, artifactoryUploadDir="") {
 	if (params.ARTIFACTORY_SERVER) {
 		def server = Artifactory.server params.ARTIFACTORY_SERVER
 		def artifactoryRepo = params.ARTIFACTORY_REPO ? params.ARTIFACTORY_REPO : "sys-rt-generic-local"
@@ -909,30 +935,42 @@ def uploadToArtifactory(pattern) {
 		if (artifactoryRoorDir.endsWith("/")) {
 			artifactoryRoorDir = artifactoryRoorDir.substring(0, artifactoryRoorDir.length() - 1);
 		}
-		def artifactoryUploadDir = "${artifactoryRepo}/${artifactoryRoorDir}/${JOB_NAME}/${BUILD_ID}/"
+		def fullUploadPath = "${artifactoryRepo}/${artifactoryRoorDir}/${JOB_NAME}/${BUILD_ID}/"
+		if (artifactoryUploadDir) {
+			fullUploadPath = "${artifactoryRepo}/${artifactoryRoorDir}/${artifactoryUploadDir}/"
+		}
 
 		def uploadSpec = """{
 			"files":[
 					{
 						"pattern": "${pattern}",
-						"target": "${artifactoryUploadDir}"
+						"target": "${fullUploadPath}"
 					}
 				]
 			}"""
 
 		def buildInfo = Artifactory.newBuildInfo()
-		// if ARTIFACTORY_NUM_ARTIFACTS is not set, set to keep 20 build artifacts
-		def numArtifacts = params.ARTIFACTORY_NUM_ARTIFACTS ? params.ARTIFACTORY_NUM_ARTIFACTS : 20
 
-		buildInfo.retention maxBuilds: numArtifacts, deleteBuildArtifacts: true
+		if (artifactoryUploadDir && artifactoryUploadDir.contains("AQAvit")) {
+			buildInfo.name = "sys-rt/AQAvit_" + buildInfo.name
+		} else {
+			// if ARTIFACTORY_NUM_ARTIFACTS is not set, set to keep 20 build artifacts
+			def numArtifacts = params.ARTIFACTORY_NUM_ARTIFACTS ? params.ARTIFACTORY_NUM_ARTIFACTS : 20
+			buildInfo.retention maxBuilds: numArtifacts, deleteBuildArtifacts: true
+		}
 		server.upload spec: uploadSpec, buildInfo: buildInfo
 		server.publishBuildInfo buildInfo
 
 		def artifactoryUrl = server.getUrl()
-		def uploadUrl = "${artifactoryUrl}/${artifactoryUploadDir}"
-		echo "Test output artifactory URL:'${uploadUrl}'"
+		def uploadUrl = "${artifactoryUrl}/${fullUploadPath}"
 		if (!currentBuild.description.contains(uploadUrl)) {
-			currentBuild.description += "<br><a href=${uploadUrl}>Artifacts</a>"
+			if (uploadUrl.contains("AQAvit")) {
+				echo "AQAvit files artifactory URL:'${uploadUrl}'"
+				currentBuild.description += "<br><a href=${uploadUrl}>AQAvit Artifacts</a>"
+			} else {
+				echo "Test output artifactory URL:'${uploadUrl}'"
+				currentBuild.description += "<br><a href=${uploadUrl}>Artifacts</a>"
+			}
 		}
 	} else {
 		echo "ARTIFACTORY_SERVER is not set. Artifacts are not uploaded onto artifactory server."
@@ -1020,12 +1058,14 @@ def run_parallel_tests() {
 									copyArtifacts (projectName: "${name}", selector: specific("${buildId}"), filter: "**/*.tap", target:"${name}/${buildId}")
 									if (!archiveAQACert) {
 										copyArtifacts (projectName: "${name}", selector: specific("${buildId}"), filter: "**/AQACert.log", target:"${name}/${buildId}")
+										copyArtifacts (projectName: "${name}", selector: specific("${buildId}"), filter: "**/SHA.txt", target:"${name}/${buildId}")
 									}
 								}
 								step([$class: "TapPublisher", testResults: "${name}/${buildId}/**/*.tap", outputTapToConsole: false, failIfNoResults: true])
 								archiveFile("${name}/${buildId}/**/*.tap", true)
 								if (!archiveAQACert) {
 									archiveFile("${name}/${buildId}/**/AQACert.log", true)
+									archiveFile("${name}/${buildId}/**/SHA.txt", true)
 									archiveAQACert = true
 								}
 							} catch (Exception e) {
@@ -1037,6 +1077,7 @@ def run_parallel_tests() {
 						echo "set build status to ${buildResult}"
 						currentBuild.result = buildResult
 					}
+					archiveAQAvitFiles()
 					addFailedTestsGrinderLink()
 				} finally {
 					// cleanWs() does not work in some cases, so set opts below


### PR DESCRIPTION
- add date time in Grinder tap file name to avoid duplicate file name
- archive SHA.txt in the parent job
- add `AQAvit Artifacts` link
- if USE_TESTENV_PROPERTIES is set to true and it is not a child job, archive AQAvit files (TAP, SHA.txt, AQACert.log) for the releases in artifactory under
AQAvit/${JDK_IMPL}/${ADOPTOPENJDK_BRANCH}/${JDK_VERSION}/${PLATFORM}/${currentDateTime}

Signed-off-by: lanxia <lan_xia@ca.ibm.com>