### PR TITLE
AArch64 macOS: Enable excluded tests

### DIFF
--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -110,10 +110,6 @@
 	$(TEST_STATUS)</command>
 		<disables>
 			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14635</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
 				<impl>openj9</impl>
 				<version>19+</version>
@@ -294,10 +290,6 @@
 	$(TEST_STATUS)</command>
 		<disables>
 			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14621</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
-			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
 				<impl>openj9</impl>
 				<version>19+</version>
@@ -323,10 +315,6 @@
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM23,sharedClassTest=MultiThreadMultiCL$(Q); \
 	$(TEST_STATUS)</command>
 		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14621</comment>
-				<platform>aarch64_mac.*</platform>
-			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
 				<impl>openj9</impl>


### PR DESCRIPTION
This commit enables the following tests on OpenJ9 AArch64 macOS:

- SharedClasses.SCM23.MultiThread
- SharedClasses.SCM23.MultiThreadMultiCL
- SC_Softmx_JitAot

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>