### PR TITLE
exclude tests with Unrecognized VM option on win32

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -269,6 +269,8 @@ compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java https://git
 compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestConservativeAntiDep.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/intrinsics/unsafe/HeapByteBufferTest.java#id1 https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopopts/superword/TestPeeledReductionNode.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tests/issues/2671 windows-x86
 compiler/vectorization/TestVectorsNotSavedAtSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -475,6 +475,11 @@ compiler/c2/TestShiftRightAndAccumulate.java https://github.com/adoptium/aqa-tes
 compiler/codegen/TestCharVect2.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/superword/Vec_MulAddS2I.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/intrinsics/unsafe/HeapByteBufferTest.java#id1 https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopopts/superword/TestPeeledReductionNode.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/ClearArray.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/rangechecks/TestRangeCheckCmpUUnderflow.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopopts/TestOverUnrolling2.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestConservativeAntiDep.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86


### PR DESCRIPTION
https://github.com/adoptium/aqa-tests/issues/2382 windows-x86

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>