### PR TITLE
Increase timeoutfactor to 4 for runtime and compiler tests

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -537,7 +537,7 @@ public class JavaTestRunner {
 			}
 			
 			fileContent += "concurrency " + concurrencyString + ";\n";
-			fileContent += "timeoutfactor 2" + ";\n";	// 2 base time limit equal 20 minutes
+			fileContent += "timeoutfactor 4" + ";\n";	// 4 base time limit equal 40 minutes
 			fileContent += keyword + ";\n";
 
 			if (platform.equals("win")) {
@@ -721,7 +721,7 @@ public class JavaTestRunner {
 			} 
 
 			fileContent += "concurrency " + concurrencyString + ";\n";
-			fileContent += "timeoutfactor 1" + ";\n";							// lang.CLSS,CONV,STMT,INFR requires more than 1h to complete. lang.Annot,EXPR,LMBD require more than 2h to complete tests
+			fileContent += "timeoutfactor 4" + ";\n";							// lang.CLSS,CONV,STMT,INFR requires more than 1h to complete. lang.Annot,EXPR,LMBD require more than 2h to complete tests
 			fileContent += keyword + ";\n";
 
 			String cmdAsStringOrFile = "cmdAsString"; // Whether to reference cmd via cmdAsString or cmdAsFile


### PR DESCRIPTION
This will allow more time for tests to finish on slow machines. 
Ref : backlog/issues/723. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>