### PR TITLE
Un-exclude java/math/BigDecimal/StringConstructor.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -236,8 +236,6 @@ sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/ado
 
 # jdk_math
 
-java/math/BigDecimal/StringConstructor.java https://github.com/eclipse-openj9/openj9/issues/15284 generic-all
-
 ############################################################################
 
 # jdk_net


### PR DESCRIPTION
Passing on later build, see https://github.com/eclipse-openj9/openj9/issues/15284#issuecomment-1163492194