### PR TITLE
Refactor systemtest.mk

### DIFF
--- a/doc/userGuide.md
+++ b/doc/userGuide.md
@@ -90,7 +90,7 @@ git push origin env_var
 
 #### Method 2: Put it in the .mk file of the test that you want to run 
 
-This method is to be used when the objective is to set that environment variable for all test targets in the group being run. For this example, we will be looking at the systemtest.mk file. 
+This method is to be used when the objective is to set that environment variable for all test targets in the group being run. For this example, we will be looking at the system.mk file. 
 
 1.	Open the aqa-tests/system folder
 

--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<!-- 
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->

--- a/system/jcstress/playlist.xml
+++ b/system/jcstress/playlist.xml
@@ -13,7 +13,7 @@
 # limitations under the License.
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<test>
 		<testCaseName>jcstress_SampleTestBench</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-latest.jar$(Q) $(APPLICATION_OPTIONS) -t SampleTestBench; \

--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<!--
 	We currently only run special.system in parallel mode and some subfolders do not have any system test in special level
 	In order to save machine resources, exclude jlm subfolder in parallel mode

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<!--
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<!-- 
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<!-- 
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<!--
 	We currently only run special.system in parallel mode and some subfolders do not have any system test in special level
 	In order to save machine resources, exclude modularity subfolder in parallel mode

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<!-- 
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->

--- a/system/security/playlist.xml
+++ b/system/security/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<!-- 
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->

--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
-	<include>../systemtest.mk</include>
+	<include>../system.mk</include>
 	<!--
 	We currently only run special.system in parallel mode and some subfolders do not have any system test in special level
 	In order to save machine resources, exclude sharedClasses subfolder in parallel mode

--- a/system/system.mk
+++ b/system/system.mk
@@ -59,9 +59,8 @@ ifeq ($(filter 8 9 10 11 12 13 14 15 16 17, $(JDK_VERSION)),)
   $(warning Environment variable JAVA_TOOL_OPTIONS is set to '$(JAVA_TOOL_OPTIONS)')
 endif
 
-JAVA_ARGS = $(JVM_OPTIONS)
 ifeq (,$(findstring $(JDK_IMPL),hotspot))
-  JAVA_ARGS += -Xdump:system:events=user
+  JVM_OPTIONS += -Xdump:system:events=user
 endif
 
 APPLICATION_OPTIONS :=
@@ -73,7 +72,7 @@ define SYSTEMTEST_CMD_TEMPLATE
 perl $(SYSTEMTEST_RESROOT)$(D)STF$(D)stf.core$(D)scripts$(D)stf.pl \
   -test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)STF;$(SYSTEMTEST_RESROOT)$(D)aqa-systemtest$(OPENJ9_PRAM)$(Q) \
   -systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q) \
-  -java-args=$(SQ)$(JAVA_ARGS)$(SQ) \
+  -java-args=$(SQ)$(JVM_OPTIONS)$(SQ) \
   -results-root=$(REPORTDIR)
 endef
 


### PR DESCRIPTION
- Renamed systemtest.mk -> system.mk to be consistent with the rest of the test types. 
- Removed unnecessary variable `JAVA_ARGS` from system.mk 
 
Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>