### PR TITLE
Revert to JAVA_ARGS

### DIFF
--- a/system/system.mk
+++ b/system/system.mk
@@ -59,8 +59,9 @@ ifeq ($(filter 8 9 10 11 12 13 14 15 16 17, $(JDK_VERSION)),)
   $(warning Environment variable JAVA_TOOL_OPTIONS is set to '$(JAVA_TOOL_OPTIONS)')
 endif
 
+JAVA_ARGS = $(JVM_OPTIONS)
 ifeq (,$(findstring $(JDK_IMPL),hotspot))
-  JVM_OPTIONS += -Xdump:system:events=user
+  JAVA_ARGS += -Xdump:system:events=user
 endif
 
 APPLICATION_OPTIONS :=
@@ -72,7 +73,7 @@ define SYSTEMTEST_CMD_TEMPLATE
 perl $(SYSTEMTEST_RESROOT)$(D)STF$(D)stf.core$(D)scripts$(D)stf.pl \
   -test-root=$(Q)$(SYSTEMTEST_RESROOT)$(D)STF;$(SYSTEMTEST_RESROOT)$(D)aqa-systemtest$(OPENJ9_PRAM)$(Q) \
   -systemtest-prereqs=$(Q)$(SYSTEMTEST_RESROOT)$(D)systemtest_prereqs$(Q) \
-  -java-args=$(SQ)$(JVM_OPTIONS)$(SQ) \
+  -java-args=$(SQ)$(JAVA_ARGS)$(SQ) \
   -results-root=$(REPORTDIR)
 endef
 


### PR DESCRIPTION
JVM_OPTIONS got set before the mode was set. This issue affects all system tests with Mode. No Modes were passed in the system tests for the past month. For details, please see https://github.com/eclipse-openj9/openj9/issues/15250#issuecomment-1283122755

Revert back to set JVM_OPTIONS in JAVA_ARGS (see the original PR https://github.com/adoptium/aqa-tests/pull/3972)

Related: https://github.com/eclipse-openj9/openj9/issues/15250

Signed-off-by: Lan Xia <Lan_Xia@ca.ibm.com>