### PR TITLE
Add exclude files for Java 20

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -1,0 +1,583 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+############################################################################
+
+# To determine required OS exclusion string see http://hg.openjdk.java.net/code-tools/jtreg/file/6f00c63c0a98/src/share/classes/com/sun/javatest/regtest/config/OS.java
+
+############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans
+
+############################################################################
+
+# jdk_lang
+
+java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/annotation/loaderLeak/Main.java https://github.com/eclipse-openj9/openj9/issues/6701 generic-all
+java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
+java/lang/annotation/UnitTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Class/forName/NonJavaNames.sh https://github.com/eclipse-openj9/openj9/issues/5225 generic-all
+java/lang/Class/GetModuleTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+#java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
+java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/eclipse-openj9/openj9/issues/5274 generic-all
+java/lang/ClassLoader/Assert.java https://github.com/eclipse-openj9/openj9/issues/6668 macosx-x64
+java/lang/ClassLoader/EndorsedDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all
+java/lang/ClassLoader/ExtDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all
+java/lang/ClassLoader/LibraryPathProperty.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java https://github.com/eclipse-openj9/openj9/issues/14441 aix-all
+java/lang/ClassLoader/RecursiveSystemLoader.java https://github.com/eclipse-openj9/openj9/issues/3178 generic-all
+java/lang/Enum/ConstantDirectoryOptimalCapacity.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/invoke/condy/CondyNestedResolutionTest.java https://github.com/eclipse-openj9/openj9/issues/7158 aix-all
+java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
+java/lang/invoke/defineHiddenClass/PreviewHiddenClass.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/invoke/FindAccessTest.java  https://github.com/eclipse-openj9/openj9/issues/6868 generic-all
+java/lang/invoke/lambda/LambdaStackTrace.java https://github.com/eclipse-openj9/openj9/issues/3394 generic-all
+java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/invoke/MethodHandlesGeneralTest.java https://github.com/eclipse-openj9/openj9/issues/7043 generic-all
+java/lang/invoke/PrivateInvokeTest.java https://github.com/eclipse-openj9/openj9/issues/7071 generic-all
+java/lang/invoke/SpecialInterfaceCall.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/invoke/VarHandle/AccessMode/OptimalMapSize.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsChar.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all
+java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
+java/lang/ProcessBuilder/Basic.java https://github.com/eclipse-openj9/openj9/issues/10921 linux-ppc64le
+java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
+java/lang/ProcessBuilder/ReaderWriterTest.java https://github.com/eclipse-openj9/openj9/issues/15280 generic-all
+java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
+java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
+java/lang/ref/CleanerTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ref/EarlyTimeout.java https://github.com/eclipse-openj9/openj9/issues/7225 generic-all
+java/lang/ref/FinalizeOverride.java https://github.com/eclipse-openj9/openj9/issues/9651 generic-all
+java/lang/ref/FinalizerHistogramTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ref/NullQueue.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ref/OOMEInReferenceHandler.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/ref/ReachabilityFenceTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/reflect/AccessibleObject/ModuleSetAccessibleTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/reflect/AccessibleObject/TrySetAccessibleTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14397 macosx-all
+java/lang/reflect/Nestmates/TestReflectionAPI.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/reflect/Proxy/ProxyLayerTest.java https://github.com/eclipse-openj9/openj9/issues/7775 generic-all
+java/lang/reflect/PublicMethods/PublicMethodsTest.java https://github.com/eclipse-openj9/openj9/issues/7897 generic-all
+java/lang/StackTraceElement/PublicConstructor.java https://github.com/eclipse-openj9/openj9/issues/6659 generic-all
+java/lang/StackTraceElement/SerialTest.java https://github.com/eclipse-openj9/openj9/issues/6659 generic-all
+java/lang/StackWalker/AcrossThreads.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/StackWalker/Basic.java https://github.com/eclipse-openj9/openj9/issues/6698 generic-all
+java/lang/StackWalker/EmbeddedStackWalkTest.java https://github.com/eclipse-openj9/openj9/issues/3941 generic-all
+java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/StackWalker/ReflectionFrames.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/StackWalker/VerifyStackTrace.java https://github.com/adoptium/aqa-tests/issues/1273 generic-all
+java/lang/String/CaseConvertSameInstance.java https://github.com/eclipse-openj9/openj9/issues/6672 generic-all
+java/lang/String/CaseInsensitiveComparator.java https://github.com/eclipse-openj9/openj9/issues/6665 generic-all
+java/lang/String/CompactString/IndexOf.java  https://github.com/eclipse-openj9/openj9/issues/6673 generic-all
+java/lang/String/concat/CompactStringsInitialCoder.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcat.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatArgCount.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatAssignLHS.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatBoundaries.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatMany.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatManyLongs.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatOrder.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/ImplicitStringConcatShapes.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/StringConcatFactoryInvariants.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/StringConcatFactoryRepeatedConstants.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/concat/WithSecurityManager.java https://github.com/eclipse-openj9/openj9/issues/9656 generic-all
+java/lang/String/EqualsIgnoreCase.java https://github.com/eclipse-openj9/openj9/issues/6666 generic-all
+java/lang/String/StringRepeat.java https://github.com/eclipse-openj9/openj9/issues/6667 generic-all
+java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
+java/lang/StringBuilder/HugeCapacity.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/System/FileEncodingTest.java https://github.com/eclipse-openj9/openj9/issues/15280 generic-all
+java/lang/System/Logger/custom/CustomLoggerTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/Logger/default/DefaultLoggerTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/DefaultLoggerFinderTest/DefaultLoggerFinderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/backend/LoggerFinderBackendTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/BaseDefaultLoggerFinderTest/BaseDefaultLoggerFinderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/BaseLoggerBridgeTest/BaseLoggerBridgeTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/PropertyTest.java https://github.com/eclipse-openj9/openj9/issues/15129 linux-all
+java/lang/Thread/BuilderTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/JoinWithDuration.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/NullStackTrace.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/SleepWithDuration.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
+java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/11930 generic-all
+java/lang/Thread/virtual/Collectable.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/GetStackTraceWhenRunnable.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/HoldsLock.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/Locking.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/Parking.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/ParkWithFixedThreadPool.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/PreviewFeaturesNotEnabled.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/ShutdownHook.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/GetStackTraceALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/PinALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/PingPong.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/Skynet.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/SleepALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/stress/YieldALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/ThreadAPI.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/ThreadAPI.java#id0 https://github.com/eclipse-openj9/openj9/issues/15503 generic-all
+java/lang/Thread/virtual/ThreadAPI.java#id1 https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
+java/lang/Thread/virtual/ThreadLocals.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/WaitNotify.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadGroup/Daemon.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadGroup/NullThreadName.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
+java/lang/ThreadGroup/Stop.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadGroup/Suspend.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/ThreadLocal/TestThreadId.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
+jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+jdk/internal/misc/ThreadFlock/ThreadFlockTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+jdk/internal/vm/Continuation/Basic.java#id0 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
+jdk/internal/vm/Continuation/Basic.java#id1 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
+jdk/internal/vm/Continuation/ClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+jdk/internal/vm/Continuation/Fuzz.java https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
+jdk/internal/vm/Continuation/HumongousStack.java https://github.com/eclipse-openj9/openj9/issues/15189 generic-all
+jdk/internal/vm/Continuation/LiveFramesDriver.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+jdk/internal/vm/Continuation/Scoped.java https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
+jdk/modules/etc/DefaultModules.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
+
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1  https://github.com/eclipse-openj9/openj9/issues/15466  generic-all
+
+############################################################################
+
+# jdk_internal
+jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
+jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
+
+############################################################################
+
+# jdk_management
+
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/CompositeData/MemoryUsageCompositeData.java  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/GarbageCollectorMXBean/GcInfoCompositeType.java  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/ManagementFactory/ProxyTypeMapping.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/ManagementFactory/ValidateOpenTypes.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/CollectionUsageThreshold.java  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/LowMemoryTest2.sh      https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagement.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/ResetPeakMemoryUsage.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+sun/management/HotspotClassLoadingMBean/GetClassInitializationTime.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetClassLoadingTime.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetInitializedClassCount.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetLoadedClassSize.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetMethodDataSize.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotClassLoadingMBean/GetUnloadedClassSize.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetSafepointCount.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetSafepointSyncTime.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotRuntimeMBean/GetTotalSafepointTime.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/HotspotThreadMBean/GetInternalThreads.java https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/jmxremote/bootstrap/LocalManagementTest.java     https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+sun/management/jmxremote/startstop/JMXStartStopTest.java     https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java    https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+############################################################################
+
+# jdk_net
+
+com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
+com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
+java/net/DatagramSocket/DatagramSocketExample.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.ibm.com/runtimes/backlog/issues/684 aix-all
+java/net/httpclient/HttpsTunnelAuthTest.java https://github.ibm.com/runtimes/backlog/issues/714 aix-all
+java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingBinaryPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingBinaryPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPingBinaryClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPongBinaryClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPingTextClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
+java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
+java/net/InetAddress/HostsFileOrderingTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
+java/net/InetAddress/InternalNameServiceTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
+java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
+java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
+java/net/ipv6tests/UdpTest.java https://github.com/adoptium/aqa-tests/issues/827 linux-all,macosx-all
+java/net/MulticastSocket/B6427403.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all,aix-all
+java/net/MulticastSocket/MulticastAddresses.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
+java/net/MulticastSocket/NoSetNetworkInterface.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all,aix-all
+java/net/MulticastSocket/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.ibm.com/runtimes/backlog/issues/707 linux-s390x,macosx-all
+java/net/MulticastSocket/SetOutgoingIf.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
+java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/Socket/asyncClose/AsyncClose.java https://github.com/eclipse-openj9/openj9/issues/4560 generic-all
+java/net/SocketPermission/SocketPermissionTest.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+jdk/net/ExtendedSocketOption/DontFragmentTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
+
+############################################################################
+
+# jdk_io
+
+java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
+java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
+java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_nio
+
+java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse-openj9/openj9/issues/4473 generic-all
+java/nio/Buffer/LimitDirectMemory.java https://github.com/eclipse-openj9/openj9/issues/8063 generic-all
+java/nio/Buffer/LimitDirectMemoryNegativeTest.java https://github.com/eclipse-openj9/openj9/issues/8065 generic-all
+java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/infrastructure/issues/1173 linux-all,aix-all
+java/nio/channels/AsynchronousChannelGroup/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousChannelGroup/GroupOfOne.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousChannelGroup/Identity.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousChannelGroup/Restart.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousChannelGroup/Unbounded.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousServerSocketChannel/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousServerSocketChannel/WithSecurityManager.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousSocketChannel/DieBeforeComplete.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousSocketChannel/Leaky.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/AsynchronousSocketChannel/StressLoopback.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Channels/Basic2.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Channels/TransferTo.java https://github.com/eclipse-openj9/openj9/issues/15040 linux-all
+java/nio/channels/DatagramChannel/AdaptorBasic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all,macosx-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ConnectedSend.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/Disconnect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
+java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
+java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java  https://github.ibm.com/runtimes/backlog/issues/684 generic-all
+java/nio/channels/etc/NetworkChannelTests.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.ibm.com/runtimes/backlog/issues/684 generic-all
+java/nio/channels/FileChannel/Transfer.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/FileChannel/TransferTo6GBFile.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/Alias.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/BasicAccept.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/BasicConnect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/ChangingInterests.java#id0 https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/CloseWhenKeyIdle.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/Connect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/ConnectWrite.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/KeysReady.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/OpRead.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/OutOfBand.java#id0 https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/RegAfterPreClose.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/SelectorLimit.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/Selector/SelectorTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/ServerSocketChannel/AdaptServerSocket.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/ServerSocketChannel/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/ServerSocketChannel/NonBlockingAccept.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/AdaptSocket.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Basic.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/CloseAfterConnect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/CloseDuringWrite.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Connect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/ConnectState.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/FinishConnect.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/GetChannel.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Hangup.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/LingerOnClose.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/LocalAddress.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/OutOfBand.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/ShortWrite.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Shutdown.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/VectorIO.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/VectorParams.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/SocketChannel/Write.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/eclipse-openj9/openj9/issues/15265 generic-all
+java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
+java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
+java/nio/file/Files/probeContentType/Basic.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
+jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4679 linux-x64,macosx-all
+
+############################################################################
+
+# jdk_rmi
+
+java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse-openj9/openj9/issues/6749 windows-all
+java/rmi/dgc/dgcAckFailure/DGCAckFailure.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
+java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java https://github.com/eclipse-openj9/openj9/issues/7592 generic-all
+java/rmi/server/RemoteServer/AddrInUse.java  https://github.com/eclipse-openj9/openj9/issues/3377 generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java https://github.com/eclipse-openj9/openj9/issues/8515 generic-all
+java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
+java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse-openj9/openj9/issues/4094 generic-all
+java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
+
+############################################################################
+
+# jdk_security
+
+java/security/KeyPairGenerator/FinalizeHalf.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
+java/security/Signature/ResetAfterException.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
+java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+
+############################################################################
+
+# jdk_security3
+
+javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all,aix-all
+javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java	https://github.com/adoptium/aqa-tests/issues/2123	linux-all,aix-all
+javax/net/ssl/SSLEngine/LargePacket.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all,aix-all,windows-all
+javax/net/ssl/SSLSocket/Tls13PacketSize.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+javax/net/ssl/TLSv11/TLSEnginesClosureTest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
+sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/mscapi/CastError.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/CngCipher.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/InteropWithSunRsaSign.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/KeyAlgorithms.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/KeyStoreEmptyCertChain.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/PublicKeyInterop.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/RSAEncryptDecrypt.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SetDupNameEntry.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/ShortRSAKeyWithinTLS.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignUsingNONEwithRSA.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignUsingSHA2withRSA.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignatureOffsets.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SignedObjectChain.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/SmallPrimeExponentP.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/VeryLongAlias.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/pkcs11/Provider/MultipleLogins.sh	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
+sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
+sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java https://github.com/eclipse-openj9/openj9/issues/15266 generic-all
+sun/security/provider/SecureRandom/StrongSecureRandom.java https://github.com/eclipse-openj9/openj9/issues/15266 generic-all
+sun/security/ssl/rsa/SignedObjectChain.java https://github.com/eclipse-openj9/openj9/issues/15266 generic-all
+sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
+sun/security/util/math/TestIntegerModuloP.java	https://github.com/eclipse-openj9/openj9/issues/15209	generic-all
+
+############################################################################
+
+# jdk_security4
+
+sun/security/krb5/auto/BasicProc.java https://github.com/eclipse-openj9/openj9/issues/14803 generic-all
+sun/security/krb5/ccache/Refresh.java https://github.com/eclipse-openj9/openj9/issues/15267 generic-all
+
+########################################################################################################################################################
+
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_util
+
+java/util/Arrays/largeMemory/ParallelPrefix.java https://github.com/eclipse-openj9/openj9/issues/4100 linux-ppc64le
+java/util/Arrays/TimSortStackSize2.java https://github.com/eclipse-openj9/openj9/issues/7086 generic-all
+java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse-openj9/openj9/issues/4720 linux-all
+java/util/concurrent/ArrayBlockingQueue/WhiteBox.java  https://github.com/eclipse-openj9/openj9/issues/5988  macosx-all
+java/util/concurrent/ExecutorService/CloseTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclipse-openj9/openj9/issues/3209 generic-all
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all
+java/util/concurrent/tck/JSR166TestCase.java https://github.com/eclipse-openj9/openj9/issues/15465 generic-all
+java/util/concurrent/ThreadPerTaskExecutor/ThreadPerTaskExecutorTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
+java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all
+java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
+java/util/logging/TestLoggerWeakRefLeak.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/util/Random/RandomTestBsi1999.java https://github.com/eclipse-openj9/openj9/issues/13202 generic-all
+java/util/Random/RandomTestChiSquared.java https://github.com/eclipse-openj9/openj9/issues/13202 generic-all
+java/util/Spliterator/SpliteratorCollisions.java https://github.com/eclipse-openj9/openj9/issues/7090 generic-all
+java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all
+java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all
+java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java https://github.com/eclipse-openj9/openj9/issues/3447 generic-all
+java/util/WeakHashMap/GCDuringIteration.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/8872  generic-all
+
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+
+com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ShenandoahGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ZGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ShenandoahGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ZGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/incubator/concurrent/StructuredTaskScope/StructuredThreadDumpTest.java https://github.com/eclipse-openj9/openj9/issues/15278 generic-all
+jdk/internal/misc/VM/GetNanoTimeAdjustment.java https://github.com/eclipse-openj9/openj9/issues/7184 generic-all
+jdk/internal/misc/VM/RuntimeArguments.java https://github.com/eclipse-openj9/openj9/issues/7186 generic-all
+jdk/internal/reflect/CallerSensitive/CheckCSMs.java https://github.com/eclipse-openj9/openj9/issues/7245 generic-all
+jdk/internal/reflect/constantPool/ConstantPoolTest.java https://github.com/eclipse-openj9/openj9/issues/7249 generic-all
+
+sun/misc/SunMiscSignalTest.java  https://github.com/eclipse-openj9/openj9/issues/7264  generic-all
+sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/adoptium/aqa-tests/issues/749 windows-all
+sun/nio/ch/TestMaxCachedBufferSize.java  https://github.com/eclipse-openj9/openj9/issues/5328  generic-all
+
+vm/verifier/VerifyProtectedConstructor.java https://github.com/eclipse-openj9/openj9/issues/7336 generic-all
+############################################################################
+
+# jdk_foreign
+
+java/foreign/channels/TestAsyncSocketChannels.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj9/openj9/issues/14135 generic-all
+java/foreign/malloc/TestMixedMallocFree.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/SafeFunctionAccessTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
+java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+java/foreign/TestDowncall.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
+java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
+java/foreign/TestIntrinsics.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestMemoryAccess.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestNative.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestNULLAddress.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestNulls.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestSegmentAllocators.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
+java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+java/foreign/TestUpcall.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+java/foreign/TestUpcall.java#async https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestUpcall.java#no_scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestUpcall.java#scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/TestUpcallException.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+java/foreign/TestUpcallHighArity.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+java/foreign/TestUpcallStructScope.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
+java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
+java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+
+############################################################################
+
+# com_sun_crypto
+
+############################################################################
+
+# jdk_vector
+
+jdk/incubator/vector/Byte128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
+jdk/incubator/vector/Byte256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
+jdk/incubator/vector/Int128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
+jdk/incubator/vector/Short256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
+jdk/incubator/vector/Vector128ConversionTests.java https://github.com/eclipse-openj9/openj9/issues/15211 generic-all
+
+############################################################################

--- a/openjdk/excludes/ProblemList_openjdk20.txt
+++ b/openjdk/excludes/ProblemList_openjdk20.txt
@@ -1,0 +1,503 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+#java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+#java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/XMLEncoder/java_awt_CardLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/java_awt_GridBagLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+#java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/javax_swing_Box.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_BoxLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_Box_Filler.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+#java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JButton.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JLayeredPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JSplitPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+#java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_OverlayLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_border_TitledBorder.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/Test4631471.java  https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+#java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810   aix-ppc64,linux-all
+java/beans/PropertyChangeSupport/Test4682386.java   https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
+java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+############################################################################
+
+# jdk_lang
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+#java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
+java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessString.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
+java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 linux-arm
+#java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
+#java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
+java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
+java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+
+############################################################################
+
+# jdk_management
+com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
+sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+############################################################################
+
+# jdk_other
+#com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
+com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
+############################################################################
+
+# jdk_net
+java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
+java/net/InetAddress/BadDottedIPAddress.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/InetAddress/CachedUnknownHostName.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/InetAddress/IPv4Formats.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699	linux-s390x
+java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/SocketPermission/SocketPermissionTest.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/net/SocketPermission/Wildcard.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/Socks/SocksV4Test.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/URL/OpenStream.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/httpclient/ConnectExceptionTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/net/httpclient/AsFileDownloadTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/StreamingBody.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/http2/ContinuationFrameTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/SpecialHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/http2/BadHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/DigestEchoClientSSL.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/ResponseBodyBeforeError.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/httpclient/ResponsePublisher.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+#Multivase failures on aix https://github.com/adoptium/aqa-tests/issues/2246
+java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all,linux-ppc64le
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/CookieHandler/CookieManagerTest.java   https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux-ppc64le
+java/net/DatagramPacket/ReuseBuf.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64, linux-ppc64le
+java/net/DatagramSocket/PortUnreachable.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/ReuseAddressTest.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/Send12k.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64,linux-ppc64le 
+java/net/DatagramSocket/SendSize.java.SendSize  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ProxyCons.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ReadTimeout.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SetSoLinger.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SoTimeout.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/AsyncClose.java  https://github.com/adoptium/aqa-tests/issues/827 aix-ppc64, linux-ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Basic.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Restart.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/SocketInputStream/SocketTimeout.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/BadProxySelector.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/SocksProxyVersion.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/Race.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/httpclient/ManyRequests.java   https://github.com/adoptium/aqa-tests/issues/2828 aix-ppc64
+
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
+#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
+java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
+java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
+java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
+java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
+java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 generic-all
+java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086 generic-all
+java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
+java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
+#java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
+java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+java/net/InetAddress/HostsFileOrderingTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+java/net/InetAddress/InternalNameServiceTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
+com/sun/net/httpserver/simpleserver/StressDirListings.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+############################################################################
+
+# jdk_io
+
+java/io/File/GetXSpace.java	https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+############################################################################
+
+# jdk_jdi
+com/sun/jdi/JdwpNetProps.java	https://bugs.openjdk.java.net/browse/JDK-8231915 linux-s390x
+com/sun/jdi/JdwpAttachTest.java	https://bugs.openjdk.java.net/browse/JDK-8253940 linux-s390x
+com/sun/jdi/BreakpointTest.java https://bugs.openjdk.java.net/browse/JDK-8050470 linux-s390x
+com/sun/jdi/JdwpAllowTest.java https://bugs.openjdk.org/browse/JDK-8241624 generic-all
+com/sun/jdi/JdwpListenTest.java https://bugs.openjdk.org/browse/JDK-8241624 generic-all
+############################################################################
+
+# jdk_nio
+java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
+java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/file/Files/InterruptCopy.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
+jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
+java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
+
+java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x
+ 
+
+############################################################################ 
+
+# jdk_rmi
+############################################################################
+
+# jdk_security
+
+sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aqa-tests/issues/3811 windows-x86
+############################################################################
+
+#jdk_security3
+javax/net/ssl/SSLEngine/LargePacket.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
+
+###########################################################################
+#jdk_security_infra
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/EntrustCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+
+############################################################################
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstatd/TestJstatdDefaults.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdExternalRegistry.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPort.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPortAndServer.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdServer.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+
+tools/jpackage/share/AddLauncherTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AppImagePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/EmptyFolderPackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/IconTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
+#The following 8 tests under tools/jpackage/share/ excluded on linux-aarch64 the tracked issue is https://github.com/adoptium/infrastructure/issues/2291
+tools/jpackage/share/InstallDirTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/LicenseTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiNameTwoPhaseTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/RuntimePackageTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/SimplePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/BasicTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/VendorTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/windows/WinDirChooserTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinInstallerUiTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinL10nTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuGroupTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinPerUserInstallTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinScriptTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutPromptTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUrlTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jlink/JLinkTest.java	https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
+tools/jlink/JLinkReproducible3Test.java	https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
+tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-pcc64
+tools/jpackage/windows/WinInstallerIconTest.java    https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AddLShortcutTest.java  https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+
+############################################################################
+
+# jdk_jdi
+com/sun/jdi/OnJcmdTest.java	https://github.com/adoptium/aqa-tests/issues/2837	windows-x86
+############################################################################
+
+# jdk_util
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/util/concurrent/tck/JSR166TestCase.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/util/regex/NegativeArraySize.java https://github.com/adoptium/aqa-tests/issues/3818 linux-all
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+############################################################################
+
+# jdk_foreign
+java/foreign/TestArrays.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayouts.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayoutPaths.java	https://github.com/adoptium/aqa-tests/issues/1701	generic-all
+java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+
+############################################################################
+# jvm_compiler
+
+compiler/graalunit/ApiDirectivesTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/ApiTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/AsmAarch64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/AsmAmd64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/CollectionsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/Core01Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/Core02Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/CoreAarch64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/CoreAmd64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/CoreJdk9Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/DebugTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/EATest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/GraphTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotAarch64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotAmd64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotJdk15Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotJdk9Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotLirTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/HotspotTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttBackendTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttBytecodeTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttExceptTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttHotpathTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttHotspotTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttJdkTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLangALTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLangMathALTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLangMathMZTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLangNZTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttLoopTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttOptimizeTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttReflectAETest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttReflectFieldGetTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttReflectFieldSetTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttReflectGZTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/JttThreadsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/LirJttTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/LirTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/LoopTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/NodesTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/OptionsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/PhasesCommonTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/Replacements12Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/Replacements9Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/ReplacementsTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/graalunit/UtilTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
+compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux-s390x
+
+compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/irTests/TestPostParseCallDevirtualization.java  https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/tiered/TieredLevelsTest.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/vectorapi/TestNoInline.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestTranslatedException.java https://github.com/adoptium/aqa-tests/issues/3658 linux-x64,windows-x64,linux-aarch64,macosx-all
+compiler/c2/TestCMoveInfiniteGVN.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/TestDeadDataLoopCmoveIdentity.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/TestModDivTopInput.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopopts/FillArrayWithUnsafe.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopopts/TestPredicateInputBelowLoopPredicate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/print/PrintInlining.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopstripmining/TestConservativeAntiDep.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+############################################################################
+
+# jdk_jfr
+jdk/jfr/event/oldobject/TestAllocationTime.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestHeapDeep.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestG1.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/api/consumer/TestRecordedFrame.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java	https://github.com/adoptium/aqa-tests/issues/2870 windows-x86,linux-arm
+jdk/jfr/event/gc/collection/TestG1ParallelPhases.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestListenerLeak.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestObjectAge.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestReferenceChainLimit.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestThreadLocalLeak.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jmx/streaming/TestClose.java	https://github.com/adoptium/aqa-tests/issues/2865 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestDelegated.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestEnableDisable.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRemoteDump.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRotate.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+
+jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/3492 generic-all
+jdk/jfr/jmx/streaming/TestMetadataEvent.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
+jdk/jfr/jmx/streaming/TestSetSettings.java  https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
+jdk/jfr/jmx/streaming/TestStart.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86
+jdk/jfr/jmx/TestGetRecordings.java  https://github.com/adoptium/aqa-tests/issues/2754 linux-ppc64le
+jdk/jfr/event/gc/detailed/TestZUncommitEvent.java https://bugs.openjdk.org/browse/JDK-8248078 generic-all
+jdk/jfr/event/gc/detailed/TestGCLockerEvent.java https://github.com/adoptium/aqa-tests/issues/3817 windows-x64
+
+###########################################################################
+
+#jdk_vector
+jdk/incubator/vector/Byte512VectorLoadStoreTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ByteMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Int64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/IntMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Short64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ShortMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+
+jdk/incubator/vector/Byte256VectorLoadStoreTests.java   https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+
+############################################################################
+
+#runtime_nestmate
+runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
+
+############################################################################
+#javax_management
+javax/management/remote/mandatory/connection/RMIConnectionIdTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/notif/RMINotifTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java  https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/util/MapNullValuesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+
+############################################################################
+#jdk_imageio
+javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+
+############################################################################
+#sun_net
+sun/net/www/http/HttpClient/B8025710.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/http/KeepAliveCache/B5045306.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/NoCache.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/ZoneId.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java https://bugs.openjdk.java.net/browse/JDK-8224204 generic-all
+sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+
+#####################################
+


### PR DESCRIPTION
Add exclude files for Java 20

Copied from `ProblemList_openjdk19.txt` & `ProblemList_openjdk19-openj9.txt`.

related to https://github.com/eclipse-openj9/openj9/pull/15528

Signed-off-by: Jason Feng <fengj@ca.ibm.com>