### PR TITLE
jck-runtime-api-javax_print test Enabled and test verification for jck migration to  Jenkins

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -1000,34 +1000,7 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_print</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx for infrastructure/issues/5254. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac</platform>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
-				<impl>hotspot</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on all platforms on 17 for backlog/issues/633 (intermittent machine issue). To be run manually</comment>
-				<version>17+</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on all platforms on 17 for backlog/issues/633 (intermittent machine issue). To be run manually</comment>
-				<version>17+</version>
-				<impl>ibm</impl>
-			</disable>
-		</disables>
-		<variations>
+				<variations>
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_print jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) testsuite=RUNTIME; \


### PR DESCRIPTION
Made changes with aqa-tests to enable the jck-runtime-API-javax_print test as part of Jenkins migration.

This PR adds a jck-runtime-API-javax_print test to run on Jenkins.

Modified playlist.xml which contains Perl commands to execute tests.
Verified Tests on all Platforms