### PR TITLE
Exclude JDK19 extended.openjdk failures

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -327,6 +327,7 @@ java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adopti
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java  https://github.ibm.com/runtimes/backlog/issues/684 generic-all
+java/nio/channels/etc/AdaptorCloseAndInterrupt.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
 java/nio/channels/etc/NetworkChannelTests.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.ibm.com/runtimes/backlog/issues/684 generic-all
 java/nio/channels/FileChannel/Transfer.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
@@ -388,6 +389,7 @@ java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.
 # jdk_security
 
 java/security/KeyPairGenerator/FinalizeHalf.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
+java/security/misc/Versions.java	https://github.com/eclipse-openj9/openj9/issues/15206	generic-all
 java/security/Signature/ResetAfterException.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
@@ -430,6 +432,8 @@ sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java	https://github.ibm.
 sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
 sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
+sun/security/util/math/TestIntegerModuloP.java	https://github.com/eclipse-openj9/openj9/issues/15209	generic-all
+sun/security/util/Resources/Usages.java	https://github.com/eclipse-openj9/openj9/issues/15209	generic-all
 
 ########################################################################################################################################################
 
@@ -493,6 +497,7 @@ java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/
 # jdk_other
 
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java  https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+javax/naming/spi/providers/InitialContextTest.java	https://github.com/eclipse-openj9/openj9/issues/15205	generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -554,5 +559,11 @@ java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/ope
 ############################################################################
 
 # com_sun_crypto
+
+############################################################################
+
+# jdk_vector
+
+jdk/incubator/vector/Vector128ConversionTests.java	https://github.com/eclipse-openj9/openj9/issues/15211	generic-all
 
 ############################################################################


### PR DESCRIPTION
Exclude JDK19 `extended.openjdk` failures

https://github.com/eclipse-openj9/openj9/issues/15152
https://github.com/eclipse-openj9/openj9/issues/15206
https://github.com/eclipse-openj9/openj9/issues/15209
https://github.com/eclipse-openj9/openj9/issues/15205
https://github.com/eclipse-openj9/openj9/issues/15211


Signed-off-by: Jason Feng <fengj@ca.ibm.com>