### PR TITLE
Start x11 only once

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -631,21 +631,21 @@ def runTest( ) {
 		}
 
 		RUNTEST_CMD = "${TARGET} ${CUSTOM_OPTION}"
-		for (int i = 1; i <= ITERATIONS; i++) {
-			echo "ITERATION: ${i}/${ITERATIONS}"
+		if (env.BUILD_LIST.contains('jck') || env.BUILD_LIST.contains('openjdk') || env.BUILD_LIST.contains('functional')) {
 			if (env.SPEC.startsWith('aix')) {
-				sh "nohup /usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX -secIP 000 :0 &"
+				sh "/usr/bin/X11/X -force -vfb -x abx -x dbe -x GLX -secIP 000 :0 &"
 				env.DISPLAY = "unix:0"
 				echo "env.DISPLAY is ${env.DISPLAY}"
-				makeTest("${RUNTEST_CMD}")
-			}
-			else if (env.SPEC.startsWith('sunos')) {
-				sh "nohup /usr/X11/bin/Xvfb :2 -screen 0 1024x768x24 &"
+				
+			} else if (env.SPEC.startsWith('sunos')) {
+				sh "/usr/X11/bin/Xvfb :2 -screen 0 1024x768x24 &"
 				env.DISPLAY = ":2"
 				echo "env.DISPLAY is ${env.DISPLAY}"
-				makeTest("${RUNTEST_CMD}")
 			}
-			else if (env.SPEC.contains('linux') && !(LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure')) {
+		}
+		for (int i = 1; i <= ITERATIONS; i++) {
+			echo "ITERATION: ${i}/${ITERATIONS}"
+			if (env.SPEC.contains('linux') && !(LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure')) {
 				// Add an additional 10 second timeout due to issue: https://github.com/adoptium/temurin-build/issues/2368#issuecomment-756683888
 				wrap([$class: 'Xvfb', autoDisplayName: true, timeout:10]) {
 					def DISPLAY = sh (
@@ -656,8 +656,7 @@ def runTest( ) {
 					echo "env.DISPLAY is ${env.DISPLAY}"
 					makeTest("${RUNTEST_CMD}")
 				}
-			}
-			else {
+			} else {
 				makeTest("${RUNTEST_CMD}")
 			}
 		}


### PR DESCRIPTION
- move x11 cmd outside of iterations
- remove nohup in x11 cmd
- only start x11 for BUILD_LIST=openjdk, jck and/or functional

Related: https://github.com/eclipse-openj9/openj9/issues/14943

Signed-off-by: lanxia <lan_xia@ca.ibm.com>