### PR TITLE
Exclude LdapPoolTimeoutTest openjdk test for JDK11 windows

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -362,6 +362,7 @@ java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/
 
 # jdk_other
 
+com/sun/jndi/ldap/LdapPoolTimeoutTest.java	https://github.ibm.com/runtimes/backlog/issues/655	windows-all
 jdk/internal/misc/VM/GetNanoTimeAdjustment.java		https://github.com/eclipse-openj9/openj9/issues/7184		generic-all
 jdk/internal/misc/VM/RuntimeArguments.java		https://github.com/eclipse-openj9/openj9/issues/7186		generic-all
 jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/eclipse-openj9/openj9/issues/7245		generic-all


### PR DESCRIPTION
- Exclude LdapPoolTimeoutTest openjdk test for JDK11 windows
- Related Issue: ibm_git/runtimes/backlog/issues/755

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>