### PR TITLE
Include jck-compiler-lang-LMBD on x86-64_windows for JDK 11

### DIFF
--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -338,20 +338,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-LMBD</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
This PR enables jck-compiler-lang-LMBD tests for ibm jck8c, jck11 and jck17

Fixes: runtimes/backlog/issues/487

Signed off by : Prodip Roy mailto:prodroy89@in.ibm.com