### PR TITLE
add windows aarch64 support to aqa-tests

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -13,6 +13,10 @@ def PLATFORM_MAP = [
         'SPEC' : 'linux_aarch64',
         'LABEL' : 'ci.role.test&&sw.os.linux&&hw.arch.aarch64',
     ],
+    'aarch64_windows' : [
+        'SPEC' : 'windows_aarch64',
+        'LABEL' : 'ci.role.test&&sw.os.windows&&hw.arch.aarch64',
+    ],
     'aarch64_alpine-linux' : [
         'SPEC' : 'alpine-linux_aarch64',
         'LABEL' : 'ci.role.test&&hw.arch.aarch64&&sw.os.alpine-linux',


### PR DESCRIPTION
This will fix the failing windows aarch64 smoke tests