### PR TITLE
Un-exclude logging UpdateConfigurationTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -493,7 +493,6 @@ java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/i
 java/util/Locale/LanguageSubtagRegistryTest.java https://github.com/eclipse-openj9/openj9/issues/15188 generic-all
 java/util/Locale/LSRDataTest.java https://github.com/eclipse-openj9/openj9/issues/15188 generic-all
 java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all
-java/util/logging/LogManager/Configuration/updateConfiguration/UpdateConfigurationTest.java https://github.com/eclipse-openj9/openj9/issues/15190 generic-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
 java/util/logging/TestLoggerWeakRefLeak.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/util/Random/RandomNextDoubleBoundary.java https://github.com/eclipse-openj9/openj9/issues/15287 generic-all


### PR DESCRIPTION
The test seems to pass on a later build.
https://github.com/eclipse-openj9/openj9/issues/15190#issuecomment-1163366183