### PR TITLE
Only use <impl>ibm</impl> disable blocks where it applies

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -104,12 +104,6 @@
 				<comment>Temporarily disabled on aix on JDK8 for test setup issue: backlog/issues/506</comment>
 				<platform>ppc64_aix</platform>
 				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Temporarily disabled on aix on JDK8 for test setup issue: backlog/issues/506</comment>
-				<platform>ppc64_aix</platform>
-				<version>8</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>

--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -343,12 +343,6 @@
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>
 				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -538,12 +532,6 @@
 	<test>
 		<testCaseName>jck-compiler-lang-ANNOT</testCaseName>
 		<disables>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
 			<disable>
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -448,12 +448,6 @@
 				<comment>Disabled on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>ppc64_aix</platform>
 				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64_aix</platform>
-				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -600,12 +594,6 @@
 				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows|x86-32_windows</platform>
 				<version>8+</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows|x86-32_windows</platform>
-				<version>8+</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -670,12 +658,6 @@
 				<comment>Disabled on osx and win for backlog/issues/489. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows|x86-64_mac</platform>
 				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on osx and win for backlog/issues/489. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows|x86-64_mac</platform>
-				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
@@ -700,11 +682,6 @@
 	<test>
 		<testCaseName>jck-runtime-api-javax_accessibility</testCaseName>
 		<disables>
-			<disable>
-				<comment>Disabled on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64_aix</platform>
-				<impl>ibm</impl>
-			</disable>
 			<disable>
 				<comment>Disabled on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>ppc64_aix</platform>

--- a/jck/runtime.xml_schema/playlist.xml
+++ b/jck/runtime.xml_schema/playlist.xml
@@ -35,12 +35,6 @@
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>
 				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -59,12 +53,6 @@
 	<test>
 		<testCaseName>jck-runtime-xml_schema-nistData-atomic</testCaseName>
 		<disables>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
 			<disable>
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>
@@ -91,12 +79,6 @@
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>
 				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -115,12 +97,6 @@
 	<test>
 		<testCaseName>jck-runtime-xml_schema-nistData-union</testCaseName>
 		<disables>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
 			<disable>
 				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>


### PR DESCRIPTION
This PR simplifies existing disable blocks in tck playlists by removing unnecessary `<impl>ibm</impl>` disable blocks. The only impl=ibm is zos JDK11 atm. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>