### PR TITLE
[arm32] Exclude problematic tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -154,6 +154,7 @@ java/nio/file/Files/InputStreamTest.java	https://github.com/adoptium/aqa-tests/i
 jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
 java/net/SocketPermission/SocketPermissionTest.java	https://bugs.openjdk.java.net/browse/JDK-8269919 aix-all
 java/nio/channels/DatagramChannel/BasicMulticastTests.java	https://bugs.openjdk.java.net/browse/JDK-8269919 aix-all
+java/nio/file/DirectoryStream/SecureDS.java https://github.com/adoptium/aqa-tests/issues/3635 linux-arm
 ############################################################################ 
 
 # jdk_rmi

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -333,6 +333,7 @@ jdk/incubator/vector/Byte256VectorLoadStoreTests.java https://github.com/adoptiu
 jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/Short64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/ShortMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte128VectorLoadStoreTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 ############################################################################
 
 # jvm_compiler

--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -137,35 +137,35 @@ java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/adoptium/in
 java/net/MulticastSocket/Test.java                             https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 ###
 java/net/MulticastSocket/B6427403.java  https://github.com/adoptium/infrastructure/issues/699   aix-ppc64
-java/net/MulticastSocket/IPMulticastIF.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux_ppc64le
-java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux_ppc64le
-java/net/CookieHandler/CookieManagerTest.java   https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux_ppc64le
-java/net/DatagramPacket/ReuseBuf.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64, linux_ppc64le
-java/net/DatagramSocket/PortUnreachable.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/ReuseAddressTest.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/Send12k.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64,linux_ppc64le 
-java/net/DatagramSocket/SendSize.java.SendSize  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/ProxyCons.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/ReadTimeout.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/SetSoLinger.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/SoTimeout.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/asyncClose/AsyncClose.java  https://github.com/adoptium/aqa-tests/issues/827 aix-ppc64, linux_ppc64le
-java/net/Socket/asyncClose/BrokenPipe.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/setReuseAddress/Basic.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/setReuseAddress/Restart.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/SocketInputStream/SocketTimeout.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socks/BadProxySelector.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socks/SocksProxyVersion.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/asyncClose/Race.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/MulticastSocket/IPMulticastIF.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux-ppc64le
+java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux-ppc64le
+java/net/CookieHandler/CookieManagerTest.java   https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux-ppc64le
+java/net/DatagramPacket/ReuseBuf.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64, linux-ppc64le
+java/net/DatagramSocket/PortUnreachable.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/ReuseAddressTest.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/Send12k.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64,linux-ppc64le 
+java/net/DatagramSocket/SendSize.java.SendSize  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ProxyCons.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ReadTimeout.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SetSoLinger.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SoTimeout.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/AsyncClose.java  https://github.com/adoptium/aqa-tests/issues/827 aix-ppc64, linux-ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Basic.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Restart.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/SocketInputStream/SocketTimeout.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/BadProxySelector.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/SocksProxyVersion.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/Race.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/httpclient/ManyRequests.java   https://github.com/adoptium/aqa-tests/issues/2828 aix-ppc64
-java/net/ipv6tests/UdpTest.java.UdpTest https://github.com/adoptium/aqa-tests/issues/2828 linux_s390x
+java/net/ipv6tests/UdpTest.java.UdpTest https://github.com/adoptium/aqa-tests/issues/2828 linux-s390x
 
 
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
@@ -175,12 +175,12 @@ java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
 java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 linux-s390x
-java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux_s390x,win_64
-java/nio/channels/FileChannel/LargeGatheringWrite.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64,win_64
+java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
+java/nio/channels/FileChannel/LargeGatheringWrite.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64,windows-x64
 java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
 java/nio/channels/DatagramChannel/AfterDisconnect.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789   aix-ppc64,win_64
+java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789   aix-ppc64,windows-x64
 java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 
 ############################################################################
@@ -214,7 +214,7 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
-java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux_ppc64le,linux_s390x
+java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x
  
 
 ############################################################################ 
@@ -246,16 +246,16 @@ security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.jav
 ############################################################################
 
 # jdk_tools
-sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
-sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
-sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
-sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
-sun/tools/jstatd/TestJstatdDefaults.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdExternalRegistry.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdPort.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdPortAndServer.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdServer.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstatd/TestJstatdDefaults.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdExternalRegistry.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPort.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPortAndServer.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdServer.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
 tools/jpackage/share/AddLauncherTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppImagePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
@@ -363,7 +363,7 @@ compiler/graalunit/Replacements12Test.java https://github.com/adoptium/aqa-tests
 compiler/graalunit/Replacements9Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/ReplacementsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/UtilTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
-compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux_s390x
+compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux-s390x
 
 compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
@@ -398,7 +398,7 @@ jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests
 
 jdk/jfr/api/consumer/TestRecordedFullStackTrace.java https://bugs.openjdk.java.net/browse/JDK-8284024 linux-s390x
 jdk/jfr/event/profiling/TestFullStackTrace.java https://bugs.openjdk.java.net/browse/JDK-8284024 linux-s390x
-jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/2919 aarch64-linux,linux_ppc64le,linux_s390x
+jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/2919 aarch64-linux,linux-ppc64le,linux-s390x
 jdk/jfr/jmx/streaming/TestMetadataEvent.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
 jdk/jfr/jmx/streaming/TestSetSettings.java  https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
 jdk/jfr/jmx/streaming/TestStart.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86
@@ -428,27 +428,27 @@ runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://b
 javax/imageio/plugins/shared/ImageWriterCompressionTest.java  https://github.com/adoptium/aqa-tests/issues/3072 linux-arm  
 ############################################################################
 #javax_management
-javax/management/remote/mandatory/connection/RMIConnectionIdTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/notif/RMINotifTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java  https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/util/MapNullValuesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
+javax/management/remote/mandatory/connection/RMIConnectionIdTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/notif/RMINotifTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java  https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/util/MapNullValuesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
 
 
 ############################################################################
 #sun_net
-sun/net/www/http/HttpClient/B8025710.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/http/KeepAliveCache/B5045306.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/http/NoCache.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/http/ZoneId.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/http/HttpClient/B8025710.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/http/KeepAliveCache/B5045306.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/NoCache.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/ZoneId.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
 #####################################
 

--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -82,7 +82,7 @@ java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adopt
 
 java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
 java/lang/System/FileEncodingTest.java  https://github.com/adoptium/aqa-tests/issues/1267   aix-ppc64
- 
+java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 linux-arm
 
 
 ############################################################################
@@ -182,6 +182,11 @@ java/nio/channels/DatagramChannel/AfterDisconnect.java  https://github.com/adopt
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
 java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789   aix-ppc64,windows-x64
 java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
+com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
+java/net/InetAddress/HostsFileOrderingTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
+java/net/InetAddress/InternalNameServiceTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
+java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk19.txt
+++ b/openjdk/excludes/ProblemList_openjdk19.txt
@@ -136,35 +136,35 @@ java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/adoptium/in
 java/net/MulticastSocket/Test.java                             https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 ###
 java/net/MulticastSocket/B6427403.java  https://github.com/adoptium/infrastructure/issues/699   aix-ppc64
-java/net/MulticastSocket/IPMulticastIF.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux_ppc64le
-java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux_ppc64le
-java/net/CookieHandler/CookieManagerTest.java   https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux_ppc64le
-java/net/DatagramPacket/ReuseBuf.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64, linux_ppc64le
-java/net/DatagramSocket/PortUnreachable.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/ReuseAddressTest.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/Send12k.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64,linux_ppc64le 
-java/net/DatagramSocket/SendSize.java.SendSize  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/ProxyCons.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/ReadTimeout.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/SetSoLinger.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/SoTimeout.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/asyncClose/AsyncClose.java  https://github.com/adoptium/aqa-tests/issues/827 aix-ppc64, linux_ppc64le
-java/net/Socket/asyncClose/BrokenPipe.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/setReuseAddress/Basic.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/setReuseAddress/Restart.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/SocketInputStream/SocketTimeout.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socks/BadProxySelector.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socks/SocksProxyVersion.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/Socket/asyncClose/Race.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+java/net/MulticastSocket/IPMulticastIF.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux-ppc64le
+java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux-ppc64le
+java/net/CookieHandler/CookieManagerTest.java   https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux-ppc64le
+java/net/DatagramPacket/ReuseBuf.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64, linux-ppc64le
+java/net/DatagramSocket/PortUnreachable.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/ReuseAddressTest.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/Send12k.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64,linux-ppc64le 
+java/net/DatagramSocket/SendSize.java.SendSize  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ProxyCons.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ReadTimeout.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SetSoLinger.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SoTimeout.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/AsyncClose.java  https://github.com/adoptium/aqa-tests/issues/827 aix-ppc64, linux-ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Basic.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Restart.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/SocketInputStream/SocketTimeout.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/BadProxySelector.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/SocksProxyVersion.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/Race.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/httpclient/ManyRequests.java   https://github.com/adoptium/aqa-tests/issues/2828 aix-ppc64
-java/net/ipv6tests/UdpTest.java.UdpTest https://github.com/adoptium/aqa-tests/issues/2828 linux_s390x
+java/net/ipv6tests/UdpTest.java.UdpTest https://github.com/adoptium/aqa-tests/issues/2828 linux-s390x
 
 
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
@@ -174,12 +174,12 @@ java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
 java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 linux-s390x
-java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux_s390x,win_64
-java/nio/channels/FileChannel/LargeGatheringWrite.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64,win_64
+java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
+java/nio/channels/FileChannel/LargeGatheringWrite.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64,windows-x64
 java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
 java/nio/channels/DatagramChannel/AfterDisconnect.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789   aix-ppc64,win_64
+java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789   aix-ppc64,windows-x64
 java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 
 ############################################################################
@@ -213,7 +213,7 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
-java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux_ppc64le,linux_s390x
+java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x
  
 
 ############################################################################ 
@@ -245,16 +245,16 @@ security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.jav
 ############################################################################
 
 # jdk_tools
-sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
-sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
-sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
-sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux_ppc64le
-sun/tools/jstatd/TestJstatdDefaults.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdExternalRegistry.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdPort.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdPortAndServer.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/tools/jstatd/TestJstatdServer.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstatd/TestJstatdDefaults.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdExternalRegistry.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPort.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPortAndServer.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdServer.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
 tools/jpackage/share/AddLauncherTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppImagePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
@@ -362,7 +362,7 @@ compiler/graalunit/Replacements12Test.java https://github.com/adoptium/aqa-tests
 compiler/graalunit/Replacements9Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/ReplacementsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/UtilTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
-compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux_s390x
+compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux-s390x
 
 compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
@@ -395,7 +395,7 @@ jdk/jfr/jmx/streaming/TestRemoteDump.java	https://github.com/adoptium/aqa-tests/
 jdk/jfr/jmx/streaming/TestRotate.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 
-jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/2919 aarch64-linux,linux_ppc64le,linux_s390x
+jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/2919 aarch64-linux,linux-ppc64le,linux-s390x
 jdk/jfr/jmx/streaming/TestMetadataEvent.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
 jdk/jfr/jmx/streaming/TestSetSettings.java  https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
 jdk/jfr/jmx/streaming/TestStart.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86
@@ -423,27 +423,27 @@ runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://b
 javax/imageio/plugins/shared/ImageWriterCompressionTest.java  https://github.com/adoptium/aqa-tests/issues/3072 linux-arm  
 ############################################################################
 #javax_management
-javax/management/remote/mandatory/connection/RMIConnectionIdTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/notif/RMINotifTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java  https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
-javax/management/remote/mandatory/util/MapNullValuesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux_ppc64le
+javax/management/remote/mandatory/connection/RMIConnectionIdTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/notif/RMINotifTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java  https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/util/MapNullValuesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
 
 
 ############################################################################
 #sun_net
-sun/net/www/http/HttpClient/B8025710.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/http/KeepAliveCache/B5045306.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/http/NoCache.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/http/ZoneId.java   https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java    https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
-sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java  https://github.com/adoptium/aqa-tests/issues/3088 linux_ppc64le
+sun/net/www/http/HttpClient/B8025710.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/http/KeepAliveCache/B5045306.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/NoCache.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/ZoneId.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
 #####################################
 

--- a/openjdk/excludes/ProblemList_openjdk19.txt
+++ b/openjdk/excludes/ProblemList_openjdk19.txt
@@ -81,7 +81,7 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-te
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 
 java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
- 
+java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 linux-arm
 
 
 ############################################################################
@@ -181,7 +181,11 @@ java/nio/channels/DatagramChannel/AfterDisconnect.java  https://github.com/adopt
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
 java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789   aix-ppc64,windows-x64
 java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-
+com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
+com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
+java/net/InetAddress/HostsFileOrderingTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
+java/net/InetAddress/InternalNameServiceTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
+java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm
 ############################################################################
 
 # jdk_io

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -107,7 +107,21 @@ runtime/7110720/Test7110720.sh https://github.com/adoptium/aqa-tests/issues/2818
 compiler/6894807/IsInstanceTest.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/8004051/Test8004051.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
-compiler/criticalnatives/argumentcorruption/Test8167409.sh https://github.com/adoptium/aqa-tests/issues/2984 linux-aarch64
+compiler/criticalnatives/argumentcorruption/Test8167409.sh https://github.com/adoptium/aqa-tests/issues/2984 linux-aarch64,linux-arm
+compiler/c2/cr6340864/TestByteVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm
+compiler/c2/cr6340864/TestDoubleVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm
+compiler/c2/cr6340864/TestFloatVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm
+compiler/c2/cr6340864/TestIntVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm
+compiler/c2/cr6340864/TestLongVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm
+compiler/c2/cr6340864/TestShortVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm
+compiler/codegen/TestCharVect2.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm
+compiler/escapeAnalysis/TestGetClass.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm
+compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm
+gc/g1/Test2GbHeap.java https://bugs.openjdk.java.net/browse/JDK-8154787 linux-arm
+gc/g1/TestHumongousShrinkHeap.java https://bugs.openjdk.java.net/browse/JDK-8041506 linux-arm
+gc/whitebox/TestConcMarkCycleWB.java https://bugs.openjdk.java.net/browse/JDK-8067368 linux-arm
+runtime/StackGap/testme.sh https://bugs.openjdk.java.net/browse/JDK-8201536 linux-arm
+runtime/containers/docker/TestMemoryAwareness.java https://github.com/adoptium/aqa-tests/issues/3250 linux-arm
 ############################################################################
 
 # jdk_awt
@@ -176,8 +190,8 @@ com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java		htt
 sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
-sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/aqa-tests/issues/2792 linux-aarch64,linux-ppc64le
-com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-x64
+sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://bugs.openjdk.java.net/browse/JDK-8031420 linux-aarch64,linux-ppc64le,linux-arm
+com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-x64,linux-arm
 
 ############################################################################
 
@@ -327,7 +341,7 @@ tools/pack200/Pack200Test.java https://github.com/adoptium/aqa-tests/issues/2657
 sun/tools/jstatd/TestJstatdExternalRegistry.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
-
+tools/launcher/RunpathTest.java https://bugs.openjdk.java.net/browse/JDK-8286118 linux-arm
 ############################################################################
 
 # jdk_jdi
@@ -380,7 +394,7 @@ com/sun/jdi/RedefineFinal.sh			https://github.com/adoptium/aqa-tests/issues/2415
 com/sun/jdi/RedefineImplementor.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
 com/sun/jdi/RedefineIntConstantToLong.sh	https://github.com/adoptium/aqa-tests/issues/2415 windows-all
 com/sun/jdi/PrivateTransportTest.sh             https://github.com/adoptium/aqa-tests/issues/2154 windows-all
-
+com/sun/jdi/RedefineCrossEvent.java https://bugs.openjdk.java.net/browse/JDK-8206330 linux-arm
 ############################################################################
 
 # jdk_util
@@ -442,3 +456,24 @@ jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java https://github.com/adoptium/aqa-test
 jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/2985 linux-aarch64
 jdk/jfr/event/io/TestInstrumentation.java https://bugs.openjdk.java.net/browse/JDK-8202142 linux-all
 jdk/jfr/event/compiler/TestCompilerPhase.java https://github.com/adoptium/aqa-tests/issues/3046 windows-all
+jdk/jfr/event/compiler/TestCompile.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/collection/TestGCCauseWithG1ConcurrentMark.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/collection/TestGCCauseWithG1FullCollection.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/detailed/TestEvacuationInfoEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/detailed/TestG1HeapRegionTypeChangeEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/detailed/TestG1MMUEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/detailed/TestPromotionEventWithG1.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventG1.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/objectcount/TestObjectCountAfterGCEventWithG1ConcurrentMark.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/stacktrace/TestG1HumongousAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/stacktrace/TestG1OldAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/stacktrace/TestG1YoungAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/stacktrace/TestMetaspaceG1GCAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/oldobject/TestObjectDescription.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/os/TestCPUInformation.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/os/TestCPUInformation.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/runtime/TestSizeTFlags.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/jvm/TestLargeJavaEvent512k.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -122,6 +122,9 @@ gc/g1/TestHumongousShrinkHeap.java https://bugs.openjdk.java.net/browse/JDK-8041
 gc/whitebox/TestConcMarkCycleWB.java https://bugs.openjdk.java.net/browse/JDK-8067368 linux-arm
 runtime/StackGap/testme.sh https://bugs.openjdk.java.net/browse/JDK-8201536 linux-arm
 runtime/containers/docker/TestMemoryAwareness.java https://github.com/adoptium/aqa-tests/issues/3250 linux-arm
+compiler/gcbarriers/PreserveFPRegistersTest.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
+gc/TestMemoryMXBeansAndPoolsPresence.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
+gc/g1/mixedgc/TestOldGenCollectionUsage.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 ############################################################################
 
 # jdk_awt


### PR DESCRIPTION
1. linux-arm jdk8
https://github.com/adoptium/aqa-tests/issues/3603#issuecomment-1113123584
https://github.com/adoptium/aqa-tests/issues/3603#issuecomment-1121863541
2. Linux-arm jdk11 https://github.com/adoptium/aqa-tests/issues/3596#issuecomment-1104643594
3. Linux-arm jdk17 https://github.com/adoptium/aqa-tests/issues/3594#issuecomment-1104042051
4. Linux-arm jdk18 https://github.com/adoptium/aqa-tests/issues/3599#issuecomment-1105959116 
https://github.com/adoptium/aqa-tests/issues/3637
5. Fix the wrong os-linux information

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>