### PR TITLE
Add Zookeeper external test

### DIFF
--- a/external/common_functions.sh
+++ b/external/common_functions.sh
@@ -30,7 +30,7 @@ supported_packages="jdk jre"
 supported_builds="full"
 
 # Supported tests
-supported_tests="external_custom camel derby elasticsearch jacoco jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test tomcat tomee wildfly wycheproof netty spring"
+supported_tests="external_custom camel derby elasticsearch jacoco jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test tomcat tomee wildfly wycheproof netty spring zookeeper"
 
 function check_version() {
     version=$1

--- a/external/zookeeper/README.md
+++ b/external/zookeeper/README.md
@@ -1,0 +1,33 @@
+# External Zookeeper Tests
+
+Zookeeper tests are a part of the external third-party application tests that help verify that the Adoptium binaries are good by running a variety of Java applications inside of Docker containers. adoptium/aqa-tests/[Issue #172](https://github.com/adoptium/aqa-tests/issues/172) lists the applications that we have initially targeted to best exercise the Adoptium binaries. For each application, we choose to run a selection of their functional tests. Zookeeper test material is pulled from the [Zookeeper](https://github.com/apache/zookeeper.git) repository.
+
+
+## Running External Zookeeper tests locally
+
+To run AQA tests locally using Zookeeper, you follow the same pattern:
+
+0. Ensure your test machine is set up with [test prereqs](https://github.com/adoptium/aqa-tests/blob/master/doc/Prerequisites.md). For external tests, you do need Docker installed.
+
+1. Download/unpack the SDK that you want to test to your test machine.
+
+2. `export TEST_JDK_HOME=</pathToWhereYouInstalledSDK>`
+
+3. `git clone https://github.com/adoptium/aqa-tests.git`
+
+4. `cd aqa-tests`
+
+5. `./get.sh`
+
+6. `cd TKG`
+
+7. export required environment variables, BUILD_LIST and EXTRA_DOCKER_ARGS (`export BUILD_LIST=external/zookeeper` and `export EXTRA_DOCKER_ARGS="-v $TEST_JDK_HOME:/opt/java/openjdk"`
+
+8. `make compile` (This fetches test material and compiles it, based on build.xml files in the test directories)
+
+9. `make _zookeeper_test` (When you defined BUILD_LIST to point to a directory in aqa-tests/external, then this is a testCaseName from the playlist.xml file within the directory you chose)
+
+When [running these from the command-line](https://github.com/adoptium/aqa-tests/blob/master/doc/userGuide.md#local-testing-via-make-targets-on-the-commandline), these tests are grouped under a make target called 'external', so 'make external' would run the entire set of tests found in the aqa-tests/external directory. This is unadvisable! Limit what you compile and run, BUILD_LIST=external/`<someSubDirectory>`, and TARGET=`<testCaseNameFromSubdirPlaylist>`
+
+These tests run regularly and results can be found in [TRSS Third Party Application view](https://trss.adoptopenjdk.net/ThirdPartyAppView).
+

--- a/external/zookeeper/build.xml
+++ b/external/zookeeper/build.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<project name="Zookeeper-Test" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build Zookeeper-Test Docker image
+	</description>
+	<import file="${TEST_ROOT}/external/build.xml"/>
+
+	<!-- set properties for this build -->
+	<property name="TEST" value="zookeeper" />
+	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
+	<property name="src" location="." />
+
+	<target name="init">
+		<mkdir dir="${DEST}"/>
+	</target>
+
+	<target name="dist" depends="move_scripts,clean_image,build_image" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml, *.mk"/>
+		</copy>
+	</target>
+
+	<target name="build">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/external/zookeeper/playlist.xml
+++ b/external/zookeeper/playlist.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
+	<test>
+		<testCaseName>zookeeper_test</testCaseName>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir zookeeper --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
+			$(TEST_STATUS); \
+			$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir zookeeper
+		</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+</playlist>

--- a/external/zookeeper/test.properties
+++ b/external/zookeeper/test.properties
@@ -1,0 +1,6 @@
+github_url="https://github.com/apache/zookeeper.git"
+test_commands="mvn clean package"
+test_results="testResults"
+tag_version="release-3.8.0-1"
+ubuntu_packages="git make wget tar"
+maven_version="3.8.5"

--- a/external/zookeeper/test.sh
+++ b/external/zookeeper/test.sh
@@ -1,0 +1,29 @@
+#/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+source $(dirname "$0")/test_base_functions.sh
+#Set up Java to be used by the netty test
+echo_setup
+
+testList="-Dtest=!org.apache.zookeeper.server.quorum.QuorumPeerMainTest,!org.apache.zookeeper.server.quorum.QuorumPeerMainMultiAddressTest,!org.apache.zookeeper.ZKUtilTest,!org.apache.zookeeper.server.util.RequestPathMetricsCollectorTest,!org.apache.zookeeper.test.ReadOnlyModeTest,!org.apache.zookeeper.server.NettyServerCnxnTest,!org.apache.zookeeper.server.ZooKeeperServerMainTest,!org.apache.zookeeper.server.quorum.EagerACLFilterTest,!org.apache.zookeeper.server.quorum.Zab1_0Test,!org.apache.zookeeper.server.quorum.UnifiedServerSocketTest,!org.apache.zookeeper.server.quorum.CommitProcessorConcurrencyTest,!org.apache.zookeeper.server.util.JvmPauseMonitorTest"
+
+echo "Compile and run zookeeper tests"
+echo mvn test --batch-mode --fail-at-end $testList
+mvn test --batch-mode --fail-at-end $testList
+test_exit_code=$?
+echo "Build zookeeper completed"
+
+find ./ -type d -name 'surefire-reports' -exec cp -r "{}" /testResults \;
+echo "Test results copied"
+
+exit $test_exit_code


### PR DESCRIPTION
As zookeeper is in  https://github.com/adoptium/aqa-tests/issues/172 list, this patch enables zookeeper release-3.8.0-1 as external extended test.