### PR TITLE
fix _SecurityTests_0 test fail

### DIFF
--- a/functional/security/src/net/adoptopenjdk/test/DefaultTlsFunctionalTest.java
+++ b/functional/security/src/net/adoptopenjdk/test/DefaultTlsFunctionalTest.java
@@ -43,7 +43,7 @@ public class DefaultTlsFunctionalTest {
 
     private final static String[] TLS_HOSTS = {
             "https://www.cloudflare.com/",
-            "https://www.google.com/",
+            "https://www2.bing.com/",
             "https://services.gradle.org/", // Ensure that Gradle can be downloaded.
             "https://repo1.maven.org/" // Ensure that Maven artifacts can be resolved.
     };


### PR DESCRIPTION
www.google.com can't be reache normally in CHINA. So change the test website from https://www.google.com/ to https://www2.bing.com/

Fixes: #3601

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>