### PR TITLE
Temporarily exclude quarkus_quickstarts for aarch and zlinux

### DIFF
--- a/external/quarkus_quickstarts/playlist.xml
+++ b/external/quarkus_quickstarts/playlist.xml
@@ -19,6 +19,18 @@
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir quarkus_quickstarts 
 		</command>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3518</comment>
+				<platform>.*(aarch64_linux|s390x_linux).*</platform>
+				<impl>hotspot</impl>
+			</disable>
+			<disable>
+				<comment>github_ibm/runtimes/backlog/issues/776</comment>
+				<platform>.*(aarch64_linux|s390).*</platform>
+				<impl>openj9</impl>
+			</disable>
+		</disables>		
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
- Temporarily exclude quarkus_quickstarts for aarch and zlinux
- Related Issue: https://github.com/adoptium/aqa-tests/issues/3518

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>