### PR TITLE
Exclude JDK19 failed openjdk tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -26,19 +26,24 @@
 
 # jdk_lang
 
+java/lang/Class/ArrayType.java	https://github.com/eclipse-openj9/openj9/issues/14598	linux-all
 java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 #java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
 java/lang/ClassLoader/Assert.java	https://github.com/eclipse-openj9/openj9/issues/6668	macosx-x64
+java/lang/ClassLoader/BadRegisterAsParallelCapableCaller.java	https://github.com/eclipse-openj9/openj9/issues/14600	linux-all
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
 java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
+java/lang/ClassLoader/exeNullCallerClassLoaderTest/NullCallerClassLoaderTest.java	https://github.com/eclipse-openj9/openj9/issues/14599	linux-all
 java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/eclipse-openj9/openj9/issues/14441	aix-all
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-openj9/openj9/issues/3178	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
 java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
+java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
 java/lang/StackWalker/Basic.java		https://github.com/eclipse-openj9/openj9/issues/6698	generic-all
@@ -80,6 +85,7 @@ java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.
 java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/PropertyTest.java	https://github.com/eclipse-openj9/openj9/issues/15129	linux-all
 java/lang/Thread/UncaughtExceptions.sh	https://github.com/eclipse-openj9/openj9/issues/6690	generic-all
 java/lang/Thread/UncaughtExceptionsTest.java	https://github.com/eclipse-openj9/openj9/issues/11930	generic-all
 java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse-openj9/openj9/issues/6691	generic-all
@@ -109,6 +115,7 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java	https://github.co
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse-openj9/openj9/issues/7158	aix-all
+java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse-openj9/openj9/issues/3394	generic-all
 java/lang/ref/CleanerTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ref/EarlyTimeout.java	https://github.com/eclipse-openj9/openj9/issues/7225	generic-all
 java/lang/ref/FinalizeOverride.java	https://github.com/eclipse-openj9/openj9/issues/9651	generic-all
@@ -191,13 +198,29 @@ com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/
 
 # jdk_net
 
+com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
+com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
+java/net/DatagramSocket/DatagramSocketExample.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.ibm.com/runtimes/backlog/issues/684 aix-all
+java/net/InetAddress/HostsFileOrderingTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
+java/net/InetAddress/InternalNameServiceTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
+java/net/InetAddress/InternalNameServiceWithHostsFileTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
 java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
-java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699	linux-s390x
-java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
+java/net/ipv6tests/UdpTest.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all,macosx-all
+java/net/MulticastSocket/B6427403.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all,aix-all
+java/net/MulticastSocket/MulticastAddresses.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
+java/net/MulticastSocket/NoSetNetworkInterface.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all,aix-all
+java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.ibm.com/runtimes/backlog/issues/707 linux-s390x,macosx-all
+java/net/MulticastSocket/SetOutgoingIf.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
+java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse-openj9/openj9/issues/4560 generic-all
 java/net/SocketPermission/SocketPermissionTest.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/net/httpclient/HttpsTunnelAuthTest.java https://github.ibm.com/runtimes/backlog/issues/714 aix-all
 java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingBinaryPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingBinaryPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
@@ -207,6 +230,7 @@ java/net/httpclient/websocket/PendingPongBinaryClose.java https://github.com/ecl
 java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+jdk/net/ExtendedSocketOption/DontFragmentTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
 
 ############################################################################
 
@@ -228,20 +252,82 @@ java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse-openj9/openj9/issues/4473 generic-all
 java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse-openj9/openj9/issues/8063	generic-all
 java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse-openj9/openj9/issues/8065	generic-all
-java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/infrastructure/issues/1173	linux-all,aix-all
+java/nio/channels/AsynchronousChannelGroup/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousChannelGroup/GroupOfOne.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousChannelGroup/Identity.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousChannelGroup/Restart.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousChannelGroup/Unbounded.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousServerSocketChannel/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousServerSocketChannel/WithSecurityManager.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
+java/nio/channels/AsynchronousSocketChannel/DieBeforeComplete.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousSocketChannel/Leaky.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousSocketChannel/StressLoopback.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Channels/Basic2.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Channels/TransferTo.java	https://github.com/eclipse-openj9/openj9/issues/15040	linux-all
+java/nio/channels/DatagramChannel/AdaptorBasic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all,macosx-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ConnectedSend.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/Disconnect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 #java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
-java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse-openj9/openj9/issues/4317 macosx-all
+java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java  https://github.ibm.com/runtimes/backlog/issues/684 generic-all
+java/nio/channels/etc/NetworkChannelTests.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.ibm.com/runtimes/backlog/issues/684 generic-all
+java/nio/channels/FileChannel/Transfer.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/FileChannel/TransferTo6GBFile.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/Alias.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/BasicAccept.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/BasicConnect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/ChangingInterests.java#id0 https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/CloseWhenKeyIdle.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/Connect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/ConnectWrite.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/KeysReady.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/OpRead.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/OutOfBand.java#id0 https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/RegAfterPreClose.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/SelectorLimit.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/SelectorTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/ServerSocketChannel/AdaptServerSocket.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/ServerSocketChannel/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/ServerSocketChannel/NonBlockingAccept.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/AdaptSocket.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/CloseAfterConnect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/CloseDuringWrite.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Connect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/ConnectState.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/FinishConnect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/GetChannel.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Hangup.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/LingerOnClose.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/LocalAddress.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/OutOfBand.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/ShortWrite.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Shutdown.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/VectorIO.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/VectorParams.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Write.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
+java/nio/file/Files/probeContentType/Basic.java  https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4679 linux-x64,macosx-all
 
 ############################################################################
@@ -267,7 +353,45 @@ security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.jav
 java/security/KeyPairGenerator/FinalizeHalf.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/Signature/ResetAfterException.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
+
 ############################################################################
+
+# jdk_security3
+
+javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all,aix-all
+javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java	https://github.com/adoptium/aqa-tests/issues/2123	linux-all,aix-all
+javax/net/ssl/SSLEngine/LargePacket.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all,aix-all,windows-all
+javax/net/ssl/SSLSocket/Tls13PacketSize.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+javax/net/ssl/TLSv11/TLSEnginesClosureTest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
+sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/mscapi/CastError.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/CngCipher.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/InteropWithSunRsaSign.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/KeyAlgorithms.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/KeyStoreEmptyCertChain.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/PublicKeyInterop.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/RSAEncryptDecrypt.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SetDupNameEntry.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/ShortRSAKeyWithinTLS.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignUsingNONEwithRSA.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignUsingSHA2withRSA.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignatureOffsets.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignedObjectChain.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SmallPrimeExponentP.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/VeryLongAlias.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/pkcs11/Provider/MultipleLogins.sh	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
+sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
+sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
+
+########################################################################################################################################################
 
 # jdk_sound
 
@@ -322,7 +446,7 @@ java/util/Random/RandomTestBsi1999.java		https://github.com/eclipse-openj9/openj
 
 # jdk_other
 
-
+com/sun/jndi/ldap/LdapPoolTimeoutTest.java  https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -347,46 +471,39 @@ vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse-openj9/op
 
 # jdk_foreign
 
-java/foreign/SafeFunctionAccessTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestDowncall.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestIntrinsics.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestNULLAddress.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestNative.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/malloc/TestMixedMallocFree.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-
-java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcall.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcallException.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcallHighArity.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcallStructScope.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-
-java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
-java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
-java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
-java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
-java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
-java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
-
-java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
-
-java/foreign/TestMemoryAccess.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestNulls.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestSegmentAllocators.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/channels/TestAsyncSocketChannels.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestUpcall.java#async https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestUpcall.java#no_scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestUpcall.java#scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-
-java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj9/openj9/issues/14135 generic-all
-
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
-java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
-
-java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+java/foreign/SafeFunctionAccessTest.java		https://github.com/eclipse-openj9/openj9/issues/13994		generic-all
+java/foreign/StdLibTest.java		https://github.com/eclipse-openj9/openj9/issues/13999		generic-all
+java/foreign/TestDowncall.java		https://github.com/eclipse-openj9/openj9/issues/13994		generic-all
+java/foreign/TestHandshake.java		https://github.com/eclipse-openj9/openj9/issues/14148		generic-all
+java/foreign/TestIllegalLink.java		https://github.com/eclipse-openj9/openj9/issues/14002		generic-all
+java/foreign/TestIntrinsics.java		https://github.com/eclipse-openj9/openj9/issues/13994		generic-all
+java/foreign/TestMemoryAccess.java		https://github.com/eclipse-openj9/openj9/issues/14134		generic-all
+java/foreign/TestNULLAddress.java		https://github.com/eclipse-openj9/openj9/issues/13994		generic-all
+java/foreign/TestNative.java		https://github.com/eclipse-openj9/openj9/issues/13994		generic-all
+java/foreign/TestNulls.java		https://github.com/eclipse-openj9/openj9/issues/14134		generic-all
+java/foreign/TestSegmentAllocators.java		https://github.com/eclipse-openj9/openj9/issues/14134		generic-all
+java/foreign/TestSegmentCopy.java		https://github.com/eclipse-openj9/openj9/issues/14148		generic-all
+java/foreign/TestUnsupportedPlatform.java		https://github.com/eclipse-openj9/openj9/issues/14828		generic-all
+java/foreign/TestUpcall.java		https://github.com/eclipse-openj9/openj9/issues/13999		generic-all
+java/foreign/TestUpcall.java#async		https://github.com/eclipse-openj9/openj9/issues/14134		generic-all
+java/foreign/TestUpcall.java#no_scope		https://github.com/eclipse-openj9/openj9/issues/14134		generic-all
+java/foreign/TestUpcall.java#scope		https://github.com/eclipse-openj9/openj9/issues/14134		generic-all
+java/foreign/TestUpcallException.java		https://github.com/eclipse-openj9/openj9/issues/13999		generic-all
+java/foreign/TestUpcallHighArity.java		https://github.com/eclipse-openj9/openj9/issues/13999		generic-all
+java/foreign/TestUpcallStructScope.java		https://github.com/eclipse-openj9/openj9/issues/13999		generic-all
+java/foreign/TestVarArgs.java		https://github.com/eclipse-openj9/openj9/issues/13994		generic-all
+java/foreign/channels/TestAsyncSocketChannels.java		https://github.com/eclipse-openj9/openj9/issues/14134		generic-all
+java/foreign/loaderLookup/TestLoaderLookup.java		https://github.com/eclipse-openj9/openj9/issues/14135		generic-all
+java/foreign/malloc/TestMixedMallocFree.java		https://github.com/eclipse-openj9/openj9/issues/13994		generic-all
+java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc		https://github.com/eclipse-openj9/openj9/issues/13993		generic-all
+java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah		https://github.com/eclipse-openj9/openj9/issues/13993		generic-all
+java/foreign/stackwalk/TestAsyncStackWalk.java#zgc		https://github.com/eclipse-openj9/openj9/issues/13993		generic-all
+java/foreign/stackwalk/TestStackWalk.java#default_gc		https://github.com/eclipse-openj9/openj9/issues/13993		generic-all
+java/foreign/stackwalk/TestStackWalk.java#shenandoah		https://github.com/eclipse-openj9/openj9/issues/13993		generic-all
+java/foreign/stackwalk/TestStackWalk.java#zgc		https://github.com/eclipse-openj9/openj9/issues/13993		generic-all
+java/foreign/upcalldeopt/TestUpcallDeopt.java		https://github.com/eclipse-openj9/openj9/issues/14134		generic-all
+java/foreign/valist/VaListTest.java		https://github.com/eclipse-openj9/openj9/issues/13994		generic-all
+java/foreign/virtual/TestVirtualCalls.java		https://github.com/eclipse-openj9/openj9/issues/13994		generic-all
 
 ############################################################################
 


### PR DESCRIPTION
- Exclude multiple failed openjdk tests for JDK19
- Related Issue: https://github.ibm.com/runtimes/backlog/issues/755

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>