### PR TITLE
Disable TestMemoryAwareness.java

### DIFF
--- a/openjdk/excludes/vendors/alibaba/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/vendors/alibaba/ProblemList_openjdk8.txt
@@ -17,6 +17,7 @@
 ############################################################################
 
 # hotspot_jre
+runtime/containers/docker/TestMemoryAwareness.java https://github.com/adoptium/aqa-tests/issues/3763 generic-all
 ############################################################################
 
 # jdk_awt


### PR DESCRIPTION
Disable runtime/containers/docker/TestMemoryAwareness.java, which fail because of kernel does not support swap limit capabilities or the cgroup is not mounted

Fixes: #3890

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>