### PR TITLE
Enable JDK 18/19/20 sun/security/krb5/auto/BasicProc.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -375,8 +375,6 @@ sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://gith
 
 # jdk_security4
 
-sun/security/krb5/auto/BasicProc.java https://github.com/eclipse-openj9/openj9/issues/14803 generic-all
-
 ########################################################################################################################################################
 
 # jdk_sound

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -439,8 +439,6 @@ sun/security/util/math/TestIntegerModuloP.java	https://github.com/eclipse-openj9
 
 # jdk_security4
 
-sun/security/krb5/auto/BasicProc.java https://github.com/eclipse-openj9/openj9/issues/14803 generic-all
-
 ########################################################################################################################################################
 
 # jdk_sound

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -444,7 +444,6 @@ sun/security/util/math/TestIntegerModuloP.java	https://github.com/eclipse-openj9
 
 # jdk_security4
 
-sun/security/krb5/auto/BasicProc.java https://github.com/eclipse-openj9/openj9/issues/14803 generic-all
 sun/security/krb5/ccache/Refresh.java https://github.com/eclipse-openj9/openj9/issues/15267 generic-all
 
 ########################################################################################################################################################


### PR DESCRIPTION
Enable JDK 18/19/20 `sun/security/krb5/auto/BasicProc.java`

related to https://github.com/eclipse-openj9/openj9/issues/14803

Signed-off-by: Jason Feng <fengj@ca.ibm.com>