### PR TITLE
Delete jdk11_tier1_cipher for duplicate testcases

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1755,34 +1755,6 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>jdk11_tier1_cipher</testCaseName>
-		<variations>
-			<variation>Mode150</variation>
-			<variation>Mode650</variation>
-			<variation>Mode1000</variation>
-		</variations>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
-	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
-	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
-	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
-	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
-	-exclude:$(Q)$(JTREG_JDK_TEST_DIR)$(D)ProblemList.txt$(Q) \
-	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
-	${FEATURE_PROBLEM_LIST_FILE} \
-	${VENDOR_PROBLEM_LIST_FILE} \
-	$(Q)$(JTREG_JDK_TEST_DIR)/com/sun/crypto/provider/Cipher$(Q); \
-	$(TEST_STATUS)</command>
-		<versions>
-			<version>11+</version>
-		</versions>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<groups>
-			<group>openjdk</group>
-		</groups>
-	</test>
-	<test>
 		<testCaseName>jdk11_tier1_buffer</testCaseName>
 		<variations>
 			<variation>Mode150</variation>


### PR DESCRIPTION
jdk11_tier1_cipher(sanity.openjdk) is subset of jdk_security2(extened.openjdk), which cause there are 91 duplicate testcases in sanity.openjdk and extended.openjdk. Delete jdk11_tier1_cipher in openjdk/playlist.xml to avoid duplicate testcases

Fixes: #3992

Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>