### PR TITLE
Do a hard reset if tck update fails and try git pull again

### DIFF
--- a/jck/build.xml
+++ b/jck/build.xml
@@ -161,11 +161,34 @@
 									</then>
 								</if>
 								<echo message="Updating ${JCK_ROOT_USED} with latest..." />
-								<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true">
+								<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false" resultproperty="return.code">
 									<arg value="pull" />
 									<arg value="${JCK_GIT_REPO_USED}" />
 									<arg value="${jck_branch}" />
 								</exec>
+								<if>
+									<not>
+										<equals arg1="${return.code}" arg2="0"/>
+									</not> 
+									<then>
+										<echo message="Performing hard reset..." />
+										<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true">
+											<arg value="reset" />
+											<arg value="--hard" />
+											<arg value="origin/master" />
+										</exec>
+										<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true">
+											<arg value="clean" />
+											<arg value="-f" />
+											<arg value="-d" />
+										</exec>
+										<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true">
+											<arg value="pull" />
+											<arg value="${JCK_GIT_REPO_USED}" />
+											<arg value="${jck_branch}" />
+										</exec>
+									</then>
+								</if>
 							</else>
 						</if>
 					</else>


### PR DESCRIPTION
If there are changes in local tck repo on disc in a Jenkins machine, the [default git pull](https://github.com/adoptium/aqa-tests/blob/master/jck/build.xml#L165) results in a merge conflict and the build fails. 

If this merge conflict occurs, this PR will catch it and clean up any local changes by performing a `git --reset hard` and a `git clean`, and `git pull` again.  

Related backlog issue: backlog/issues/705

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>