### PR TITLE
Exclude api-java_net from aix, mac and win

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -512,6 +512,11 @@
 				<comment>Disabled on all platforms due to backlog/issues/462. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>.*zos.*</platform>
 			</disable>
+			<disable>
+				<comment>Disabled due to backlog/issues/921,923,750. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
+				<platform>ppc64_aix|x86-64_mac|x86-64_window|x86-32_windows</platform>
+				<impl>openj9</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>


### PR DESCRIPTION
- This PR excludes `api-java_net` target from aix, mac and win - as it fails due to various sub-test errors on these platforms. This target will be run manually until we fix the issues that cause it to fail in automation on these platforms. 
- Related issues : backlog/issues 921, 923, 750.

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>