### PR TITLE
Un-exclude java/nio/channels/etc/AdaptorCloseAndInterrupt.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -331,7 +331,6 @@ java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adopti
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java  https://github.ibm.com/runtimes/backlog/issues/684 generic-all
-java/nio/channels/etc/AdaptorCloseAndInterrupt.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/nio/channels/etc/NetworkChannelTests.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.ibm.com/runtimes/backlog/issues/684 generic-all
 java/nio/channels/FileChannel/Transfer.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all


### PR DESCRIPTION
Passing on later build, see https://github.com/eclipse-openj9/openj9/issues/15210