### PR TITLE
get.sh: use standard syntax for locating `javac`

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -603,10 +603,10 @@ testJavaVersion()
 		# Search javac as java may not be unique
 		if [[ "$CODE_COVERAGE" == "true" ]]; then
 			echo "${TEST_JDK_HOME}/build/bin/java does not exist! Searching under TEST_JDK_HOME: ${TEST_JDK_HOME}..."
-			javac_path=`find ${TEST_JDK_HOME} \( -path "*/images/jdk/bin/javac" -o -path "*/images/jdk/bin/javac.exe" \)`
+			javac_path=`find ${TEST_JDK_HOME} \( -name javac -o -name javac.exe \) | egrep '/images/jdk/bin/javac$|/images/jdk/bin/javac.exe$'`
 		else
 			echo "${TEST_JDK_HOME}/bin/java does not exist! Searching under TEST_JDK_HOME: ${TEST_JDK_HOME}..."
-			javac_path=`find ${TEST_JDK_HOME} \( -path "*/bin/javac" -o -path "*/bin/javac.exe" \)`
+			javac_path=`find ${TEST_JDK_HOME} \( -name javac -o -name javac.exe \) | egrep 'bin/javac$|bin/javac.exe$'`
 		fi
 		if [ "$javac_path" != "" ]; then
 			echo "javac_path: ${javac_path}"


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/2695

I think this should be equivalent to the old code and work properly on a `find` command that does not have the `-path` parameter so will be more portable.

Original failing job listed in the PR: See https://ci.adoptopenjdk.net/job/Grinder/5391
Re-run against this PR branch: See https://ci.adoptopenjdk.net/job/Grinder/5393

If reviews can verify that it looks like it's done the right thing in that job it would be appreciated :-)

Signed-off-by: Stewart X Addison <sxa@redhat.com>