### PR TITLE
(v0.9.1-release) Exclude failed tests in jdk_nio and jdk_other (#3648)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -305,6 +305,7 @@ java/nio/channels/SocketChannel/VectorParams.java https://github.ibm.com/runtime
 java/nio/channels/SocketChannel/Write.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
+java/nio/file/Files/probeContentType/Basic.java  https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4679 linux-x64,macosx-all
 
@@ -386,6 +387,7 @@ java/util/Random/RandomTestBsi1999.java		https://github.com/eclipse-openj9/openj
 
 # jdk_other
 
+com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/755 windows-all
 
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -402,7 +404,6 @@ jdk/internal/misc/VM/RuntimeArguments.java		https://github.com/eclipse-openj9/op
 jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/eclipse-openj9/openj9/issues/7245		generic-all
 jdk/internal/reflect/constantPool/ConstantPoolTest.java	https://github.com/eclipse-openj9/openj9/issues/7249		generic-all
 
-sun/jndi/ldap/LdapPoolTimeoutTest.java  https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 sun/misc/SunMiscSignalTest.java		https://github.com/eclipse-openj9/openj9/issues/7264		generic-all
 sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/adoptium/aqa-tests/issues/749 windows-all
 sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse-openj9/openj9/issues/5328		generic-all


### PR DESCRIPTION
- Exclude probeContentType in jdk_nio
- Exclude ldapPoolTimeoutTests in jdk_other

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>