### PR TITLE
Make jck additional jtx general

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -27,10 +27,8 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -42,8 +40,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
+
 import java.io.FileNotFoundException;
 
 public class JavaTestRunner {
@@ -67,7 +64,7 @@ public class JavaTestRunner {
 	private static String initialJtxFullPath;
 	private static String jtxFullPath;
 	private static String kflFullPath;
-	private static String fipsJtxFullPath;
+	private static String testFlagJtxFullPath;
 	private static String krbConfFile;
 	private static String fileUrl;
 
@@ -282,18 +279,18 @@ public class JavaTestRunner {
 			kflFullPath = "";
 		}
 
-		if (task == null || !task.equals("custom")) {  
-			fipsJtxFullPath = "";
-			if (testFlag != null && testFlag.equals("FIPS")) {
-				// Look for a known failures list file specific to FIPS testing
-				fipsJtxFullPath = jckRoot + File.separator + "excludes" + File.separator + jckVersion + "-fips.jtx";
-				File fipsJtxFile = new File(fipsJtxFullPath);
+		if (task == null || !task.equals("custom")) {
+			testFlagJtxFullPath = "";
+			if (testFlag != null) {
+				// Look for a known failures list file specific to TEST_FLAG testing
+				testFlagJtxFullPath = jckRoot + File.separator + "excludes" + File.separator + jckVersion + "-" + testFlag.toLowerCase() + ".jtx";
+				File testFlagJtxFile = new File(testFlagJtxFullPath);
 				
-				if (fipsJtxFile.exists()) {
-					System.out.println("Using FIPS specific failures list file " + fipsJtxFullPath);
+				if (testFlagJtxFile.exists()) {
+					System.out.println("Using " + testFlag + " specific failures list file " + testFlagJtxFullPath);
 				} else {
-					System.out.println("Unable to find FIPS specific failures list file " + fipsJtxFullPath);
-					fipsJtxFullPath = "";
+					System.out.println("Unable to find " + testFlag + " specific failures list file " + testFlagJtxFullPath);
+					testFlagJtxFullPath = "";
 				}
 			}
 		}
@@ -418,7 +415,7 @@ public class JavaTestRunner {
 		// Only use default initial jtx exclude and disregard the rest of jck exclude lists 
 		// when running a test via jck_custom.
 		if (task == null || !task.equals("custom")) {  
-			fileContent += "set jck.excludeList.customFiles \"" + initialJtxFullPath + " " + jtxFullPath + " " + kflFullPath + " " + fipsJtxFullPath + "\";\n";
+			fileContent += "set jck.excludeList.customFiles \"" + initialJtxFullPath + " " + jtxFullPath + " " + kflFullPath + " " + testFlagJtxFullPath + "\";\n";
 		} else {
 			fileContent += "set jck.excludeList.customFiles \"" + initialJtxFullPath + " " + jtxFullPath + " " + kflFullPath + "\";\n";
 		}
@@ -982,7 +979,7 @@ public class JavaTestRunner {
 			
 			try {
 				jckRC = jck.exitValue();
-			} catch (java.lang.IllegalThreadStateException e) {
+			} catch (IllegalThreadStateException e) {
 				// If the 'jck' process "hangs" for some reasons, exitValue() will result in this exception.
 				// Attempt to forcibly terminate the process at that point.
 				jck.destroy();


### PR DESCRIPTION
Currently jck additional jtx only support FIPS. Make jck additional jtx general and make vairable fipsJtxFullPath to testFlagJtxFullPath for more general.

Fixes: #3931