### PR TITLE
Allow any project to copyArtifact from test jobs

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -195,6 +195,9 @@ ARCH_OS_LIST.each { ARCH_OS ->
 								}
 							}
 						}
+						copyArtifactPermission {
+							projectNames('*')
+						}
 					}
 
 					definition {


### PR DESCRIPTION
When a Jenkins instance doesn't allow anonymous read by default, the copyArtifact plugin step will fail unless the job with the artifacts has copyArtifactPermission enabled with a set of projects listed or a wildcard to allow any job.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>