### PR TITLE
Exclude TestFunctionDescriptor on all supported platforms

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -448,6 +448,8 @@ java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-op
 
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
 
+java/foreign/TestFunctionDescriptor.java https://github.com/eclipse-openj9/openj9/issues/15579 generic-all
+
 ############################################################################
 
 # com_sun_crypto

--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -497,7 +497,7 @@ java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
 
-java/foreign/TestFunctionDescriptor.java https://github.com/eclipse-openj9/openj9/issues/14487 macosx-all
+java/foreign/TestFunctionDescriptor.java https://github.com/eclipse-openj9/openj9/issues/15579 generic-all
 
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
 

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -565,6 +565,8 @@ java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/
 java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
 java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
 
+java/foreign/TestFunctionDescriptor.java https://github.com/eclipse-openj9/openj9/issues/15579 generic-all
+
 ############################################################################
 
 # com_sun_crypto

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -565,6 +565,8 @@ java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/
 java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
 java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
 
+java/foreign/TestFunctionDescriptor.java https://github.com/eclipse-openj9/openj9/issues/15579 generic-all
+
 ############################################################################
 
 # com_sun_crypto


### PR DESCRIPTION
The change is to exclude this FFI related test suite
to avoid unexpected failure due to incomplete code.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>