### PR TITLE
Jck test support jck8b

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -1189,7 +1189,7 @@ public class JavaTestRunner {
 			testSpecificJvmOptions += " -Djava.security.properties=" + secPropsFile;
 		}
 		
-		Matcher matcher = Pattern.compile("jck(\\d+)c?").matcher(jckVersion);
+		Matcher matcher = Pattern.compile("jck(\\d+)[bc]?").matcher(jckVersion);
 		if (matcher.matches()) {
 			// first group is going to be 8, 9, 10, 11, etc.
 			int jckVerNum = Integer.parseInt(matcher.group(1));
@@ -1337,7 +1337,7 @@ public class JavaTestRunner {
 	}
 	
 	private static int getJckVersionInt(String version) {
-		if (version.equals("8c")) {
+		if (version.equals("8c") || version.equals("8b")) {
 			return 8; 
 		} else {
 			return Integer.parseInt(version); 

--- a/jck/jtrunner/config/jck8b/compiler.jti
+++ b/jck/jtrunner/config/jck8b/compiler.jti
@@ -1,0 +1,193 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=JCK8b_compiler
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_compiler
+QUESTION=jck.end
+# TESTSUITE example: /jck/jck8b/JCK-compiler-8b
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-compiler-8b
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.compiler.agent.networkClassLoading=No
+jck.env.compiler.agent.passivePort=
+jck.env.compiler.agent.resourcesRemoving=No
+# jck.env.compiler.compRefExecute.cmdAsFile example: /home/user/jdk-8/jre/bin/java
+jck.env.compiler.compRefExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.compRefExecute.otherEnvVars=
+jck.env.compiler.compRefExecute.otherOpts=
+jck.env.compiler.rmi.tcpLower=
+jck.env.compiler.rmi.tcpRange=No
+jck.env.compiler.rmi.tcpUpper=
+jck.env.compiler.rmic=Yes
+jck.env.compiler.services.autostartServices=
+jck.env.compiler.services.servicesOn=No
+jck.env.compiler.testCompile.annoProc=-processor \#
+jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
+jck.env.compiler.testCompile.classpath=environment variable
+jck.env.compiler.testCompile.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.classpathOpt=-classpath \#
+# jck.env.compiler.testCompile.cmdAsFile example: /home/user/jdk-8/jre/bin/javac
+jck.env.compiler.testCompile.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.cmdAsString=
+jck.env.compiler.testCompile.compilerClass=
+jck.env.compiler.testCompile.compilerType=Java compiler API (JSR 199)
+jck.env.compiler.testCompile.compilerstaticsigtest=Yes
+# jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspath example /home/user/jdk-8/jre/lib
+jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspath=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspathRemote=
+jck.env.compiler.testCompile.compilerstaticsigtest.supportCompilerStaticSigTest=Yes
+jck.env.compiler.testCompile.defaultCompiler=Yes
+jck.env.compiler.testCompile.otherEnvVars=
+jck.env.compiler.testCompile.otherOpts=-source 1.8
+jck.env.compiler.testCompile.outDirOpt=-d \#
+jck.env.compiler.testCompile.outSrcDirOpt=-s \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=environment variable
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
+# jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile example: /home/user/jdk-8/jre/bin/java
+jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile=will_be_set_by_test_automation_at_run_time
+# jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsString example: /home/user/jdk-8/jre/bin/java
+jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsString=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
+jck.env.compiler.testRmic.classpath=environment variable
+jck.env.compiler.testRmic.classpathEnv=CLASSPATH
+jck.env.compiler.testRmic.classpathOpt=-classpath \#
+# jck.env.compiler.testRmic.cmdAsFile example:  /home/user/jdk-8/jre/bin/rmic
+jck.env.compiler.testRmic.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testRmic.iiopOption=-iiop
+jck.env.compiler.testRmic.otherEnvVars=
+jck.env.compiler.testRmic.otherOpts=
+jck.env.compiler.testRmic.outDirOpt=-d \#
+jck.env.compiler.testRmic.v11Option=-v1.1
+jck.env.compiler.testRmic.v12Option=-v1.2
+jck.env.description=JCK8b_compiler
+jck.env.devtools.agent.networkClassLoading=No
+jck.env.devtools.agent.passivePort=
+jck.env.devtools.agent.resourcesRemoving=No
+jck.env.devtools.jaxb.defaultOperationMode=Yes
+jck.env.devtools.jaxb.needJaxbClasses=No
+jck.env.devtools.jaxb.skipJ2XOptional=Yes
+jck.env.devtools.refExecute.otherEnvVars=
+jck.env.devtools.refExecute.otherOpts=
+jck.env.devtools.scriptEnvVars=
+jck.env.devtools.services.autostartServices=
+jck.env.devtools.services.servicesOn=No
+jck.env.devtools.testExecute.classpath=command line option
+jck.env.devtools.testExecute.classpathEnv=CLASSPATH
+jck.env.devtools.testExecute.classpathOpt=-classpath \#
+jck.env.devtools.testExecute.otherEnvVars=
+jck.env.devtools.testExecute.otherOpts=
+jck.env.envName=jck_compiler
+jck.env.mode=classpath
+jck.env.modules=
+jck.env.product=compiler
+jck.env.profile=4
+jck.env.runtime.agent.networkClassLoading=No
+jck.env.runtime.agent.passivePort=
+jck.env.runtime.agent.resourcesRemoving=No
+jck.env.runtime.audio.canPlayMidi=Yes
+jck.env.runtime.audio.canPlaySound=Yes
+jck.env.runtime.audio.canRecordSound=Yes
+jck.env.runtime.audio.soundURLChoice=Yes
+jck.env.runtime.audio.soundURLYesJCK=.WAV
+jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
+jck.env.runtime.awt.robotAvailable=Yes
+jck.env.runtime.awt.splashScreenOpt=-splash\:\#
+jck.env.runtime.awt.splashScreenSupported=Yes
+jck.env.runtime.fp.doubleMaxExponent=
+jck.env.runtime.fp.doubleMinExponent=
+jck.env.runtime.fp.floatMaxExponent=
+jck.env.runtime.fp.floatMinExponent=
+jck.env.runtime.fp.supportExtended=No
+jck.env.runtime.ftpSupport=No
+# jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
+jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.idl.orbPort=1,050
+jck.env.runtime.jaas.authPolicy=standard system property
+jck.env.runtime.jaas.loginConfig=standard system property
+jck.env.runtime.jdwp.VMSuspended=Yes
+jck.env.runtime.jdwp.connectorType=attaching
+jck.env.runtime.jdwp.jdwpSupported=Yes
+jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
+jck.env.runtime.jgss.loginModule=No
+jck.env.runtime.jplis.jplisCmdLine=Yes
+jck.env.runtime.jplis.jplisLivePhase=Yes
+jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
+jck.env.runtime.jsse.isJKSSupported=Yes
+jck.env.runtime.memory.expectOutOfMemory=Yes
+jck.env.runtime.memory.memoryAllocation=Yes
+# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
+jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.tcpLower=
+jck.env.runtime.net.tcpRange=No
+jck.env.runtime.net.tcpUpper=
+jck.env.runtime.net.udpLower=
+jck.env.runtime.net.udpRange=No
+jck.env.runtime.net.udpUpper=
+jck.env.runtime.print.hasPrinter=Yes
+jck.env.runtime.remoteAgent.loadClasses=No
+jck.env.runtime.remoteAgent.passivePort=
+jck.env.runtime.remoteAgent.passivePortDefault=Yes
+jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
+jck.env.runtime.services.autostartServices=
+jck.env.runtime.services.servicesOn=No
+jck.env.runtime.staticsigtest.supportStaticSigTest=No
+jck.env.runtime.testExecute.activationPortValue=
+jck.env.runtime.testExecute.classpath=command line option
+jck.env.runtime.testExecute.classpathEnv=CLASSPATH
+jck.env.runtime.testExecute.classpathOpt=-classpath \#
+jck.env.runtime.testExecute.jarExecution=Yes
+jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
+jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
+jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
+jck.env.runtime.testExecute.libPath=environment variable
+jck.env.runtime.testExecute.modulepathOpt=-L \#
+jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
+jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
+jck.env.runtime.testExecute.optionSpecification=Yes
+jck.env.runtime.testExecute.otherEnvVars=
+jck.env.runtime.testExecute.otherOpts=
+jck.env.runtime.testExecute.rmiActivationSupport=No
+jck.env.runtime.testExecute.stdActivationPort=Yes
+jck.env.runtime.testExecute.verify=-Xfuture
+# jck.env.runtime.url.ftpURL example: ftp\://ftp.w3.org/welcome.msg
+jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.httpURL example: http\://www.iana.org/domains/example/index.html
+jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
+jck.env.simpleOrAdvanced=advanced
+# jck.env.runtime.url.httpURL example: http\://www.iana.org/domains/example/index.html
+jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
+# jck.env.testPlatform.display example: :1 or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=other
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+# jck.env.testPlatform.systemRoot example: C\:\\WINDOWS
+jck.env.testPlatform.systemRoot=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck8b/excludes/jck8b.jtx\n/jck/jck8b/excludes/jck8a.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.needKeywords=No
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.needTests=No
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/jck/jtrunner/config/jck8b/devtools.jti
+++ b/jck/jtrunner/config/jck8b/devtools.jti
@@ -1,0 +1,190 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=Devtools
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_devtools
+QUESTION=jck.end
+# TESTSUITE example: /jck/jck8b/JCK-devtools-8b
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-devtools-8b
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.compiler.agent.networkClassLoading=No
+jck.env.compiler.agent.passivePort=
+jck.env.compiler.agent.resourcesRemoving=No
+jck.env.compiler.compRefExecute.otherEnvVars=
+jck.env.compiler.compRefExecute.otherOpts=
+jck.env.compiler.rmi.tcpLower=
+jck.env.compiler.rmi.tcpRange=No
+jck.env.compiler.rmi.tcpUpper=
+jck.env.compiler.services.autostartServices=
+jck.env.compiler.services.servicesOn=No
+jck.env.compiler.testCompile.annoProc=-processor \#
+jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
+jck.env.compiler.testCompile.classpath=command line option
+jck.env.compiler.testCompile.classpathOpt=-classpath \#
+jck.env.compiler.testCompile.compilerType=command line tool
+jck.env.compiler.testCompile.compilerstaticsigtest.supportCompilerStaticSigTest=No
+jck.env.compiler.testCompile.defaultCompiler=Yes
+jck.env.compiler.testCompile.otherEnvVars=
+jck.env.compiler.testCompile.otherOpts=
+jck.env.compiler.testCompile.outDirOpt=-d \#
+jck.env.compiler.testCompile.outSrcDirOpt=-s \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=environment variable
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
+jck.env.compiler.testRmic.classpath=command line option
+jck.env.compiler.testRmic.classpathOpt=-classpath \#
+jck.env.compiler.testRmic.iiopOption=-iiop
+jck.env.compiler.testRmic.otherEnvVars=
+jck.env.compiler.testRmic.otherOpts=
+jck.env.compiler.testRmic.outDirOpt=-d \#
+jck.env.compiler.testRmic.v11Option=-v1.1
+jck.env.compiler.testRmic.v12Option=-v1.2
+jck.env.description=Devtools
+jck.env.devtools.agent.networkClassLoading=No
+jck.env.devtools.agent.passivePort=
+jck.env.devtools.agent.resourcesRemoving=No
+jck.env.devtools.jaxb=Yes
+jck.env.devtools.jaxb.defaultOperationMode=Yes
+jck.env.devtools.jaxb.java2schema=Yes
+# jck.env.devtools.jaxb.jxcCmd example: C\:\\jck\\jck8b\\JCK-devtools-8b\\win32\\bin\\ibm_schemagen.bat
+jck.env.devtools.jaxb.jxcCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxb.needJaxbClasses=No
+jck.env.devtools.jaxb.skipJ2XOptional=Yes
+# jck.env.devtools.jaxb.xjcCmd example: C\:\\jck\\jck8b\\JCK-devtools-8b\\win32\\bin\\ibm_xjc.bat
+jck.env.devtools.jaxb.xjcCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxb.xml_schema=Yes
+jck.env.devtools.jaxws=Yes
+# jck.env.devtools.jaxws.cmdJavac example: C\:\\jdk-8\\bin\\javac.exe
+jck.env.devtools.jaxws.cmdJavac=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.jaxws.genCmd example: C\:\\jck\\jck8b\\JCK-devtools-8b\\win32\\bin\\ibm_wsgen.bat
+jck.env.devtools.jaxws.genCmd=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.jaxws.impCmd example: C\:\\jck\\jck8b\\JCK-devtools-8b\\win32\\bin\\ibm_wsimport.bat
+jck.env.devtools.jaxws.impCmd=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.refExecute.cmdAsFile example: C\:\\jdk-8\\jre\\bin\\java.exe
+jck.env.devtools.refExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.refExecute.otherEnvVars=
+jck.env.devtools.refExecute.otherOpts=
+jck.env.devtools.scriptEnvVars=
+jck.env.devtools.services.autostartServices=
+jck.env.devtools.services.servicesOn=No
+jck.env.devtools.testExecute.additionalClasspathRemote=
+jck.env.devtools.testExecute.classpath=command line option
+jck.env.devtools.testExecute.classpathEnv=CLASSPATH
+jck.env.devtools.testExecute.classpathOpt=-classpath \#
+# jck.env.devtools.testExecute.cmdAsString example: C\:\\jdk-8\\jre\\bin\\java.exe
+jck.env.devtools.testExecute.cmdAsString=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.testExecute.otherEnvVars=
+jck.env.devtools.testExecute.otherOpts=
+jck.env.envName=jck_devtools2
+jck.env.mode=classpath
+jck.env.modules=
+jck.env.product=devtools
+jck.env.profile=4
+jck.env.runtime.agent.networkClassLoading=No
+jck.env.runtime.agent.passivePort=
+jck.env.runtime.agent.resourcesRemoving=No
+jck.env.runtime.audio.canPlayMidi=Yes
+jck.env.runtime.audio.canPlaySound=Yes
+jck.env.runtime.audio.canRecordSound=Yes
+jck.env.runtime.audio.soundURLChoice=Yes
+jck.env.runtime.audio.soundURLYesJCK=.WAV
+jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
+jck.env.runtime.awt.robotAvailable=Yes
+jck.env.runtime.awt.splashScreenOpt=-splash\:\#
+jck.env.runtime.awt.splashScreenSupported=Yes
+jck.env.runtime.fp.doubleMaxExponent=
+jck.env.runtime.fp.doubleMinExponent=
+jck.env.runtime.fp.floatMaxExponent=
+jck.env.runtime.fp.floatMinExponent=
+jck.env.runtime.fp.supportExtended=No
+jck.env.runtime.ftpSupport=No
+# jck.env.runtime.idl.orbHost example: localhost
+jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.jaas.authPolicy=standard system property
+jck.env.runtime.jaas.loginConfig=standard system property
+jck.env.runtime.jdwp.VMSuspended=Yes
+jck.env.runtime.jdwp.connectorType=attaching
+jck.env.runtime.jdwp.jdwpSupported=Yes
+jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
+jck.env.runtime.jgss.loginModule=No
+jck.env.runtime.jplis.jplisCmdLine=Yes
+jck.env.runtime.jplis.jplisLivePhase=Yes
+jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
+jck.env.runtime.jsse.isJKSSupported=Yes
+jck.env.runtime.memory.expectOutOfMemory=Yes
+jck.env.runtime.memory.memoryAllocation=Yes
+# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
+jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.tcpLower=
+jck.env.runtime.net.tcpRange=No
+jck.env.runtime.net.tcpUpper=
+jck.env.runtime.net.udpLower=
+jck.env.runtime.net.udpRange=No
+jck.env.runtime.net.udpUpper=
+jck.env.runtime.print.hasPrinter=Yes
+jck.env.runtime.remoteAgent.loadClasses=No
+jck.env.runtime.remoteAgent.passivePort=
+jck.env.runtime.remoteAgent.passivePortDefault=Yes
+jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
+jck.env.runtime.services.autostartServices=
+jck.env.runtime.services.servicesOn=No
+jck.env.runtime.staticsigtest.supportStaticSigTest=No
+jck.env.runtime.testExecute.activationPortValue=
+jck.env.runtime.testExecute.classpath=command line option
+jck.env.runtime.testExecute.classpathEnv=CLASSPATH
+jck.env.runtime.testExecute.classpathOpt=-classpath \#
+jck.env.runtime.testExecute.jarExecution=Yes
+jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
+jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
+jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
+jck.env.runtime.testExecute.libPath=environment variable
+jck.env.runtime.testExecute.modulepathOpt=-L \#
+jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
+jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
+jck.env.runtime.testExecute.optionSpecification=Yes
+jck.env.runtime.testExecute.otherEnvVars=
+jck.env.runtime.testExecute.otherOpts=
+jck.env.runtime.testExecute.rmiActivationSupport=No
+jck.env.runtime.testExecute.stdActivationPort=Yes
+jck.env.runtime.testExecute.verify=-Xfuture
+# jck.env.runtime.url.ftpURL example: ftp\://xxxx.xxxx.xxxx.com/xxx.txt
+jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
+jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=other
+jck.env.testPlatform.proxyPort=0
+jck.env.testPlatform.remoteNetworking=Remote network support
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck8b/excludes\\jck8b.jtx
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.needKeywords=No
+# jck.knownFailuresList.customFiles example: /jck/jck8b/excludes/jck8b.kfl
+jck.knownFailuresList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.needTests=No
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/jck/jtrunner/config/jck8b/runtime.jti
+++ b/jck/jtrunner/config/jck8b/runtime.jti
@@ -1,0 +1,235 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=JCK8b-runtime
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_runtime
+QUESTION=jck.env.runtime.idl.orbPort
+# TESTSUITE example: /jck/jck8b/JCK-runtime-8b
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-runtime-8b
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.compiler.agent.networkClassLoading=No
+jck.env.compiler.agent.passivePort=
+jck.env.compiler.agent.resourcesRemoving=No
+jck.env.compiler.compRefExecute.otherEnvVars=
+jck.env.compiler.compRefExecute.otherOpts=
+jck.env.compiler.rmi.tcpLower=
+jck.env.compiler.rmi.tcpRange=No
+jck.env.compiler.rmi.tcpUpper=
+jck.env.compiler.services.autostartServices=
+jck.env.compiler.services.servicesOn=No
+jck.env.compiler.testCompile.annoProc=-processor \#
+jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
+jck.env.compiler.testCompile.classpath=command line option
+jck.env.compiler.testCompile.classpathOpt=-classpath \#
+jck.env.compiler.testCompile.compilerType=command line tool
+jck.env.compiler.testCompile.compilerstaticsigtest.supportCompilerStaticSigTest=No
+jck.env.compiler.testCompile.defaultCompiler=Yes
+jck.env.compiler.testCompile.otherEnvVars=
+jck.env.compiler.testCompile.otherOpts=
+jck.env.compiler.testCompile.outDirOpt=-d \#
+jck.env.compiler.testCompile.outSrcDirOpt=-s \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=environment variable
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
+jck.env.compiler.testRmic.classpath=command line option
+jck.env.compiler.testRmic.classpathOpt=-classpath \#
+jck.env.compiler.testRmic.iiopOption=-iiop
+jck.env.compiler.testRmic.otherEnvVars=
+jck.env.compiler.testRmic.otherOpts=
+jck.env.compiler.testRmic.outDirOpt=-d \#
+jck.env.compiler.testRmic.v11Option=-v1.1
+jck.env.compiler.testRmic.v12Option=-v1.2
+jck.env.description=JCK8b-runtime
+jck.env.devtools.agent.networkClassLoading=No
+jck.env.devtools.agent.passivePort=
+jck.env.devtools.agent.resourcesRemoving=No
+jck.env.devtools.jaxb.defaultOperationMode=Yes
+jck.env.devtools.jaxb.needJaxbClasses=No
+jck.env.devtools.jaxb.skipJ2XOptional=Yes
+jck.env.devtools.refExecute.otherEnvVars=
+jck.env.devtools.refExecute.otherOpts=
+jck.env.devtools.scriptEnvVars=
+jck.env.devtools.services.autostartServices=
+jck.env.devtools.services.servicesOn=No
+jck.env.devtools.testExecute.classpath=command line option
+jck.env.devtools.testExecute.classpathEnv=CLASSPATH
+jck.env.devtools.testExecute.classpathOpt=-classpath \#
+jck.env.devtools.testExecute.otherEnvVars=
+jck.env.devtools.testExecute.otherOpts=
+jck.env.envName=jck_runtime
+jck.env.mode=classpath
+jck.env.modules=
+jck.env.product=runtime
+jck.env.profile=4
+jck.env.runtime.RemoteAgent=Yes
+jck.env.runtime.agent.networkClassLoading=No
+jck.env.runtime.agent.passivePort=
+jck.env.runtime.agent.resourcesRemoving=No
+jck.env.runtime.audio=Yes
+jck.env.runtime.audio.canPlayMidi=Yes
+jck.env.runtime.audio.canPlaySound=Yes
+jck.env.runtime.audio.canRecordSound=Yes
+jck.env.runtime.audio.soundURLChoice=Yes
+jck.env.runtime.audio.soundURLYesJCK=.WAV
+jck.env.runtime.awt=Yes
+jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
+jck.env.runtime.awt.robotAvailable=Yes
+jck.env.runtime.awt.splashScreenOpt=-splash\:\#
+jck.env.runtime.awt.splashScreenSupported=Yes
+jck.env.runtime.fp=Yes
+jck.env.runtime.fp.doubleMaxExponent=
+jck.env.runtime.fp.doubleMinExponent=
+jck.env.runtime.fp.floatMaxExponent=
+jck.env.runtime.fp.floatMinExponent=
+jck.env.runtime.fp.format=Intel, 15 bit exponent
+jck.env.runtime.fp.supportExtended=Yes
+jck.env.runtime.ftpSupport=Yes
+jck.env.runtime.idl=Yes
+# jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
+jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.idl.orbPort=9,876
+jck.env.runtime.jaas=Yes
+jck.env.runtime.jaas.authPolicy=standard system property
+jck.env.runtime.jaas.loginConfig=standard system property
+jck.env.runtime.jdwp=Yes
+jck.env.runtime.jdwp.VMSuspended=Yes
+jck.env.runtime.jdwp.connectorType=attaching
+jck.env.runtime.jdwp.jdwpOpts=-agentlib\:jdwp\=server\=y,transport\=dt_socket,address\=localhost\:35000,suspend\=y
+jck.env.runtime.jdwp.jdwpSupported=Yes
+jck.env.runtime.jdwp.transportAddress=localhost\:35000
+jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
+jck.env.runtime.jgss=Yes
+jck.env.runtime.jgss.kdc=No
+# jck.env.runtime.jgss.kdcHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.jgss.kdcHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.jgss.kdcRealm=No
+# jck.env.runtime.jgss.kdcRealmName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.jgss.kdcRealmName=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ClientPassword example: password2
+jck.env.runtime.jgss.krb5ClientPassword=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ClientUsername example: user2
+jck.env.runtime.jgss.krb5ClientUsername=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ServerPassword example: password1
+jck.env.runtime.jgss.krb5ServerPassword=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ServerUsername example: user1
+jck.env.runtime.jgss.krb5ServerUsername=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.jgss.loginModule=Yes
+jck.env.runtime.jplis=Yes
+jck.env.runtime.jplis.jplisCmdLine=Yes
+jck.env.runtime.jplis.jplisLivePhase=No
+jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
+jck.env.runtime.jsse=Yes
+jck.env.runtime.jsse.isJKSSupported=Yes
+jck.env.runtime.memory=Yes
+jck.env.runtime.memory.expectOutOfMemory=Yes
+jck.env.runtime.memory.memoryAllocation=Yes
+jck.env.runtime.net=Yes
+# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
+jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.other=Yes
+jck.env.runtime.net.tcpLower=
+jck.env.runtime.net.tcpRange=No
+jck.env.runtime.net.tcpUpper=
+# jck.env.runtime.net.testHost1IPAddr example: n.n.n.n
+jck.env.runtime.net.testHost1IPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost1Name example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.testHost1Name=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost2IPAddr example: n.n.n.n
+jck.env.runtime.net.testHost2IPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost2Name example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.testHost2Name=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.udpLower=
+jck.env.runtime.net.udpRange=No
+jck.env.runtime.net.udpUpper=
+jck.env.runtime.print=Yes
+jck.env.runtime.print.hasPrinter=Yes
+jck.env.runtime.remoteAgent.loadClasses=No
+jck.env.runtime.remoteAgent.passiveHost=localhost
+jck.env.runtime.remoteAgent.passivePort=
+jck.env.runtime.remoteAgent.passivePortDefault=Yes
+jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
+jck.env.runtime.services.autostartServices=RMI_service ORB_service Distributed_Agent
+jck.env.runtime.services.servicesOn=No
+jck.env.runtime.staticsigtest=Yes
+# jck.env.runtime.staticsigtest.staticSigTestClasspath example:/home/user/jdk-8/lib\n/home/user/jdk-8/jre/lib
+jck.env.runtime.staticsigtest.staticSigTestClasspath=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.staticsigtest.supportStaticSigTest=Yes
+jck.env.runtime.testExecute.activationPortValue=
+jck.env.runtime.testExecute.additionalClasspath=
+jck.env.runtime.testExecute.classpath=command line option
+jck.env.runtime.testExecute.classpathEnv=CLASSPATH
+jck.env.runtime.testExecute.classpathOpt=-classpath \#
+# jck.env.runtime.testExecute.cmdAsFile example: /home/user/jdk-8/jre/bin/java
+jck.env.runtime.testExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.jarExecution=Yes
+jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
+jck.env.runtime.testExecute.jmx=Yes
+# jck.env.runtime.testExecute.jmxResourcePathFileValue example: /jck/jck8b/natives/linux_x86-64
+jck.env.runtime.testExecute.jmxResourcePathFileValue=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.jni=Yes
+jck.env.runtime.testExecute.jvmti=Yes
+jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
+jck.env.runtime.testExecute.jvmtiLivePhase=No
+jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
+jck.env.runtime.testExecute.libPath=environment variable
+jck.env.runtime.testExecute.libPathEnv=PATH
+jck.env.runtime.testExecute.modulepathOpt=-L \#
+# jck.env.runtime.testExecute.nativeLibPathFileValue example: /jck/jck8b/natives/linux_x86-64
+jck.env.runtime.testExecute.nativeLibPathFileValue=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
+jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
+jck.env.runtime.testExecute.optionSpecification=Yes
+jck.env.runtime.testExecute.otherEnvVars=
+jck.env.runtime.testExecute.otherOpts=
+jck.env.runtime.testExecute.rmi=Yes
+jck.env.runtime.testExecute.rmiActivationSupport=Yes
+jck.env.runtime.testExecute.stdActivationPort=Yes
+jck.env.runtime.testExecute.supportIIOP=Yes
+jck.env.runtime.testExecute.verify=-Xfuture
+jck.env.runtime.url=Yes
+# jck.env.runtime.url.fileURL example: file\:///home/user/urlfile.txt
+jck.env.runtime.url.fileURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.ftpURL example: ftp\://user\:password@xxxx.xxxx.xxxx.com/xxx.txt
+jck.env.runtime.url.ftpURL=ftp\://jckftp\:CqwbpqMpe4Q68kDRXj4mqxM7W@jckservices.adoptium.net/filename.txt
+# jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
+jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=other
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+# jck.env.testPlatform.systemRoot example: C\:\\WINDOWS
+jck.env.testPlatform.systemRoot=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck8b/excludes/jck8b.jtx\n/jck/jck8b/excludes/jck8a.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords=\!interactive&\!jvmtilivephase&\!robot
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=\!interactive&\!jvmtilivephase&\!robot
+jck.keywords.needKeywords=Yes
+jck.knownFailuresList.customFiles=
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.needTests=No
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=10


### PR DESCRIPTION
Some openjdk vendor can only obtain the jck test suite of the jck8b version, so the aqavit test framework needs to support both jck8b and jck8c

Fixes: #3861

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>