### PR TITLE
Exclude ubuntu22 machine for external tests temporarily

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -180,6 +180,11 @@ timestamps{
                 LABEL = LABEL.minus("ci.role.test&&").concat("&&ci.role.test.fips")
             }
 
+            // Temporarily exclude ubuntu 22 machines for criu sanity.external pipeline
+            if (JOB_NAME.contains ("sanity.external") && JOB_NAME.contains("_criu")) {
+                LABEL += "&&!sw.os.ubuntu.22"
+            }
+
             if (params.DOCKER_REQUIRED) {
                 LABEL += "&&sw.tool.docker"
             }


### PR DESCRIPTION
- Since external criu tests don't work with ubuntu22 now, exclude the machine label temporarily.
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/15957 https://github.com/eclipse-openj9/openj9/issues/15958

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>