### PR TITLE
Re-enable jni/nullCaller/NullCallerTest.java on some platforms

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -37,9 +37,7 @@ java/lang/Class/GetModuleTest.java https://github.com/adoptium/aqa-tests/issues/
 java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/eclipse-openj9/openj9/issues/5274 generic-all
 java/lang/ClassLoader/Assert.java https://github.com/eclipse-openj9/openj9/issues/6668 macosx-x64
 java/lang/ClassLoader/EndorsedDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all
-java/lang/ClassLoader/exeNullCallerClassLoaderTest/NullCallerClassLoaderTest.java https://github.com/eclipse-openj9/openj9/issues/15168 generic-all
 java/lang/ClassLoader/ExtDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all
-java/lang/ClassLoader/exeNullCallerClassLoaderTest/NullCallerClassLoaderTest.java https://github.com/eclipse-openj9/openj9/issues/14599 linux-all
 java/lang/ClassLoader/LibraryPathProperty.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java https://github.com/eclipse-openj9/openj9/issues/14441 aix-all
 java/lang/ClassLoader/RecursiveSystemLoader.java https://github.com/eclipse-openj9/openj9/issues/3178 generic-all
@@ -181,7 +179,7 @@ jdk/internal/vm/Continuation/LiveFramesDriver.java https://github.com/eclipse-op
 jdk/internal/vm/Continuation/Scoped.java https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/modules/etc/DefaultModules.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
-jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15168 generic-all
+jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
Re-enable the test on platforms where it passes. The test crashes on
plinux, mac, see https://github.com/eclipse-openj9/openj9/issues/15370

Also remove obsolete test
java/lang/ClassLoader/exeNullCallerClassLoaderTest/NullCallerClassLoaderTest.java

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>