### PR TITLE
Exclude project loom related test failure

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -516,6 +516,7 @@ jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ParallelGC https://git
 jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ShenandoahGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ZGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java https://github.com/eclipse-openj9/openj9/issues/15624 generic-all
 jdk/incubator/concurrent/StructuredTaskScope/StructuredThreadDumpTest.java https://github.com/eclipse-openj9/openj9/issues/15278 generic-all
 jdk/internal/misc/VM/GetNanoTimeAdjustment.java https://github.com/eclipse-openj9/openj9/issues/7184 generic-all
 jdk/internal/misc/VM/RuntimeArguments.java https://github.com/eclipse-openj9/openj9/issues/7186 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -516,6 +516,7 @@ jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ParallelGC https://git
 jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ShenandoahGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryRetentionTests.java#with_ZGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java https://github.com/eclipse-openj9/openj9/issues/15624 generic-all
 jdk/incubator/concurrent/StructuredTaskScope/StructuredThreadDumpTest.java https://github.com/eclipse-openj9/openj9/issues/15278 generic-all
 jdk/internal/misc/VM/GetNanoTimeAdjustment.java https://github.com/eclipse-openj9/openj9/issues/7184 generic-all
 jdk/internal/misc/VM/RuntimeArguments.java https://github.com/eclipse-openj9/openj9/issues/7186 generic-all


### PR DESCRIPTION
Disable `jdk/incubator/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java`

Related OpenJ9 issues:
https://github.com/eclipse-openj9/openj9/issues/15624
https://github.com/eclipse-openj9/openj9/issues/15627
https://github.com/eclipse-openj9/openj9/issues/15629

Signed-off-by: Jason Feng <fengj@ca.ibm.com>