### PR TITLE
If no custom JTX file is supplied, ensure it's not null

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -283,13 +283,14 @@ public class JavaTestRunner {
 			jtxDevFullPath = "";
 		}
 		
-		if (customJtx != null && !customJtx.equals("")) {
+		if (customJtx == null) {
+			customJtx = "";
+		} else {
 			File customJtxFile = new File(customJtx);
 			if (customJtxFile.exists()) {
 				System.out.println("Using additional custom excludes list file " + customJtx);
 			} else {
 				System.out.println("Unable to find additional custom excludes list file " + customJtx);
-				customJtx = "";
 			}
 		}
 


### PR DESCRIPTION
This PR fixes an issue introduced by https://github.com/adoptium/aqa-tests/pull/3942 : If no custom JTX file is supplied, we need to ensure it's not null. Otherwise grinder jobs with tck targets will fail with a null value in generated command jtb. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>