### PR TITLE
Exclude jdk_beans testcase TestConstructorFinder.java

### DIFF
--- a/openjdk/excludes/vendors/alibaba/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/vendors/alibaba/ProblemList_openjdk8.txt
@@ -24,6 +24,7 @@
 ############################################################################
 
 # jdk_beans
+java/beans/XMLDecoder/8028054/TestConstructorFinder.java https://github.com/adoptium/aqa-tests/issues/3752 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Exclude jdk_beans testcase java/beans/XMLDecoder/8028054/TestConstructorFinder.java only vendor is alibaba

Fixes: #3752

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>