### PR TITLE
Include jck-compiler-api-java_rmi on all platforms for JDK8 and JDK11

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -16,16 +16,6 @@
 	<include>../jck.mk</include>
 	<test>
 		<testCaseName>jck-compiler-api-java_rmi</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on all platforms and Java levels due to backlog/issues/559. To be run manually by CR team</comment>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on all platforms and Java levels due to backlog/issues/559. To be run manually by CR team</comment>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>

--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -338,20 +338,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-LMBD</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
-				<impl>ibm</impl>
-			</disable>
-			<disable>
-				<comment>Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
This PR, enables jck-compiler-api-java_rmi tests for JCK8C and JCK11

Related: runtimes/backlog/issues/559

Signed off by : Prodip Roy (prodroy89@in.ibm.com)