### PR TITLE
Un-exclude java/util/Locale/LanguageSubtagRegistryTest and LSRDataTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -490,8 +490,6 @@ java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse
 java/util/concurrent/tck/JSR166TestCase.java https://github.com/eclipse-openj9/openj9/issues/15160 generic-all
 java/util/concurrent/ThreadPerTaskExecutor/ThreadPerTaskExecutorTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
-java/util/Locale/LanguageSubtagRegistryTest.java https://github.com/eclipse-openj9/openj9/issues/15188 generic-all
-java/util/Locale/LSRDataTest.java https://github.com/eclipse-openj9/openj9/issues/15188 generic-all
 java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all
 java/util/logging/LogManager/Configuration/updateConfiguration/UpdateConfigurationTest.java https://github.com/eclipse-openj9/openj9/issues/15190 generic-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all


### PR DESCRIPTION
The tests are passing on a later build, see https://github.com/eclipse-openj9/openj9/issues/15188#issuecomment-1163363383