### PR TITLE
Fix Syntax error for test target dragonwell8_tenant_jdk

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2080,7 +2080,7 @@
 	</test>
 	<test>
 		<testCaseName>dragonwell8_tenant_hotspot</testCaseName>
-		<command>${TEST_JDK_HOME}bin/jgroup -u testuser -g testuser ; \
+		<command>sudo ${TEST_JDK_HOME}$(D)bin$(D)jgroup -u ${USER} -g ${USER} ; \
 			$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 			$(JTREG_BASIC_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS)$(Q) \
 			-w $(Q)$(REPORTDIR)$(D)work$(Q) \


### PR DESCRIPTION
Fix Syntax error for test target dragonwell8_tenant_jdk, for missing / sign and hardcode username

Fixes: #3747

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>