### PR TITLE
Add serviceability for JDK19+ openj9

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -218,6 +218,37 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>serviceability_jvmti_j9</testCaseName>
+		<variations>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) -nativepath:"$(TESTIMAGE_PATH)/hotspot/jtreg/native" -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(JTREG_HOTSPOT_TEST_DIR)/serviceability/jvmti$(Q); \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>19+</version>
+		</versions>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>ASGCTBaseTest</testCaseName>
 		<variations>
 			<variation>Mode150</variation>


### PR DESCRIPTION
Enable hotspot serviceability jvmti test to run with openj9.
Set `-nativepath:"$(TESTIMAGE_PATH)/hotspot/jtreg/native"`
Since this is a hotspot test, some subtests may require minor tweaks.

related: https://github.com/eclipse-openj9/openj9/issues/15748
Signed-off-by: lanxia <lan_xia@ca.ibm.com>