### PR TITLE
Exclude external quarkus_test for openj9 11+

### DIFF
--- a/external/quarkus/playlist.xml
+++ b/external/quarkus/playlist.xml
@@ -23,7 +23,7 @@
 			</disable>
 			<disable>
 				<comment>runtimes_backlog/issues/831</comment>
-				<version>11</version>
+				<version>11+</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>


### PR DESCRIPTION
- Exclude external quarkus_test for openj9 11+

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>