### PR TITLE
Limit exclude of java_applet to 8 only

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -379,13 +379,14 @@
 		<testCaseName>jck-runtime-api-java_applet</testCaseName>
 		<disables>
 			<disable>
-				<comment>Disabled on aix for backlog/issues/486, Problem Report 147661 for Mac. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
-				<impl>ibm</impl>
+				<comment>Disabled on aix for backlog/issues/486 Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>ppc64_aix</platform>
+				<impl>openj9</impl>
 			</disable>
 			<disable>
-				<comment>Disabled on aix for backlog/issues/486, Problem Report 147661 for Mac. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_mac|ppc64_aix</platform>
+				<comment>Disabled on Mac for Problem Report 147661. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>x86-64_mac</platform>
+				<version>8</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>


### PR DESCRIPTION
This is an update on the exclude made in https://github.com/adoptium/aqa-tests/pull/3777 - we need to limit java_applet exclude to only 8, as it works fine on the newer  SDKs levels. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>