### PR TITLE
(v0.9.5-release) Add external aot-test impl openj9 (#4070)

### DIFF
--- a/external/aot/playlist.xml
+++ b/external/aot/playlist.xml
@@ -34,5 +34,8 @@
 		<groups>
 			<group>external</group>
 		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
 	</test>
 </playlist>


### PR DESCRIPTION
- This is a ported change from master branch
- Add external aot-test impl openj9
- Related Issue: https://github.com/adoptium/aqa-tests/issues/4062

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>