### PR TITLE
add Alpine Linux aarch64 to platform map

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -13,6 +13,10 @@ def PLATFORM_MAP = [
         'SPEC' : 'linux_aarch64',
         'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
     ],
+    'aarch64_alpine-linux' : [
+        'SPEC' : 'alpine-linux_aarch64',
+        'LABEL' : 'ci.role.test&&hw.arch.aarch64&&sw.os.alpine-linux',
+    ],
     'ppc32_aix' : [
         'SPEC' : 'aix_ppc',
         'LABEL' : 'ci.role.test&&hw.arch.ppc64&&sw.os.aix',


### PR DESCRIPTION
@sxa has added two test machines: https://ci.adoptopenjdk.net/label/sw.os.alpine-linux&&hw.arch.aarch64/