### PR TITLE
(v0.9.5-release) Exclude openliberty_microprofile_tck_jdk8_j9 test (#4084)

### DIFF
--- a/external/openliberty-mp-tck/playlist.xml
+++ b/external/openliberty-mp-tck/playlist.xml
@@ -22,6 +22,11 @@
 		<versions>
 			<version>8</version>
 		</versions>
+		<disables>
+			<disable>
+				<comment>To enable later, also remove disable in build.xml, https://github.ibm.com/runtimes/backlog/issues/945</comment>
+			</disable>
+		</disables>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>


### PR DESCRIPTION
- This is a ported change from master branch
- Exclude openliberty_microprofile_tck_jdk8_j9 test

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>