### PR TITLE
Enable jdk_security3 for openj9 and hotspot jdk11

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -267,6 +267,36 @@ java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj
 
 ############################################################################
 
+# jdk_security3
+
+javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
+javax/net/ssl/SSLEngine/LargePacket.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-s390x,windows-all
+sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/mscapi/CastError.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/InteropWithSunRsaSign.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/KeyAlgorithms.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/KeyStoreEmptyCertChain.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/PublicKeyInterop.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/RSAEncryptDecrypt.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/ShortRSAKeyWithinTLS.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignUsingNONEwithRSA.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignUsingSHA2withRSA.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignatureOffsets.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignedObjectChain.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SmallPrimeExponentP.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/VeryLongAlias.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/pkcs11/Provider/MultipleLogins.sh	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
+sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
+sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
+
+############################################################################
+
 # jdk_security_infra
 
 security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all

--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -168,6 +168,18 @@ security/infra/java/security/cert/CertPathValidator/certification/LetsEncryptCA.
 
 ############################################################################
 
+# jdk_security3
+
+jdk/security/jarsigner/JarWithOneNonDisabledDigestAlg.java	https://github.com/adoptium/aqa-tests/issues/2123	aix-all
+sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/pkcs11/fips/SunJSSEFIPSInit.java	https://github.com/adoptium/aqa-tests/issues/2123	linux-all
+sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/util/RegisteredDomain/ParseNames.java	https://github.com/adoptium/aqa-tests/issues/2123	aix-all
+sun/security/util/RegisteredDomain/Versions.java	https://github.com/adoptium/aqa-tests/issues/2123	aix-all
+
+############################################################################
+
 # jdk_security_infra
 
 security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all

--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -274,6 +274,18 @@ java/security/KeyPairGenerator/FinalizeHalf.java https://github.com/eclipse-open
 java/security/Signature/SignatureLength.java https://github.com/eclipse-openj9/openj9/issues/12083 windows-all
 
 ############################################################################
+
+# jdk_security3
+
+sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/pkcs11/Secmod/TestNssDbSqlite.java	https://github.ibm.com/runtimes/backlog/issues/795	generic-all
+sun/security/pkcs11/fips/TestTLS12.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
+sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/ssl/CipherSuite/SSL_NULL.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+
+############################################################################
 # jdk_security4
 
 sun/security/krb5/auto/ReplayCacheTestProc.java https://github.com/adoptium/aqa-tests/issues/2349 generic-all

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -301,6 +301,16 @@ sun/security/rsa/TestCACerts.java	https://github.com/adoptium/aqa-tests/issues/6
 
 ############################################################################
 
+# jdk_security3
+
+sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/pkcs11/Secmod/TestNssDbSqlite.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/21233	generic-all
+sun/security/tools/jarsigner/diffend.sh	https://github.com/adoptium/aqa-tests/issues/21233	linux-aarch64
+sun/security/tools/jarsigner/emptymanifest.sh	https://github.com/adoptium/aqa-tests/issues/21233	linux-aarch6
+
+############################################################################
+
 # jdk_security4
 
 sun/security/krb5/auto/ReplayCacheTestProc.java https://github.com/adoptium/aqa-tests/issues/2349 generic-all

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -835,14 +835,7 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/2123#issuecomment-758367994</comment>
-			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
-				<impl>ibm</impl>
+				<version>17+</version>
 			</disable>
 		</disables>
 		<variations>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -837,6 +837,11 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/2123#issuecomment-758367994</comment>
 				<version>17+</version>
 			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
+				<platform>.*windows.*</platform>
+				<version>8</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>


### PR DESCRIPTION
- Enable jdk_security3 for jdk11
- JDK 17+ enable will be in another PR
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/10757 https://github.com/adoptium/aqa-tests/issues/2123 https://github.ibm.com/runtimes/backlog/issues/795

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>