### PR TITLE
Exclude JDK19 known failures

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -155,6 +155,7 @@ java/lang/Thread/virtual/stress/SleepALot.java#id0 https://github.com/eclipse-op
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/lang/Thread/virtual/stress/YieldALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/lang/Thread/virtual/ThreadAPI.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/ThreadAPI.java#id0 https://github.com/eclipse-openj9/openj9/issues/15503 generic-all
 java/lang/Thread/virtual/ThreadAPI.java#id1 https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
 java/lang/Thread/virtual/ThreadLocals.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
@@ -482,6 +483,7 @@ java/util/concurrent/ArrayBlockingQueue/WhiteBox.java  https://github.com/eclips
 java/util/concurrent/ExecutorService/CloseTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclipse-openj9/openj9/issues/3209 generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all
+java/util/concurrent/tck/JSR166TestCase.java https://github.com/eclipse-openj9/openj9/issues/15465 generic-all
 java/util/concurrent/ThreadPerTaskExecutor/ThreadPerTaskExecutorTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all


### PR DESCRIPTION
Exclude JDK19 known failures

```
java/lang/Thread/virtual/ThreadAPI.java#id0
java/util/concurrent/tck/JSR166TestCase.java
```

Related https://github.com/eclipse-openj9/openj9/issues/15503 https://github.com/eclipse-openj9/openj9/issues/15465

Signed-off-by: Jason Feng <fengj@ca.ibm.com>