### PR TITLE
Skip dragonwell feature test target when the test jdk is dragonwell standard version

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1943,6 +1943,9 @@
 			$(Q)$(JTREG_JDK_TEST_DIR)/com/alibaba/wisp2$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<features>
+			<feature>Dragonwell_Standard:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>8</version>
 			<version>11</version>
@@ -1972,6 +1975,9 @@
 			$(Q)$(JTREG_JDK_TEST_DIR)/com/alibaba/wisp$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<features>
+			<feature>Dragonwell_Standard:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>8</version>
 			<version>11</version>
@@ -2003,6 +2009,9 @@
 			$(Q)$(JTREG_JDK_TEST_DIR)/com/alibaba/rcm$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<features>
+			<feature>Dragonwell_Standard:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>8</version>
 		</versions>
@@ -2031,6 +2040,9 @@
 			$(Q)$(JTREG_JDK_TEST_DIR)/com/alibaba/management$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<features>
+			<feature>Dragonwell_Standard:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>8</version>
 		</versions>
@@ -2060,6 +2072,9 @@
 			$(Q)$(JTREG_JDK_TEST_DIR)/multi-tenant$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<features>
+			<feature>Dragonwell_Standard:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>8</version>
 		</versions>
@@ -2088,6 +2103,9 @@
 			$(Q)$(JTREG_JDK_TEST_DIR)/elastic-heap$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<features>
+			<feature>Dragonwell_Standard:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>8</version>
 		</versions>
@@ -2116,6 +2134,9 @@
 			$(Q)$(JTREG_HOTSPOT_TEST_DIR)/elastic-heap$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<features>
+			<feature>Dragonwell_Standard:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>8</version>
 		</versions>
@@ -2144,6 +2165,9 @@
 			$(Q)$(JTREG_HOTSPOT_TEST_DIR)/jwarmup$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<features>
+			<feature>Dragonwell_Standard:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>8</version>
 		</versions>
@@ -2173,6 +2197,9 @@
 			$(Q)$(JTREG_HOTSPOT_TEST_DIR)/multi-tenant$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<features>
+			<feature>Dragonwell_Standard:nonapplicable</feature>
+		</features>
 		<versions>
 			<version>8</version>
 		</versions>


### PR DESCRIPTION
Skip dragonwell feature test target when the test jdk is dragonwell standard version. When the test jdk is dragonwell standard version, export TEST_FLAG=Dragonwell_Standard

Fixes: #3911

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>