### PR TITLE
Update artifactory retention

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -945,7 +945,26 @@ def uploadToArtifactory(pattern, artifactoryUploadDir="") {
 		if (artifactoryUploadDir && artifactoryUploadDir.contains("AQAvit")) {
 			buildInfo.name = "sys-rt/AQAvit_" + buildInfo.name
 		} else {
-			buildInfo.retention maxDays: 30, deleteBuildArtifacts: true
+			def numArtifacts = params.ARTIFACTORY_NUM_ARTIFACTS ?: -1
+			def numDays = 20
+			if (params.ARTIFACTORY_NUM_DAYS) {
+				numDays = params.ARTIFACTORY_NUM_DAYS
+			} else {
+				if (ARTIFACTORY_SERVER.contains("ci-eclipse-openj9")) {
+					if (JOB_NAME.contains("Grinder")) {
+						numDays = 7
+					} else {
+						numDays = 25
+					}
+				} else {
+					if (JOB_NAME.contains("Grinder")) {
+						numDays = 20
+					} else {
+						numDays = 45
+					}
+				}
+			}
+			buildInfo.retention maxBuilds: numArtifacts, maxDays: numDays, deleteBuildArtifacts: true
 		}
 		server.upload spec: uploadSpec, buildInfo: buildInfo
 		server.publishBuildInfo buildInfo


### PR DESCRIPTION
Space limit is different in openj9 artifactory and internal. Update the logic again to set the following:
- Internal:
Grinder 20 days
regular test job 45 days
- External:
Grinder 7 days
regular test job 25 days

Allow user to override for both maxDays and maxBuilds if needed

related: runtimes/infrastructure/issues/6820

Signed-off-by: lanxia <lan_xia@ca.ibm.com>