### PR TITLE
Fix typo in platform name for x86-64_windows

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -514,7 +514,7 @@
 			</disable>
 			<disable>
 				<comment>Disabled due to backlog/issues/921,923,750. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>ppc64_aix|x86-64_mac|x86-64_window|x86-32_windows</platform>
+				<platform>ppc64_aix|x86-64_mac|x86-64_windows|x86-32_windows</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>


### PR DESCRIPTION
Fix typo in platform name for x86-64_windows

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>