### PR TITLE
Exclude openjdk MulticastSendReceiveTests in jdk_nio

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -165,8 +165,6 @@ java/net/Socket/asyncClose/AsyncClose.java	https://github.com/eclipse-openj9/ope
 java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issues/1105 linux-all,macosx-all
 java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
 java/net/ipv6tests/UdpTest.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all,macosx-all
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java    https://github.com/adoptium/infrastructure/issues/699    linux-s390x
-java/nio/channels/DatagramChannel/Promiscuous.java                  https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 sun/net/www/http/ChunkedOutputStream/checkError.java	https://github.com/adoptium/aqa-tests/issues/1506	windows-all,linux-all
 
 ############################################################################
@@ -194,8 +192,9 @@ java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/eclipse-openj9/
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
 java/nio/channels/AsynchronousSocketChannel/CompletionHandlerRelease.java https://github.com/eclipse-openj9/openj9/issues/12167 aix-all
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java https://bugs.openjdk.java.net/browse/JDK-8211851 aix-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.ibm.com/runtimes/backlog/issues/783	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699   linux-s390x
 java/nio/channels/DatagramChannel/SendToUnresolved.java	https://github.com/eclipse-openj9/openj9/issues/1130	generic-all
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.ibm.com/runtimes/backlog/issues/783	macosx-all
 java/nio/channels/Selector/KeySets.java	https://github.com/eclipse-openj9/openj9/issues/1130	generic-all
 java/nio/channels/Selector/RacyDeregister.java	https://bugs.openjdk.java.net/browse/JDK-8161083	aix-all
 java/nio/channels/ServerSocketChannel/AdaptServerSocket.java	https://github.com/adoptium/aqa-tests/issues/821	windows-all


### PR DESCRIPTION
- Exclude openjdk MulticastSendReceiveTests in jdk_nio
- Related Issue: backlog/783

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>