### PR TITLE
Catch TKG exit code in JenkinsfileBase

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -15,6 +15,8 @@ def makeTest(testParam) {
 		} else {
 			sh "$makeTestCmd"
 		}
+	} catch (err) {
+		currentBuild.result = 'UNSTABLE'
 	} finally {
 		sh "$tearDownCmd"
 	}


### PR DESCRIPTION
- initially set build status to UNSTABLE if exit code is not zero
- build status will be updated by checkTestResults() later

Signed-off-by: renfeiw <renfeiw@ca.ibm.com>