### PR TITLE
Exclude FFI related test suite in JDK19

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -180,7 +180,7 @@ jdk/modules/etc/DefaultModules.java https://github.com/eclipse-openj9/openj9/iss
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java  https://github.com/eclipse-openj9/openj9/issues/15466  generic-all
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1  https://github.com/eclipse-openj9/openj9/issues/15466  generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The change is to exclude the real test cases in
ImplicitAttach which is enabled via AttachTest.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>