### PR TITLE
Define -jvmArgs in systemtest.mk for JCStress

### DIFF
--- a/system/jcstress/playlist.xml
+++ b/system/jcstress/playlist.xml
@@ -13,9 +13,10 @@
 # limitations under the License.
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
+	<include>../systemtest.mk</include>
 	<test>
 		<testCaseName>jcstress_SampleTestBench</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-latest.jar$(Q) -jvmArgs $(Q)$(JVM_OPTIONS) -t SampleTestBench$(Q); \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-latest.jar$(Q) $(APPLICATION_OPTIONS) -t SampleTestBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/system/systemtest.mk
+++ b/system/systemtest.mk
@@ -64,6 +64,11 @@ ifeq (,$(findstring $(JDK_IMPL),hotspot))
   JAVA_ARGS += -Xdump:system:events=user
 endif
 
+APPLICATION_OPTIONS :=
+ifdef JVM_OPTIONS
+  APPLICATION_OPTIONS := -jvmArgs $(Q)$(JVM_OPTIONS)$(Q)
+endif
+
 define SYSTEMTEST_CMD_TEMPLATE
 perl $(SYSTEMTEST_RESROOT)$(D)STF$(D)stf.core$(D)scripts$(D)stf.pl \
   -test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)STF;$(SYSTEMTEST_RESROOT)$(D)aqa-systemtest$(OPENJ9_PRAM)$(Q) \


### PR DESCRIPTION
Define `APPLICATION_OPTIONS` in systemtest.mk and compose the JCStress option `-jvmArgs` therein. 

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>