### PR TITLE
JDK19/18 excludes

### DIFF
--- a/functional/MBCS_Tests/i18n/playlist.xml
+++ b/functional/MBCS_Tests/i18n/playlist.xml
@@ -45,6 +45,13 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_i18n_zh_CN_linux</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15249</comment>
+				<impl>openj9</impl>
+				<version>19+</version>
+			</disable>
+		</disables>
 		<command>LANG=zh_CN.UTF-8 perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.linux</platformRequirements>
@@ -150,6 +157,13 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_i18n_zh_CN_aix</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15249</comment>
+				<impl>openj9</impl>
+				<version>19+</version>
+			</disable>
+		</disables>
 		<command>LANG=zh_CN perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>

--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -372,6 +372,12 @@ sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtime
 sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
 sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
 
+############################################################################
+
+# jdk_security4
+
+sun/security/krb5/auto/BasicProc.java https://github.com/eclipse-openj9/openj9/issues/14803 generic-all
+
 ########################################################################################################################################################
 
 # jdk_sound

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -26,157 +26,163 @@
 
 # jdk_lang
 
-java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/annotation/loaderLeak/Main.java	https://github.com/eclipse-openj9/openj9/issues/6701	generic-all
+java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/annotation/loaderLeak/Main.java https://github.com/eclipse-openj9/openj9/issues/6701 generic-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
-java/lang/annotation/UnitTest.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Class/ArrayType.java	https://github.com/eclipse-openj9/openj9/issues/14598	linux-all
-java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
-java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/annotation/UnitTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Class/ArrayType.java https://github.com/eclipse-openj9/openj9/issues/14598 generic-all
+java/lang/Class/forName/NonJavaNames.sh https://github.com/eclipse-openj9/openj9/issues/5225 generic-all
+java/lang/Class/GetModuleTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 #java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
-java/lang/ClassLoader/Assert.java	https://github.com/eclipse-openj9/openj9/issues/6668	macosx-x64
-java/lang/ClassLoader/BadRegisterAsParallelCapableCaller.java	https://github.com/eclipse-openj9/openj9/issues/14600	linux-all
-java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
-java/lang/ClassLoader/exeNullCallerClassLoaderTest/NullCallerClassLoaderTest.java	https://github.com/eclipse-openj9/openj9/issues/15168	generic-all
-java/lang/ClassLoader/ExtDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
-java/lang/ClassLoader/exeNullCallerClassLoaderTest/NullCallerClassLoaderTest.java	https://github.com/eclipse-openj9/openj9/issues/14599	linux-all
-java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/eclipse-openj9/openj9/issues/14441	aix-all
-java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-openj9/openj9/issues/3178	generic-all
-java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse-openj9/openj9/issues/7158	aix-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/eclipse-openj9/openj9/issues/5274 generic-all
+java/lang/ClassLoader/Assert.java https://github.com/eclipse-openj9/openj9/issues/6668 macosx-x64
+java/lang/ClassLoader/BadRegisterAsParallelCapableCaller.java https://github.com/eclipse-openj9/openj9/issues/14600 generic-all
+java/lang/ClassLoader/EndorsedDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all
+java/lang/ClassLoader/exeNullCallerClassLoaderTest/NullCallerClassLoaderTest.java https://github.com/eclipse-openj9/openj9/issues/15168 generic-all
+java/lang/ClassLoader/ExtDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all
+java/lang/ClassLoader/exeNullCallerClassLoaderTest/NullCallerClassLoaderTest.java https://github.com/eclipse-openj9/openj9/issues/14599 linux-all
+java/lang/ClassLoader/LibraryPathProperty.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java https://github.com/eclipse-openj9/openj9/issues/14441 aix-all
+java/lang/ClassLoader/RecursiveSystemLoader.java https://github.com/eclipse-openj9/openj9/issues/3178 generic-all
+java/lang/Enum/ConstantDirectoryOptimalCapacity.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/invoke/condy/CondyNestedResolutionTest.java https://github.com/eclipse-openj9/openj9/issues/7158 aix-all
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
-java/lang/invoke/defineHiddenClass/PreviewHiddenClass.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/invoke/FindAccessTest.java		https://github.com/eclipse-openj9/openj9/issues/6868	generic-all
-java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse-openj9/openj9/issues/3394	generic-all
-java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/MethodHandlesGeneralTest.java	https://github.com/eclipse-openj9/openj9/issues/7043	generic-all
-java/lang/invoke/PrivateInvokeTest.java	https://github.com/eclipse-openj9/openj9/issues/7071	generic-all
-java/lang/invoke/SpecialInterfaceCall.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/VarHandle/AccessMode/OptimalMapSize.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestAccessInt.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/eclipse-openj9/openj9/issues/13368	generic-all
-java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
-java/lang/ProcessBuilder/Basic.java	https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
-java/lang/ProcessBuilder/Basic.java	https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
+java/lang/invoke/defineHiddenClass/PreviewHiddenClass.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/invoke/FindAccessTest.java  https://github.com/eclipse-openj9/openj9/issues/6868 generic-all
+java/lang/invoke/lambda/LambdaStackTrace.java https://github.com/eclipse-openj9/openj9/issues/3394 generic-all
+java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/invoke/MethodHandlesGeneralTest.java https://github.com/eclipse-openj9/openj9/issues/7043 generic-all
+java/lang/invoke/PrivateInvokeTest.java https://github.com/eclipse-openj9/openj9/issues/7071 generic-all
+java/lang/invoke/SpecialInterfaceCall.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/invoke/VarHandle/AccessMode/OptimalMapSize.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all
+java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
+java/lang/ProcessBuilder/Basic.java https://github.com/eclipse-openj9/openj9/issues/10921 linux-ppc64le
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
+java/lang/ProcessBuilder/ReaderWriterTest.java https://github.com/eclipse-openj9/openj9/issues/15280 generic-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
-java/lang/ref/CleanerTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/ref/EarlyTimeout.java	https://github.com/eclipse-openj9/openj9/issues/7225	generic-all
-java/lang/ref/FinalizeOverride.java	https://github.com/eclipse-openj9/openj9/issues/9651	generic-all
-java/lang/ref/FinalizerHistogramTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/ref/NullQueue.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/ref/OOMEInReferenceHandler.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/ref/ReachabilityFenceTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/lang/ref/CleanerTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ref/EarlyTimeout.java https://github.com/eclipse-openj9/openj9/issues/7225 generic-all
+java/lang/ref/FinalizeOverride.java https://github.com/eclipse-openj9/openj9/issues/9651 generic-all
+java/lang/ref/FinalizerHistogramTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ref/NullQueue.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ref/OOMEInReferenceHandler.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ref/ReachabilityFenceTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14397 macosx-all
-java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all
-java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
-java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
-java/lang/StackTraceElement/SerialTest.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
-java/lang/StackWalker/AcrossThreads.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/StackWalker/Basic.java	https://github.com/eclipse-openj9/openj9/issues/6698	generic-all
-java/lang/StackWalker/EmbeddedStackWalkTest.java	https://github.com/eclipse-openj9/openj9/issues/3941	generic-all
-java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/StackWalker/ReflectionFrames.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/StackWalker/VerifyStackTrace.java	https://github.com/adoptium/aqa-tests/issues/1273	generic-all
-java/lang/String/CaseConvertSameInstance.java	https://github.com/eclipse-openj9/openj9/issues/6672	generic-all
-java/lang/String/CaseInsensitiveComparator.java	https://github.com/eclipse-openj9/openj9/issues/6665	generic-all
-java/lang/String/CompactString/IndexOf.java		https://github.com/eclipse-openj9/openj9/issues/6673	generic-all
-java/lang/String/concat/CompactStringsInitialCoder.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/ImplicitStringConcat.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/ImplicitStringConcatArgCount.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/ImplicitStringConcatAssignLHS.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/ImplicitStringConcatBoundaries.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/ImplicitStringConcatMany.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/ImplicitStringConcatManyLongs.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/ImplicitStringConcatOrder.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/ImplicitStringConcatShapes.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/StringConcatFactoryInvariants.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/StringConcatFactoryRepeatedConstants.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/concat/WithSecurityManager.java	https://github.com/eclipse-openj9/openj9/issues/9656	generic-all
-java/lang/String/EqualsIgnoreCase.java	https://github.com/eclipse-openj9/openj9/issues/6666	generic-all
-java/lang/String/StringRepeat.java	https://github.com/eclipse-openj9/openj9/issues/6667	generic-all
+java/lang/reflect/Nestmates/TestReflectionAPI.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/reflect/Proxy/ProxyLayerTest.java https://github.com/eclipse-openj9/openj9/issues/7775 generic-all
+java/lang/reflect/PublicMethods/PublicMethodsTest.java https://github.com/eclipse-openj9/openj9/issues/7897 generic-all
+java/lang/StackTraceElement/PublicConstructor.java https://github.com/eclipse-openj9/openj9/issues/6659 generic-all
+java/lang/StackTraceElement/SerialTest.java https://github.com/eclipse-openj9/openj9/issues/6659 generic-all
+java/lang/StackWalker/AcrossThreads.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/StackWalker/Basic.java https://github.com/eclipse-openj9/openj9/issues/6698 generic-all
+java/lang/StackWalker/EmbeddedStackWalkTest.java https://github.com/eclipse-openj9/openj9/issues/3941 generic-all
+java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/StackWalker/ReflectionFrames.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/StackWalker/VerifyStackTrace.java https://github.com/adoptium/aqa-tests/issues/1273 generic-all
+java/lang/String/CaseConvertSameInstance.java https://github.com/eclipse-openj9/openj9/issues/6672 generic-all
+java/lang/String/CaseInsensitiveComparator.java https://github.com/eclipse-openj9/openj9/issues/6665 generic-all
+java/lang/String/CompactString/IndexOf.java  https://github.com/eclipse-openj9/openj9/issues/6673 generic-all
+java/lang/String/concat/CompactStringsInitialCoder.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcat.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatArgCount.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatAssignLHS.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatBoundaries.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatMany.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatManyLongs.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatOrder.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatShapes.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/StringConcatFactoryInvariants.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/StringConcatFactoryRepeatedConstants.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/WithSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/EqualsIgnoreCase.java https://github.com/eclipse-openj9/openj9/issues/6666 generic-all
+java/lang/String/StringRepeat.java https://github.com/eclipse-openj9/openj9/issues/6667 generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
-java/lang/StringBuilder/HugeCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/lang/System/Logger/custom/CustomLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/Logger/default/DefaultLoggerTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/DefaultLoggerFinderTest/DefaultLoggerFinderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/internal/backend/LoggerFinderBackendTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/internal/BaseDefaultLoggerFinderTest/BaseDefaultLoggerFinderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/internal/BaseLoggerBridgeTest/BaseLoggerBridgeTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/PropertyTest.java	https://github.com/eclipse-openj9/openj9/issues/15129	linux-all
-java/lang/Thread/BuilderTest.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/JoinWithDuration.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/NullStackTrace.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/SleepWithDuration.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/UncaughtExceptions.sh	https://github.com/eclipse-openj9/openj9/issues/6690	generic-all
-java/lang/Thread/UncaughtExceptionsTest.java	https://github.com/eclipse-openj9/openj9/issues/11930	generic-all
-java/lang/Thread/virtual/Collectable.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/CustomScheduler.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/GetStackTraceWhenRunnable.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/HoldsLock.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/Locking.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/Parking.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/ParkWithFixedThreadPool.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/PreviewFeaturesNotEnabled.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/Reflection.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/ShutdownHook.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/StackTraces.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/stress/GetStackTraceALot.java#id0	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/stress/PinALot.java#id0	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/stress/PingPong.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/stress/Skynet.java#id0	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/stress/SleepALot.java#id0	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/stress/TimedGet.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/stress/YieldALot.java#id0	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/ThreadAPI.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/ThreadLocals.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/TracePinnedThreads.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Thread/virtual/WaitNotify.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/ThreadGroup/Daemon.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/ThreadGroup/NullThreadName.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse-openj9/openj9/issues/6691	generic-all
-java/lang/ThreadGroup/Stop.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/ThreadGroup/Suspend.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/ThreadLocal/TestThreadId.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/lang/Throwable/SuppressedExceptions.java	https://github.com/eclipse-openj9/openj9/issues/6692	generic-all
+java/lang/StringBuilder/HugeCapacity.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/System/FileEncodingTest.java https://github.com/eclipse-openj9/openj9/issues/15280 generic-all
+java/lang/System/Logger/custom/CustomLoggerTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/Logger/default/DefaultLoggerTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/DefaultLoggerFinderTest/DefaultLoggerFinderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/backend/LoggerFinderBackendTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/BaseDefaultLoggerFinderTest/BaseDefaultLoggerFinderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/BaseLoggerBridgeTest/BaseLoggerBridgeTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/PropertyTest.java https://github.com/eclipse-openj9/openj9/issues/15129 linux-all
+java/lang/Thread/BuilderTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/JoinWithDuration.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/NullStackTrace.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/SleepWithDuration.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
+java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/11930 generic-all
+java/lang/Thread/virtual/Collectable.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/GetStackTraceWhenRunnable.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/HoldsLock.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/Locking.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/Parking.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/ParkWithFixedThreadPool.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/PreviewFeaturesNotEnabled.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/ShutdownHook.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/GetStackTraceALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/PinALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/PingPong.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/Skynet.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/SleepALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/YieldALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/ThreadAPI.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/ThreadAPI.java#id1 https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
+java/lang/Thread/virtual/ThreadLocals.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/WaitNotify.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadGroup/Daemon.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadGroup/NullThreadName.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
+java/lang/ThreadGroup/Stop.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadGroup/Suspend.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadLocal/TestThreadId.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
-jdk/internal/misc/ThreadFlock/ThreadFlockTest.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-jdk/internal/vm/Continuation/Basic.java	https://github.com/eclipse-openj9/openj9/issues/15163	generic-all
-jdk/internal/vm/Continuation/ClassUnloading.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-jdk/internal/vm/Continuation/HumongousStack.java	https://github.com/eclipse-openj9/openj9/issues/15189	generic-all
-jdk/internal/vm/Continuation/LiveFramesDriver.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-jdk/internal/vm/Continuation/Scoped.java	https://github.com/eclipse-openj9/openj9/issues/15163	generic-all
-jdk/modules/etc/DefaultModules.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+jdk/internal/misc/ThreadFlock/ThreadFlockTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+jdk/internal/vm/Continuation/Basic.java#id0 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
+jdk/internal/vm/Continuation/Basic.java#id1 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
+jdk/internal/vm/Continuation/ClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+jdk/internal/vm/Continuation/Fuzz.java https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
+jdk/internal/vm/Continuation/HumongousStack.java https://github.com/eclipse-openj9/openj9/issues/15189 generic-all
+jdk/internal/vm/Continuation/LiveFramesDriver.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+jdk/internal/vm/Continuation/Scoped.java https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
+jdk/modules/etc/DefaultModules.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15168 generic-all
 
 ############################################################################
 
@@ -210,16 +216,16 @@ java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/a
 java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
-sun/management/HotspotClassLoadingMBean/GetClassInitializationTime.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
-sun/management/HotspotClassLoadingMBean/GetClassLoadingTime.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
-sun/management/HotspotClassLoadingMBean/GetInitializedClassCount.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
-sun/management/HotspotClassLoadingMBean/GetLoadedClassSize.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
-sun/management/HotspotClassLoadingMBean/GetMethodDataSize.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
-sun/management/HotspotClassLoadingMBean/GetUnloadedClassSize.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
-sun/management/HotspotRuntimeMBean/GetSafepointCount.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
-sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
-sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
-sun/management/HotspotThreadMBean/GetInternalThreads.java	https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetClassInitializationTime.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetClassLoadingTime.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetInitializedClassCount.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetLoadedClassSize.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetMethodDataSize.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetUnloadedClassSize.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetSafepointCount.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotThreadMBean/GetInternalThreads.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
 sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -233,13 +239,14 @@ sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/ado
 
 # jdk_math
 
+java/math/BigDecimal/StringConstructor.java https://github.com/eclipse-openj9/openj9/issues/15284 generic-all
 
 ############################################################################
 
 # jdk_net
 
-com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
-com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
+com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
+com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
 java/net/DatagramSocket/DatagramSocketExample.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 java/net/DatagramSocket/SendReceiveMaxSize.java https://github.ibm.com/runtimes/backlog/issues/684 aix-all
@@ -253,31 +260,31 @@ java/net/httpclient/websocket/PendingPingTextClose.java https://github.com/eclip
 java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
-java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
-java/net/InetAddress/HostsFileOrderingTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
-java/net/InetAddress/InternalNameServiceTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
-java/net/InetAddress/InternalNameServiceWithHostsFileTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
+java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
+java/net/InetAddress/HostsFileOrderingTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
+java/net/InetAddress/InternalNameServiceTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
+java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
 java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
-java/net/ipv6tests/UdpTest.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all,macosx-all
+java/net/ipv6tests/UdpTest.java https://github.com/adoptium/aqa-tests/issues/827 linux-all,macosx-all
 java/net/MulticastSocket/B6427403.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all,aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
 java/net/MulticastSocket/NoSetNetworkInterface.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all,aix-all
-java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
+java/net/MulticastSocket/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.ibm.com/runtimes/backlog/issues/707 linux-s390x,macosx-all
 java/net/MulticastSocket/SetOutgoingIf.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
 java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse-openj9/openj9/issues/4560 generic-all
 java/net/SocketPermission/SocketPermissionTest.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-jdk/net/ExtendedSocketOption/DontFragmentTest.java	https://github.com/adoptium/aqa-tests/issues/3637	linux-all
+jdk/net/ExtendedSocketOption/DontFragmentTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
 
 ############################################################################
 
 # jdk_io
 
-java/io/CharArrayReader/OverflowInRead.java	https://github.com/adoptium/aqa-tests/issues/1500	generic-all
-java/io/File/GetXSpace.java	https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
+java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -290,9 +297,9 @@ java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse
 # jdk_nio
 
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse-openj9/openj9/issues/4473 generic-all
-java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse-openj9/openj9/issues/8063	generic-all
-java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse-openj9/openj9/issues/8065	generic-all
-java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/infrastructure/issues/1173	linux-all,aix-all
+java/nio/Buffer/LimitDirectMemory.java https://github.com/eclipse-openj9/openj9/issues/8063 generic-all
+java/nio/Buffer/LimitDirectMemoryNegativeTest.java https://github.com/eclipse-openj9/openj9/issues/8065 generic-all
+java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/infrastructure/issues/1173 linux-all,aix-all
 java/nio/channels/AsynchronousChannelGroup/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/AsynchronousChannelGroup/GroupOfOne.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/AsynchronousChannelGroup/Identity.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
@@ -301,12 +308,12 @@ java/nio/channels/AsynchronousChannelGroup/Unbounded.java https://github.ibm.com
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousServerSocketChannel/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/AsynchronousServerSocketChannel/WithSecurityManager.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/DieBeforeComplete.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/AsynchronousSocketChannel/Leaky.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/Channels/Basic2.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-java/nio/channels/Channels/TransferTo.java	https://github.com/eclipse-openj9/openj9/issues/15040	linux-all
+java/nio/channels/Channels/TransferTo.java https://github.com/eclipse-openj9/openj9/issues/15040 linux-all
 java/nio/channels/DatagramChannel/AdaptorBasic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all,macosx-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
@@ -321,13 +328,13 @@ java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
+#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
-java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java  https://github.ibm.com/runtimes/backlog/issues/684 generic-all
-java/nio/channels/etc/AdaptorCloseAndInterrupt.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
+java/nio/channels/etc/AdaptorCloseAndInterrupt.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/nio/channels/etc/NetworkChannelTests.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.ibm.com/runtimes/backlog/issues/684 generic-all
 java/nio/channels/FileChannel/Transfer.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
@@ -366,8 +373,11 @@ java/nio/channels/SocketChannel/VectorIO.java https://github.ibm.com/runtimes/ba
 java/nio/channels/SocketChannel/VectorParams.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/SocketChannel/Write.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/eclipse-openj9/openj9/issues/15265 generic-all
+java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
-java/nio/file/Files/probeContentType/Basic.java  https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/nio/file/Files/probeContentType/Basic.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/nio/file/Files/ReadWriteString.java https://github.com/eclipse-openj9/openj9/issues/15289 generic-all
 java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4679 linux-x64,macosx-all
 
@@ -376,25 +386,25 @@ jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4
 # jdk_rmi
 
 java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse-openj9/openj9/issues/6749 windows-all
-java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
-java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse-openj9/openj9/issues/7592	generic-all
-java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse-openj9/openj9/issues/3377	generic-all
-java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse-openj9/openj9/issues/8515	generic-all
-java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
+java/rmi/dgc/dgcAckFailure/DGCAckFailure.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
+java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java https://github.com/eclipse-openj9/openj9/issues/7592 generic-all
+java/rmi/server/RemoteServer/AddrInUse.java  https://github.com/eclipse-openj9/openj9/issues/3377 generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java https://github.com/eclipse-openj9/openj9/issues/8515 generic-all
+java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse-openj9/openj9/issues/4094 generic-all
-java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
+java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
 
 ############################################################################
 
 # jdk_security
 
 java/security/KeyPairGenerator/FinalizeHalf.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
-java/security/misc/Versions.java	https://github.com/eclipse-openj9/openj9/issues/15206	generic-all
+java/security/misc/Versions.java https://github.com/eclipse-openj9/openj9/issues/15206 generic-all
 java/security/Signature/ResetAfterException.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
-security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
 
 ############################################################################
 
@@ -424,8 +434,9 @@ sun/security/mscapi/SmallPrimeExponentP.java	https://github.ibm.com/runtimes/bac
 sun/security/mscapi/VeryLongAlias.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/pkcs11/Provider/MultipleLogins.sh	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
 sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
-sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java	https://github.ibm.com/runtimes/backlog/issues/809	linux-aarch64
-sun/security/provider/SecureRandom/StrongSecureRandom.java	https://github.ibm.com/runtimes/backlog/issues/809	linux-aarch64
+sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java https://github.com/eclipse-openj9/openj9/issues/15266 generic-all
+sun/security/provider/SecureRandom/StrongSecureRandom.java https://github.com/eclipse-openj9/openj9/issues/15266 generic-all
+sun/security/ssl/rsa/SignedObjectChain.java https://github.com/eclipse-openj9/openj9/issues/15266 generic-all
 sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
@@ -436,6 +447,13 @@ sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/
 sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
 sun/security/util/math/TestIntegerModuloP.java	https://github.com/eclipse-openj9/openj9/issues/15209	generic-all
 sun/security/util/Resources/Usages.java	https://github.com/eclipse-openj9/openj9/issues/15209	generic-all
+
+############################################################################
+
+# jdk_security4
+
+sun/security/krb5/auto/BasicProc.java https://github.com/eclipse-openj9/openj9/issues/14803 generic-all
+sun/security/krb5/ccache/Refresh.java https://github.com/eclipse-openj9/openj9/issues/15267 generic-all
 
 ########################################################################################################################################################
 
@@ -466,29 +484,30 @@ sun/security/util/Resources/Usages.java	https://github.com/eclipse-openj9/openj9
 # jdk_util
 
 java/util/Arrays/largeMemory/ParallelPrefix.java https://github.com/eclipse-openj9/openj9/issues/4100 linux-ppc64le
-java/util/Arrays/TimSortStackSize2.java	https://github.com/eclipse-openj9/openj9/issues/7086	generic-all
+java/util/Arrays/TimSortStackSize2.java https://github.com/eclipse-openj9/openj9/issues/7086 generic-all
 java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse-openj9/openj9/issues/4720 linux-all
-java/util/concurrent/ArrayBlockingQueue/WhiteBox.java 	https://github.com/eclipse-openj9/openj9/issues/5988 	macosx-all
-java/util/concurrent/ExecutorService/CloseTest.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
-java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclipse-openj9/openj9/issues/3209	generic-all
-java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse-openj9/openj9/issues/7125	macosx-all,linux-all,aix-all
-java/util/concurrent/tck/JSR166TestCase.java	https://github.com/eclipse-openj9/openj9/issues/15160	generic-all
-java/util/concurrent/ThreadPerTaskExecutor/ThreadPerTaskExecutorTest.java	https://github.com/eclipse-openj9/openj9/issues/15152	generic-all
+java/util/concurrent/ArrayBlockingQueue/WhiteBox.java  https://github.com/eclipse-openj9/openj9/issues/5988  macosx-all
+java/util/concurrent/ExecutorService/CloseTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclipse-openj9/openj9/issues/3209 generic-all
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all
+java/util/concurrent/tck/JSR166TestCase.java https://github.com/eclipse-openj9/openj9/issues/15160 generic-all
+java/util/concurrent/ThreadPerTaskExecutor/ThreadPerTaskExecutorTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
-java/util/Locale/LanguageSubtagRegistryTest.java	https://github.com/eclipse-openj9/openj9/issues/15188	generic-all
-java/util/Locale/LSRDataTest.java	https://github.com/eclipse-openj9/openj9/issues/15188	generic-all
-java/util/logging/CheckZombieLockTest.java	https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all
-java/util/logging/LogManager/Configuration/updateConfiguration/UpdateConfigurationTest.java	https://github.com/eclipse-openj9/openj9/issues/15190	generic-all
+java/util/Locale/LanguageSubtagRegistryTest.java https://github.com/eclipse-openj9/openj9/issues/15188 generic-all
+java/util/Locale/LSRDataTest.java https://github.com/eclipse-openj9/openj9/issues/15188 generic-all
+java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all
+java/util/logging/LogManager/Configuration/updateConfiguration/UpdateConfigurationTest.java https://github.com/eclipse-openj9/openj9/issues/15190 generic-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
-java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/util/Random/RandomTestBsi1999.java		https://github.com/eclipse-openj9/openj9/issues/13202	generic-all
-java/util/Random/RandomTestChiSquared.java	https://github.com/eclipse-openj9/openj9/issues/13202	generic-all
-java/util/Spliterator/SpliteratorCollisions.java	https://github.com/eclipse-openj9/openj9/issues/7090	generic-all
+java/util/logging/TestLoggerWeakRefLeak.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/util/Random/RandomNextDoubleBoundary.java https://github.com/eclipse-openj9/openj9/issues/15287 generic-all
+java/util/Random/RandomTestBsi1999.java https://github.com/eclipse-openj9/openj9/issues/13202 generic-all
+java/util/Random/RandomTestChiSquared.java https://github.com/eclipse-openj9/openj9/issues/13202 generic-all
+java/util/Spliterator/SpliteratorCollisions.java https://github.com/eclipse-openj9/openj9/issues/7090 generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all
-java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse-openj9/openj9/issues/3447	generic-all
-java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java https://github.com/eclipse-openj9/openj9/issues/3447 generic-all
+java/util/WeakHashMap/GCDuringIteration.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/8872  generic-all
 
 ############################################################################
 
@@ -498,8 +517,8 @@ java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/
 
 # jdk_other
 
-com/sun/jndi/ldap/LdapPoolTimeoutTest.java  https://github.ibm.com/runtimes/backlog/issues/655 windows-all
-javax/naming/spi/providers/InitialContextTest.java	https://github.com/eclipse-openj9/openj9/issues/15205	generic-all
+com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+javax/naming/spi/providers/InitialContextTest.java https://github.com/eclipse-openj9/openj9/issues/15205 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -510,16 +529,17 @@ jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ParallelGC https://git
 jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ShenandoahGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ZGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
-jdk/internal/misc/VM/GetNanoTimeAdjustment.java		https://github.com/eclipse-openj9/openj9/issues/7184		generic-all
-jdk/internal/misc/VM/RuntimeArguments.java		https://github.com/eclipse-openj9/openj9/issues/7186		generic-all
-jdk/internal/reflect/CallerSensitive/CheckCSMs.java	https://github.com/eclipse-openj9/openj9/issues/7245		generic-all
-jdk/internal/reflect/constantPool/ConstantPoolTest.java	https://github.com/eclipse-openj9/openj9/issues/7249		generic-all
+jdk/incubator/concurrent/StructuredTaskScope/StructuredThreadDumpTest.java https://github.com/eclipse-openj9/openj9/issues/15278 generic-all
+jdk/internal/misc/VM/GetNanoTimeAdjustment.java https://github.com/eclipse-openj9/openj9/issues/7184 generic-all
+jdk/internal/misc/VM/RuntimeArguments.java https://github.com/eclipse-openj9/openj9/issues/7186 generic-all
+jdk/internal/reflect/CallerSensitive/CheckCSMs.java https://github.com/eclipse-openj9/openj9/issues/7245 generic-all
+jdk/internal/reflect/constantPool/ConstantPoolTest.java https://github.com/eclipse-openj9/openj9/issues/7249 generic-all
 
-sun/misc/SunMiscSignalTest.java		https://github.com/eclipse-openj9/openj9/issues/7264		generic-all
+sun/misc/SunMiscSignalTest.java  https://github.com/eclipse-openj9/openj9/issues/7264  generic-all
 sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/adoptium/aqa-tests/issues/749 windows-all
-sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse-openj9/openj9/issues/5328		generic-all
+sun/nio/ch/TestMaxCachedBufferSize.java  https://github.com/eclipse-openj9/openj9/issues/5328  generic-all
 
-vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse-openj9/openj9/issues/7336	generic-all
+vm/verifier/VerifyProtectedConstructor.java https://github.com/eclipse-openj9/openj9/issues/7336 generic-all
 ############################################################################
 
 # jdk_foreign
@@ -566,6 +586,10 @@ java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/ope
 
 # jdk_vector
 
-jdk/incubator/vector/Vector128ConversionTests.java	https://github.com/eclipse-openj9/openj9/issues/15211	generic-all
+jdk/incubator/vector/Byte128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
+jdk/incubator/vector/Byte256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
+jdk/incubator/vector/Int128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
+jdk/incubator/vector/Short256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
+jdk/incubator/vector/Vector128ConversionTests.java https://github.com/eclipse-openj9/openj9/issues/15211 generic-all
 
 ############################################################################

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -38,6 +38,13 @@
 	</test>
 	<test>
 		<testCaseName>langtools_custom</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15264</comment>
+				<version>19+</version>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -1266,6 +1273,13 @@
 	</test>
 	<test>
 		<testCaseName>jdk_foreign</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15152</comment>
+				<version>19+</version>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -99,6 +99,13 @@
 	</test>
 	<test>
 		<testCaseName>MauveMultiThrdLoad_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15253</comment>
+				<version>19+</version>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -270,6 +270,13 @@
 	</test>
 	<test>
 		<testCaseName>HCRLateAttachWorkload_previewEnabled</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15250</comment>
+				<impl>openj9</impl>
+				<version>19+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>

--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -113,6 +113,11 @@
 				<comment>https://github.com/eclipse-openj9/openj9/issues/14635</comment>
 				<platform>aarch64_mac.*</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
+				<impl>openj9</impl>
+				<version>19+</version>
+			</disable>
 		</disables>
 		<levels>
 			<level>extended</level>
@@ -128,6 +133,13 @@
 	</test>
 	<test>
 		<testCaseName>SC_Softmx_JitAot_Linux</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
+				<impl>openj9</impl>
+				<version>19+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -285,6 +297,11 @@
 				<comment>https://github.com/eclipse-openj9/openj9/issues/14621</comment>
 				<platform>aarch64_mac.*</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
+				<impl>openj9</impl>
+				<version>19+</version>
+			</disable>
 		</disables>
 		<levels>
 			<level>extended</level>
@@ -309,6 +326,11 @@
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/14621</comment>
 				<platform>aarch64_mac.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
+				<impl>openj9</impl>
+				<version>19+</version>
 			</disable>
 		</disables>
 		<levels>


### PR DESCRIPTION
JDK19:
`langtools_custom` https://github.com/eclipse-openj9/openj9/issues/15264
`jdk_foreign` https://github.com/eclipse-openj9/openj9/issues/15152
`HCRLateAttachWorkload_previewEnabled` https://github.com/eclipse-openj9/openj9/issues/15250
`MauveMultiThrdLoad_5m` https://github.com/eclipse-openj9/openj9/issues/15253
`MBCS_Tests_i18n_zh_CN_linux` https://github.com/eclipse-openj9/openj9/issues/15249
`MBCS_Tests_i18n_zh_CN_aix` https://github.com/eclipse-openj9/openj9/issues/15249
`SC_Softmx_JitAot` https://github.com/eclipse-openj9/openj9/issues/15251
`SC_Softmx_JitAot_Linux` https://github.com/eclipse-openj9/openj9/issues/15251
`SharedClasses.SCM23.MultiThread` https://github.com/eclipse-openj9/openj9/issues/15251
`SharedClasses.SCM23.MultiThreadMultiCL` https://github.com/eclipse-openj9/openj9/issues/15251
`java/lang/Class/ArrayType.java` https://github.com/eclipse-openj9/openj9/issues/14598
`java/lang/ClassLoader/BadRegisterAsParallelCapableCaller.java` https://github.com/eclipse-openj9/openj9/issues/14600
`java/lang/ProcessBuilder/ReaderWriterTest.java` https://github.com/eclipse-openj9/openj9/issues/15280
`java/lang/System/FileEncodingTest.java` https://github.com/eclipse-openj9/openj9/issues/15280
`java/lang/Thread/virtual/ThreadAPI.java#id1` https://github.com/eclipse-openj9/openj9/issues/15247
`java/math/BigDecimal/StringConstructor.java` https://github.com/eclipse-openj9/openj9/issues/15284
`java/nio/channels/vthread/BlockingChannelOps.java#id0` https://github.com/eclipse-openj9/openj9/issues/15265
`java/nio/channels/vthread/BlockingChannelOps.java#id1` https://github.com/eclipse-openj9/openj9/issues/15247
`java/nio/file/Files/ReadWriteString.java` https://github.com/eclipse-openj9/openj9/issues/15289
`java/util/Random/RandomNextDoubleBoundary.java` https://github.com/eclipse-openj9/openj9/issues/15287
`jdk/incubator/concurrent/StructuredTaskScope/StructuredThreadDumpTest.java` https://github.com/eclipse-openj9/openj9/issues/15278
`jdk/incubator/vector/Byte128VectorTests.java` https://github.com/eclipse-openj9/openj9/issues/15268
`jdk/incubator/vector/Byte256VectorTests.java` https://github.com/eclipse-openj9/openj9/issues/15268
`jdk/incubator/vector/Int128VectorTests.java` https://github.com/eclipse-openj9/openj9/issues/15268
`jdk/incubator/vector/Short256VectorTests.java` https://github.com/eclipse-openj9/openj9/issues/15268
`jdk/internal/vm/Continuation/Basic.java#id0` https://github.com/eclipse-openj9/openj9/issues/15163
`jdk/internal/vm/Continuation/Basic.java#id1` https://github.com/eclipse-openj9/openj9/issues/15163
`jdk/internal/vm/Continuation/Fuzz.java` https://github.com/eclipse-openj9/openj9/issues/15247
`jni/nullCaller/NullCallerTest.java` https://github.com/eclipse-openj9/openj9/issues/15168
`sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java` https://github.com/eclipse-openj9/openj9/issues/15266
`sun/security/provider/SecureRandom/StrongSecureRandom.java` https://github.com/eclipse-openj9/openj9/issues/15266
`sun/security/ssl/rsa/SignedObjectChain.java` https://github.com/eclipse-openj9/openj9/issues/15266
`sun/security/krb5/auto/BasicProc.java` https://github.com/eclipse-openj9/openj9/issues/14803
`sun/security/krb5/ccache/Refresh.java` https://github.com/eclipse-openj9/openj9/issues/15267

JDK18
`sun/security/krb5/auto/BasicProc.java` https://github.com/eclipse-openj9/openj9/issues/14803

Internal grinders:
`sanity.openjdk` - `view/Test_grinder/job/Grinder/24803/`
`extended.openjdk` - `view/Test_grinder/job/Grinder/24783/`

FYI @tajila @fengxue-IS 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>