### PR TITLE
Enable AttachTest in JDK19+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -178,8 +178,6 @@ jdk/modules/etc/DefaultModules.java https://github.com/eclipse-openj9/openj9/iss
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1  https://github.com/eclipse-openj9/openj9/issues/15466  generic-all
-
 ############################################################################
 
 # jdk_internal

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -180,8 +180,6 @@ jdk/modules/etc/DefaultModules.java https://github.com/eclipse-openj9/openj9/iss
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1  https://github.com/eclipse-openj9/openj9/issues/15466  generic-all
-
 ############################################################################
 
 # jdk_internal


### PR DESCRIPTION
The change is to enable AttachTest given
the upcall thunk was implemented on all
supported platforms.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>