### PR TITLE
Add -Xdump:system:events=user to all stf test command lines on opnej9

### DIFF
--- a/system/systemtest.mk
+++ b/system/systemtest.mk
@@ -59,11 +59,16 @@ ifeq ($(filter 8 9 10 11 12 13 14 15 16 17, $(JDK_VERSION)),)
   $(warning Environment variable JAVA_TOOL_OPTIONS is set to '$(JAVA_TOOL_OPTIONS)')
 endif
 
+JAVA_ARGS = $(JVM_OPTIONS)
+ifeq (,$(findstring $(JDK_IMPL),hotspot))
+  JAVA_ARGS += -Xdump:system:events=user
+endif
+
 define SYSTEMTEST_CMD_TEMPLATE
 perl $(SYSTEMTEST_RESROOT)$(D)STF$(D)stf.core$(D)scripts$(D)stf.pl \
   -test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)STF;$(SYSTEMTEST_RESROOT)$(D)aqa-systemtest$(OPENJ9_PRAM)$(Q) \
   -systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q) \
-  -java-args=$(SQ)$(JVM_OPTIONS)$(SQ) \
+  -java-args=$(SQ)$(JAVA_ARGS)$(SQ) \
   -results-root=$(REPORTDIR)
 endef
 


### PR DESCRIPTION
Add -Xdump:system:events=user to all stf test command lines on opnej9, so that a system core gets generated when a kill -3 occurs.

Resolves https://github.com/adoptium/STF/issues/131

FYI @pshipton 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>