### PR TITLE
(v0.9.3-release) Temporarily disable quarkus_test for openj9 11 (#3848)

### DIFF
--- a/external/quarkus/playlist.xml
+++ b/external/quarkus/playlist.xml
@@ -21,6 +21,11 @@
 				<version>11</version>
 				<impl>hotspot</impl>
 			</disable>
+			<disable>
+				<comment>runtimes_backlog/issues/831</comment>
+				<version>11</version>
+				<impl>openj9</impl>
+			</disable>
 		</disables>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir quarkus --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
 		$(TEST_STATUS); \


### PR DESCRIPTION
- This is a ported change from master branch
- Temporarily disable quarkus_test for openj9 11

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>