### PR TITLE
Re-enable javax/naming/spi/providers/InitialContextTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -503,7 +503,6 @@ java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/
 # jdk_other
 
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
-javax/naming/spi/providers/InitialContextTest.java https://github.com/eclipse-openj9/openj9/issues/15205 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
Re-enable javax/naming/spi/providers/InitialContextTest.java

Related https://github.com/eclipse-openj9/openj9/issues/15205

Signed-off-by: Jason Feng <fengj@ca.ibm.com>