### PR TITLE
excluded testcases for vthread on aix java 19

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19.txt
+++ b/openjdk/excludes/ProblemList_openjdk19.txt
@@ -235,7 +235,7 @@ java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issue
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
 java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x
- 
+java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/adoptium/aqa-tests/issues/4024 aix-all
 
 ############################################################################ 
 


### PR DESCRIPTION
excluded testcases for vthread on aix java 19

fixes #3983 
signed off; lumuchris 