### PR TITLE
Disable TestMemoryAwareness.java for all vendors

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -112,7 +112,6 @@ gc/g1/TestHumongousShrinkHeap.java https://bugs.openjdk.java.net/browse/JDK-8041
 gc/whitebox/TestConcMarkCycleWB.java https://bugs.openjdk.java.net/browse/JDK-8067368 linux-arm
 runtime/StackGap/testme.sh https://bugs.openjdk.java.net/browse/JDK-8201536 linux-arm
 #https://github.com/adoptium/aqa-tests/issues/3250 linux-arm
-runtime/containers/docker/TestMemoryAwareness.java https://bugs.openjdk.java.net/browse/JDK-8229182 linux-arm,linux-ppc64le
 compiler/gcbarriers/PreserveFPRegistersTest.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/TestMemoryMXBeansAndPoolsPresence.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/g1/mixedgc/TestOldGenCollectionUsage.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
@@ -137,8 +136,8 @@ compiler/intrinsics/mathexact/LongMulOverflowTest.java https://bugs.openjdk.org/
 runtime/containers/docker/DockerBasicTest.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64,linux-arm
 runtime/containers/docker/TestCPUAwareness.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64,linux-arm
 runtime/containers/docker/TestCPUSets.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64,linux-arm
-runtime/containers/docker/TestMemoryAwareness.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64,linux-arm
 runtime/containers/docker/TestMisc.java https://github.com/adoptium/aqa-tests/issues/3629 linux-aarch64,linux-arm
+runtime/containers/docker/TestMemoryAwareness.java https://bugs.openjdk.java.net/browse/JDK-8229182,https://github.com/adoptium/aqa-tests/issues/3629,https://github.com/adoptium/aqa-tests/issues/3905 generic-all
 ############################################################################
 
 # jdk_awt
@@ -530,3 +529,4 @@ jdk/jfr/api/flightrecorder/TestGetEventTypes.java https://github.com/adoptium/aq
 jfr/api/consumer/TestRecordedFrame.java https://bugs.openjdk.org/browse/JDK-8247203 linux-aarch64,linux-ppc64le
 jdk/jfr/api/consumer/TestRecordedFrame.java https://bugs.openjdk.java.net/browse/JDK-8247203 linux-arm,linux-ppc64le
 jdk/jfr/event/compiler/TestCompilerInlining.java https://github.com/adoptium/aqa-tests/issues/3277 windows-all
+

--- a/openjdk/excludes/vendors/alibaba/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/vendors/alibaba/ProblemList_openjdk8.txt
@@ -17,7 +17,7 @@
 ############################################################################
 
 # hotspot_jre
-runtime/containers/docker/TestMemoryAwareness.java https://github.com/adoptium/aqa-tests/issues/3763 generic-all
+
 ############################################################################
 
 # jdk_awt


### PR DESCRIPTION
Disable runtime/containers/docker/TestMemoryAwareness.java for all vendors, because of the -vmoption:"-Xmx512M" cause this testcase run fail.

Fixes: #3905

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>