### PR TITLE
Disable criu checkpoint ubi and ubuntu tests to separate from sanity.external

### DIFF
--- a/external/criu-portable-checkpoint/playlist.xml
+++ b/external/criu-portable-checkpoint/playlist.xml
@@ -19,6 +19,11 @@
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir criu-portable-checkpoint --platform "${PLATFORM}" --node_labels "${NODE_LABELS}" --docker_registry_url $(DOCKER_REGISTRY_URL)
 		</command>
+		<disables>
+			<disable>
+				<comment>runtimes_backlog_issues_879</comment>
+			</disable>
+		</disables>
 		<features>
 			<feature>CRIU:required</feature>
 		</features>

--- a/external/criu-ubi-portable-checkpoint/playlist.xml
+++ b/external/criu-ubi-portable-checkpoint/playlist.xml
@@ -19,6 +19,11 @@
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir criu-ubi-portable-checkpoint --platform "${PLATFORM}" --node_labels "${NODE_LABELS}" --docker_registry_url $(DOCKER_REGISTRY_URL)
 		</command>
+		<disables>
+			<disable>
+				<comment>runtimes_backlog_issues_879</comment>
+			</disable>
+		</disables>
 		<features>
 			<feature>CRIU:required</feature>
 		</features>


### PR DESCRIPTION
- Disable criu checkpoint ubi and ubuntu tests to run it separately from sanity.external
- Related Issue: runtimes_backlog_issues_879

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>