### PR TITLE
Ignore exclude lists for jck_custom

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -19,7 +19,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(JCK_CUSTOM_TARGET); \
+		<command>$(JCK_CMD_TEMPLATE) tests=$(JCK_CUSTOM_TARGET) task=custom; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
This change makes sure that when jck_custom target is used, we'd ignore all exclude files except the default. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>