### PR TITLE
Excluded docker testcases on linux-aarch64 platform

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -134,6 +134,11 @@ compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh https://github.com/adopti
 compiler/floatingpoint/8165673/TestFloatJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 compiler/rtm/locking/TestRTMTotalCountIncrRate.java https://github.com/adoptium/aqa-tests/issues/3050 linux-all,windows-all
 compiler/intrinsics/mathexact/LongMulOverflowTest.java https://bugs.openjdk.org/browse/JDK-8196568 solaris-x64
+runtime/containers/docker/DockerBasicTest.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64
+runtime/containers/docker/TestCPUAwareness.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64
+runtime/containers/docker/TestCPUSets.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64
+runtime/containers/docker/TestMemoryAwareness.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64
+runtime/containers/docker/TestMisc.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64
 ############################################################################
 
 # jdk_awt


### PR DESCRIPTION
Excluded docker testcases on linux-aarch64: DockerBasicTest.java TestCPUAwareness.java TestCPUSets.java TestMemoryAwareness.java TestMisc.java

Fixes: #3629

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>