### PR TITLE
Exclude FFI specific tests in JDK19

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -180,6 +180,8 @@ jdk/modules/etc/DefaultModules.java https://github.com/eclipse-openj9/openj9/iss
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java  https://github.com/eclipse-openj9/openj9/issues/15466  generic-all
+
 ############################################################################
 
 # jdk_internal


### PR DESCRIPTION
The change is to exclude the FFI specific tests in JDK19
as all related code are not yet merged to the repo.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>