### PR TITLE
Disable external aot test

### DIFF
--- a/external/aot/playlist.xml
+++ b/external/aot/playlist.xml
@@ -19,6 +19,12 @@
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir aot --platform "${PLATFORM}" --node_labels "${NODE_LABELS}"
 		</command>
+		<disables>
+			<disable>
+				<comment>Disable until next release https://github.com/eclipse-openj9/openj9/pull/15812#issuecomment-1235566485</comment>
+				<platform>aarch64_linux</platform>
+			</disable>
+		</disables>
 		<features>
 			<feature>AOT:applicable</feature>
 		</features>


### PR DESCRIPTION
- external aot test is failing on aarch due to SCC
- re-enable it when docker image updated for next release
- Related Issue: https://github.com/eclipse-openj9/openj9/pull/15812#issuecomment-1235566485 https://github.com/eclipse-openj9/openj9/issues/15801

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>