### PR TITLE
[AQA_Test_Pipeline] : Do not parallel for temurin functional and perf categories

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -64,6 +64,11 @@ JDK_VERSIONS.each { JDK_VERSION ->
             if (TARGET.contains("jck") || TARGET.contains("openjdk")) {
                 keep_reportdir = true
             }
+            if (TARGET.contains("functional") || TARGET.contains("perf") {
+                if (params.VARIANT == "temurin") {
+                    PARALLEL = "None"
+                }
+            }
             if (AUTO_AQA_GEN) {
                 String[] targetTokens = TARGET.split("\\.")
                 def level = targetTokens[0];


### PR DESCRIPTION
For temurin the functional set is small so it's not necessary to run in parallel especially for platforms with limited resources. Machines with label `ci.role.perf` are also limited in Adoptium. Running in parallel may result in the waiting time is 90% of the whole job time. Disable parallel for funtional and perf tests. 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>