### PR TITLE
Temporarily disable quarkus_test for openj9

### DIFF
--- a/external/quarkus/playlist.xml
+++ b/external/quarkus/playlist.xml
@@ -21,6 +21,11 @@
 				<version>11</version>
 				<impl>hotspot</impl>
 			</disable>
+			<disable>
+				<comment>runtimes_backlog/issues/831</comment>
+				<version>11</version>
+				<impl>openj9</impl>
+			</disable>
 		</disables>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir quarkus --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
 		$(TEST_STATUS); \


### PR DESCRIPTION
- Temporarily disable quarkus_test for openj9 11
- Related Issue: runtimes_backlog/issues/831

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>