### PR TITLE
Modified playlist.xml for javax_print

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -914,16 +914,6 @@
 				<platform>x86-64_mac|aarch64_mac</platform>
 				<impl>hotspot</impl>
 			</disable>
-			<disable>
-				<comment>Disabled on all platforms on 17 for backlog/issues/633 (intermittent machine issue). To be run manually</comment>
-				<version>17+</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on all platforms on 17 for backlog/issues/633 (intermittent machine issue). To be run manually</comment>
-				<version>17+</version>
-				<impl>ibm</impl>
-			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>


### PR DESCRIPTION
Made changes with aqa-tests to enable the jck-runtime-API-javax_print test for jdk17 on openj9 as part of Jenkins migration.

This PR adds a jck-runtime-API-javax_print test to run on Jenkins for jdk17 on all platforms.

Modified playlist.xml which contains Perl commands to execute tests.
Verified Tests on all Platforms

https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/25202/ - AIX
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/24623/ - Linux
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/25203/ - Windows
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/25204/ - Mac
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/25205/ - Linux ppc64le
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/25207/ - Linux_390-64
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/25208/ - Linux_aarch64
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/25209/ - Mac_arch64
