### PR TITLE
Use configAltPath for jti files

### DIFF
--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -62,14 +62,14 @@ ifndef JCK_ROOT
 endif
 
 ifndef CONFIG_ALT_PATH
-  export CONFIG_ALT_PATH:=$(TEST_ROOT)$(D)jck$(D)jtrunner$(D)config$(D)default
+  export CONFIG_ALT_PATH:=$(TEST_ROOT)$(D)jck$(D)jtrunner$(D)config
 endif
 
 OTHER_OPTS=
 # if JDK_IMPL is openj9 or ibm
 ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
   OTHER_OPTS= -Xtrace:maximal=all{level2} -Xfuture
-  export CONFIG_ALT_PATH:=$(JCK_ROOT)$(D)config$(D)default
+  export CONFIG_ALT_PATH:=$(JCK_ROOT)$(D)config
   ifneq (,$(findstring zos, $(SPEC)))
     OTHER_OPTS += -Dcom.ibm.tools.attach.enable=yes
   endif
@@ -97,7 +97,7 @@ ifeq ($(USE_JRE),1)
   JCK_CMD_TEMPLATE = $(JRE_COMMAND)
 endif
 
-JCK_CMD_TEMPLATE += -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavaTestRunner resultsRoot=$(REPORTDIR) testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION)
+JCK_CMD_TEMPLATE += -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavaTestRunner resultsRoot=$(REPORTDIR) testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH)
 
 VERIFIER_INSTRUCTIONS_TESTS_GROUP1=$(Q)vm/verifier/instructions/aaload;vm/verifier/instructions/aastore;vm/verifier/instructions/anewarray;vm/verifier/instructions/areturn;vm/verifier/instructions/baload;vm/verifier/instructions/bastore;vm/verifier/instructions/bipush;vm/verifier/instructions/caload;vm/verifier/instructions/castore;vm/verifier/instructions/d2f;vm/verifier/instructions/d2i;vm/verifier/instructions/d2l;vm/verifier/instructions/dadd;vm/verifier/instructions/daload;vm/verifier/instructions/dastore;vm/verifier/instructions/dcmp;vm/verifier/instructions/dconst;vm/verifier/instructions/ddiv;vm/verifier/instructions/dmul;vm/verifier/instructions/dneg;vm/verifier/instructions/drem;vm/verifier/instructions/dreturn;vm/verifier/instructions/dsub;vm/verifier/instructions/dup;vm/verifier/instructions/dup2$(Q)
 VERIFIER_INSTRUCTIONS_TESTS_GROUP2=$(Q)vm/verifier/instructions/dup2x1;vm/verifier/instructions/dup2x2;vm/verifier/instructions/dupx1;vm/verifier/instructions/dupx2;vm/verifier/instructions/f2d;vm/verifier/instructions/f2i;vm/verifier/instructions/f2l;vm/verifier/instructions/fadd;vm/verifier/instructions/faload;vm/verifier/instructions/fastore;vm/verifier/instructions/fcmp;vm/verifier/instructions/fconst;vm/verifier/instructions/fdiv;vm/verifier/instructions/fmul;vm/verifier/instructions/fneg;vm/verifier/instructions/frem;vm/verifier/instructions/freturn;vm/verifier/instructions/fsub;vm/verifier/instructions/getfield;vm/verifier/instructions/getstatic;vm/verifier/instructions/i2b;vm/verifier/instructions/i2c;vm/verifier/instructions/i2d;vm/verifier/instructions/i2f;vm/verifier/instructions/i2l$(Q)

--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -238,9 +238,11 @@ public class JavaTestRunner {
 		if (platform.equals("solaris")) {
 			nativesLoc = jckRoot + File.separator + "natives" + File.separator + "sunos";
 		}
-		jtiFile = testRoot + File.separator + "jck" + File.separator + "jtrunner" + File.separator + CONFIG + File.separator + jckVersion + File.separator + testSuite.toLowerCase() + ".jti"; 
-		fileUrl = "file:///" + jckBase + "/testsuite.jtt";
 
+		jtiFile = configAltPath + File.separator + jckVersion + File.separator + testSuite.toLowerCase() + ".jti"; 
+		fileUrl = "file:///" + jckBase + "/testsuite.jtt";
+		System.out.println("Using jti file "+ jtiFile);
+		
 		// The first release of a JCK will have an initial excludes (.jtx) file in test-suite/lib - e.g. JCK-runtime-8b/lib/jck8b.jtx.
 		// Updates to the excludes list may subsequently be supplied as a separate file, which supersedes the initial file.
 		// A known failures list (.kfl) file is optional.
@@ -292,15 +294,16 @@ public class JavaTestRunner {
 
 		if (testSuite.equals("RUNTIME") && (tests.contains("api/java_net") || tests.contains("api/java_nio") || tests.contains("api/org_ietf") || tests.contains("api/javax_security") || tests.equals("api"))) {
 			if (!configAltPath.equals("NULL")) {
-				jckConfigLoc = configAltPath;
+				jckConfigLoc = configAltPath + File.separator + "default";
 			} else {
 				if (config.equals("NULL")) {
 					config = "default";	
 				}
-				String subdir = "config/" + config;
+				String subdir = "config" + File.separator + config;
 				jckConfigLoc = jckRoot + File.separator + subdir; 
 			}
 			
+			System.out.println("Reading config files from "+ jckConfigLoc);
 			File configFolder = new File(jckConfigLoc); 
 			if (!configFolder.exists()) {
 				System.out.println(testExecutionType + "Cannot locate the configuration directory containing the Kerberos and Http server settings here: " + jckConfigLoc + ". The requested tests include at least one of the tests which require these files.");

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -19,7 +19,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(JCK_CUSTOM_TARGET) configAltPath=$(CONFIG_ALT_PATH); \
+		<command>$(JCK_CMD_TEMPLATE) tests=$(JCK_CUSTOM_TARGET); \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -613,7 +613,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_net testsuite=RUNTIME concurrency=1 configAltPath=$(CONFIG_ALT_PATH); \
+		<command>$(JCK_CMD_TEMPLATE) tests=api/java_net testsuite=RUNTIME concurrency=1; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -627,7 +627,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_nio testsuite=RUNTIME configAltPath=$(CONFIG_ALT_PATH); \
+		<command>$(JCK_CMD_TEMPLATE) tests=api/java_nio testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -1056,7 +1056,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_security testsuite=RUNTIME configAltPath=$(CONFIG_ALT_PATH); \
+		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_security testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -1208,7 +1208,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/org_ietf testsuite=RUNTIME configAltPath=$(CONFIG_ALT_PATH); \
+		<command>$(JCK_CMD_TEMPLATE) tests=api/org_ietf testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>


### PR DESCRIPTION
- Allows vendor specific jti files to be in internal repos, while the ones in the open can be used by the community. 
- Should be delivered after updates to all internal repos have been made with appropriate config files. 

Related : backlog/issues/799

FYI @JasonFengJ9 @llxia @smlambert 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>