### PR TITLE
Git clone support ssh protocol

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -46,7 +46,7 @@ def setupEnv() {
 		TKG_BRANCH = tkg[1]
 		//For Zos, the right repo should be something like: git@github.ibm.com:runtimes/openj9-openjdk-jdk**-zos.git and for now there is only jdk11
 		env.JDK_REPO = params.JDK_REPO ? params.JDK_REPO : ""
-		if (env.SPEC.startsWith('zos')) {
+		if (env.SPEC.startsWith('zos') || env.USE_GIT_SSH == "true") {
 			ADOPTOPENJDK_REPO = ADOPTOPENJDK_REPO.replace("https://github.com/","git@github.com:")
 			OPENJ9_REPO = OPENJ9_REPO.replace("https://github.com/","git@github.com:")
 		}

--- a/buildenv/jenkins/getDependency
+++ b/buildenv/jenkins/getDependency
@@ -17,12 +17,18 @@ def testBuild() {
 	timeout(time: time_limit, unit: 'HOURS') {
 		try {
 			if( params.BUILD_TYPE == "systemtest" ){
+				AQA_SYSTEMTEST_REPO="https://github.com/adoptium/aqa-systemtest"
+				STF_REPO="https://github.com/adoptium/STF"
+				if( env.USE_GIT_SSH == "true" ){
+					AQA_SYSTEMTEST_REPO.replace("https://github.com/","git@github.com:")
+					STF_REPO.replace("https://github.com/","git@github.com:")
+				}
 				sh 'curl -OLJks "https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk"'
 				sh 'mkdir ${WORKSPACE}/j2sdk-image'
 				sh 'tar -xzf OpenJDK8U-jdk_x64_linux_hotspot*.gz -C ${WORKSPACE}/j2sdk-image --strip-components 1'
 				sh '${WORKSPACE}/j2sdk-image/jre/bin/java -version'
-				sh 'git clone https://github.com/adoptium/aqa-systemtest'
-				sh 'git clone https://github.com/adoptium/STF'
+				sh "git clone ${AQA_SYSTEMTEST_REPO}"
+				sh "git clone ${STF_REPO}"
 				sh 'ant -f ./aqa-systemtest/openjdk.build/build.xml -Djava.home=${WORKSPACE}/j2sdk-image/jre -Dprereqs_root=${WORKSPACE}/systemtest_prereqs configure'
 				sh 'ant -f ./aqa-systemtest/openjdk.test.mauve/build.xml -Djava.home=${WORKSPACE}/j2sdk-image/jre -Dprereqs_root=${WORKSPACE}/systemtest_prereqs configure'
 				archiveArtifacts '**/systemtest_prereqs/cvsclient/org-netbeans-lib-cvsclient.jar'

--- a/compile.sh
+++ b/compile.sh
@@ -17,6 +17,9 @@ if [ $USE_TESTENV_PROPERTIES == true ]; then
         testenv_file="./testenv/testenv_arm32.properties"
     fi
     while read line; do
+        if [[ "$USE_GIT_SSH" = "true" ]]; then
+            line=`echo $line | sed "s|https://github.com/|git@github.com:|"`
+        fi
         export $line
     done <$testenv_file
     if [ $JDK_IMPL == "openj9" ] || [ $JDK_IMPL == "ibm" ]; then

--- a/external/tomcat/test.sh
+++ b/external/tomcat/test.sh
@@ -16,7 +16,11 @@ source $(dirname "$0")/test_base_functions.sh
 #Set up Java to be used by the tomcat test
 echo_setup
 
-git clone -q -b 1.6.x --single-branch https://github.com/apache/apr.git $TEST_HOME/tmp/apr
+git_prefix="https://github.com/"
+if [[ "$USE_GIT_SSH" = "true" ]]; then
+    git_prefix="git@github.com:"
+fi
+git clone -q -b 1.6.x --single-branch ${git_prefix}apache/apr.git $TEST_HOME/tmp/apr
 cd $TEST_HOME/tmp/apr
 ./buildconf
 ./configure --prefix=$TEST_HOME/tmp/apr-build
@@ -24,7 +28,7 @@ make
 make install
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$TEST_HOME/tmp/apr-build/lib"
 
-git clone -q https://github.com/apache/tomcat-native.git $TEST_HOME/tmp/tomcat-native
+git clone -q ${git_prefix}apache/tomcat-native.git $TEST_HOME/tmp/tomcat-native
 cd $TEST_HOME/tmp/tomcat-native/native
 sh buildconf --with-apr=$TEST_HOME/tmp/apr
 ./configure --with-apr=$TEST_HOME/tmp/apr --with-java-home=$JAVA_HOME --with-ssl=yes --prefix=$TEST_HOME/tmp/tomcat-native-build

--- a/get.sh
+++ b/get.sh
@@ -428,6 +428,9 @@ getTestKitGen()
 	cd $TESTDIR
 	if [ "$TKG_REPO" = "" ]; then
 		TKG_REPO="https://github.com/adoptium/TKG.git"
+		if [ "$USE_GIT_SSH" = "true" ]; then
+			TKG_REPO="git@github.com:adoptium/TKG.git"
+		fi
 	fi
 
 	executeCmdWithRetry "TKG" "git clone -q $TKG_REPO"
@@ -497,6 +500,10 @@ getFunctionalTestMaterial()
 	if [ "$OPENJ9_BRANCH" != "" ]
 	then
 		OPENJ9_BRANCH="-b $OPENJ9_BRANCH"
+	fi
+	if [ "$USE_GIT_SSH" = "true" ]
+	then
+		OPENJ9_REPO=`echo $OPENJ9_REPO | sed "s|https://github.com/|git@github.com:|"`
 	fi
 
 	executeCmdWithRetry "openj9" "git clone --depth 1 --reference-if-able ${HOME}/openjdk_cache $OPENJ9_BRANCH $OPENJ9_REPO"

--- a/perf/bumbleBench/build.xml
+++ b/perf/bumbleBench/build.xml
@@ -22,9 +22,16 @@
 	<property environment="env" />
 	<property name="DEST" value="${BUILD_ROOT}/perf/bumbleBench" />
 	<property name="SRC" location="." />
+	<property environment="SystemVariable" />
+	<property name="isSSH" value="${SystemVariable.USE_GIT_SSH}" />
 	
 	<condition property="isZOS" value="true">
 		<equals arg1="${os.name}" arg2="z/OS"/>
+	</condition>
+
+	<var name="git_command" value="clone --depth 1 -b master ${git-prefix}://github.com/adoptium/bumblebench.git"/>
+	<condition property="git_command" value="clone --depth 1 -b master git@github.com:adoptium/bumblebench.git">
+		<equals arg1="${isSSH}" arg2="true"/>
 	</condition>
 		
 	<condition property="git-prefix" value="git" else="https">
@@ -37,7 +44,6 @@
 
 	<target name="getBumbleBench" depends="init" description="Clone the distribution">
 		<echo message="Cloning BumbleBench"/>
-		<var name="git_command" value="clone --depth 1 -b master ${git-prefix}://github.com/adoptium/bumblebench.git"/>
 		<echo message="git ${git_command}" />
 		<exec executable="git" failonerror="false" dir=".">
 			<arg line="${git_command}" />


### PR DESCRIPTION
The network connection between CHINA and github server is unstable. Git clone intermittently fail for "Encountered end of file" by HTTPS protocol. Git clone by SSH protocol is more stable than HTTPS protocol. This patch support SSH git clone, when the environment variable USE_GIT_SSH set to "true"

Fixes: #3779