### PR TITLE
Update jcstress jar file name in jcstress_SampleTestBench

### DIFF
--- a/system/jcstress/playlist.xml
+++ b/system/jcstress/playlist.xml
@@ -16,7 +16,7 @@
 	<include>../system.mk</include>
 	<test>
 		<testCaseName>jcstress_SampleTestBench</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-latest.jar$(Q) $(APPLICATION_OPTIONS) -t SampleTestBench; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-tests-all-20220908.jar$(Q) $(APPLICATION_OPTIONS) -t SampleTestBench; \
 		$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
Background: openj9-openjdk-jdk11-zos/issues/1623#issuecomment-48626861. 
Related pr : https://github.com/adoptium/TKG/pull/359.

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>