### PR TITLE
Reenabled fixed source tests in jdk_build

### DIFF
--- a/openjdk/excludes/vendors/redhat/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/vendors/redhat/ProblemList_openjdk11.txt
@@ -30,8 +30,6 @@
 
 # jdk_build
 
-build/releaseFile/CheckSource.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
-
 ############################################################################
 
 # jdk_compiler

--- a/openjdk/excludes/vendors/redhat/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/vendors/redhat/ProblemList_openjdk17.txt
@@ -30,8 +30,6 @@
 
 # jdk_build
 
-build/releaseFile/CheckSource.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
-
 ############################################################################
 
 # jdk_compiler

--- a/openjdk/excludes/vendors/redhat/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/vendors/redhat/ProblemList_openjdk18.txt
@@ -30,8 +30,6 @@
 
 # jdk_build
 
-build/releaseFile/CheckSource.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
-
 ############################################################################
 
 # jdk_compiler

--- a/openjdk/excludes/vendors/redhat/ProblemList_openjdk19.txt
+++ b/openjdk/excludes/vendors/redhat/ProblemList_openjdk19.txt
@@ -30,8 +30,6 @@
 
 # jdk_build
 
-build/releaseFile/CheckSource.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
-
 ############################################################################
 
 # jdk_compiler


### PR DESCRIPTION
please note, that the fix should go to stable release  version too. Please note, that the test was alone in its group in jdk11. That was a bit dangerous.