### PR TITLE
Enable OpenJDK vector tests for all 128 bits species

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1976,6 +1976,34 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>jdk_vector_byte128_j9</testCaseName>
+		<variations>
+			<variation>-Xjit:{*Byte128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(CUSTOM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(TIMEOUT_HANDLER) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	$(Q)$(JTREG_JDK_TEST_DIR)$(D)jdk/incubator/vector/Byte128VectorTests.java$(Q); \
+	echo "grep #VECTOR API $(REPORTDIR)/work/jdk/incubator/vector/Byte128VectorTests.jtr"; \
+	grep  "#VECTOR API" $(REPORTDIR)/work/jdk/incubator/vector/Byte128VectorTests.jtr; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>19+</version>
+		</versions>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_vector_byte64_j9</testCaseName>
 		<variations>
 			<variation>-Xjit:{*Byte64VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1864,6 +1864,34 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>jdk_vector_float128_j9</testCaseName>
+		<variations>
+			<variation>-Xjit:{*Float128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(CUSTOM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(TIMEOUT_HANDLER) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	$(Q)$(JTREG_JDK_TEST_DIR)$(D)jdk/incubator/vector/Float128VectorTests.java$(Q); \
+	echo "grep #VECTOR API $(REPORTDIR)/work/jdk/incubator/vector/Float128VectorTests.jtr"; \
+	grep  "#VECTOR API" $(REPORTDIR)/work/jdk/incubator/vector/Float128VectorTests.jtr; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>19+</version>
+		</versions>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_vector_double128_j9</testCaseName>
 		<variations>
 			<variation>-Xjit:{*Double128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1864,9 +1864,9 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>jdk_vector_float128_j9</testCaseName>
+		<testCaseName>jdk_vector_double128_j9</testCaseName>
 		<variations>
-			<variation>-Xjit:{*Float128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
+			<variation>-Xjit:{*Double128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(CUSTOM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
@@ -1874,9 +1874,9 @@
 	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
 	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
 	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
-	$(Q)$(JTREG_JDK_TEST_DIR)$(D)jdk/incubator/vector/Float128VectorTests.java$(Q); \
-	echo "grep #VECTOR API $(REPORTDIR)/work/jdk/incubator/vector/Float128VectorTests.jtr"; \
-	grep  "#VECTOR API" $(REPORTDIR)/work/jdk/incubator/vector/Float128VectorTests.jtr; \
+	$(Q)$(JTREG_JDK_TEST_DIR)$(D)jdk/incubator/vector/Double128VectorTests.java$(Q); \
+	echo "grep #VECTOR API $(REPORTDIR)/work/jdk/incubator/vector/Double128VectorTests.jtr"; \
+	grep  "#VECTOR API" $(REPORTDIR)/work/jdk/incubator/vector/Double128VectorTests.jtr; \
 	$(TEST_STATUS)</command>
 		<versions>
 			<version>19+</version>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2004,6 +2004,34 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>jdk_vector_long128_j9</testCaseName>
+		<variations>
+			<variation>-Xjit:{*Long128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(CUSTOM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(TIMEOUT_HANDLER) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	$(Q)$(JTREG_JDK_TEST_DIR)$(D)jdk/incubator/vector/Long128VectorTests.java$(Q); \
+	echo "grep #VECTOR API $(REPORTDIR)/work/jdk/incubator/vector/Long128VectorTests.jtr"; \
+	grep  "#VECTOR API" $(REPORTDIR)/work/jdk/incubator/vector/Long128VectorTests.jtr; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>19+</version>
+		</versions>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_vector_byte64_j9</testCaseName>
 		<variations>
 			<variation>-Xjit:{*Byte64VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1947,6 +1947,35 @@
 			<impl>openj9</impl>
 		</impls>
 	</test>
+	</test>
+		<test>
+		<testCaseName>jdk_vector_short128_j9</testCaseName>
+		<variations>
+			<variation>-Xjit:{*Short128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(CUSTOM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(TIMEOUT_HANDLER) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	$(Q)$(JTREG_JDK_TEST_DIR)$(D)jdk/incubator/vector/Short128VectorTests.java$(Q); \
+	echo "grep #VECTOR API $(REPORTDIR)/work/jdk/incubator/vector/Short128VectorTests.jtr"; \
+	grep  "#VECTOR API" $(REPORTDIR)/work/jdk/incubator/vector/Short128VectorTests.jtr; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>19+</version>
+		</versions>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
 	<test>
 		<testCaseName>jdk_vector_byte64_j9</testCaseName>
 		<variations>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1919,7 +1919,7 @@
 			<impl>openj9</impl>
 		</impls>
 	</test>
-		<test>
+	<test>
 		<testCaseName>jdk_vector_int128_j9</testCaseName>
 		<variations>
 			<variation>-Xjit:{*Int128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
@@ -1947,8 +1947,7 @@
 			<impl>openj9</impl>
 		</impls>
 	</test>
-	</test>
-		<test>
+	<test>
 		<testCaseName>jdk_vector_short128_j9</testCaseName>
 		<variations>
 			<variation>-Xjit:{*Short128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1919,6 +1919,34 @@
 			<impl>openj9</impl>
 		</impls>
 	</test>
+		<test>
+		<testCaseName>jdk_vector_int128_j9</testCaseName>
+		<variations>
+			<variation>-Xjit:{*Int128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(CUSTOM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(TIMEOUT_HANDLER) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	$(Q)$(JTREG_JDK_TEST_DIR)$(D)jdk/incubator/vector/Int128VectorTests.java$(Q); \
+	echo "grep #VECTOR API $(REPORTDIR)/work/jdk/incubator/vector/Int128VectorTests.jtr"; \
+	grep  "#VECTOR API" $(REPORTDIR)/work/jdk/incubator/vector/Int128VectorTests.jtr; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>19+</version>
+		</versions>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
 	<test>
 		<testCaseName>jdk_vector_byte64_j9</testCaseName>
 		<variations>


### PR DESCRIPTION
resolves: #3954 
signed-off-by: Moman Malik <momanmalik@ibm.com>