### PR TITLE
Use shellcheck on compile.sh

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -3,7 +3,7 @@ usage() {
     echo '                Please export USE_TESTENV_PROPERTIES, JDK_VERSION and JDK_IMPL before running the script locally.'
 
 }
-if [ $(uname) = AIX ] || [ $(uname) = SunOS ] || [ $(uname) = *BSD ]; then
+if [ "$(uname)" = AIX ] || [ "$(uname)" = SunOS ] || [ "$(uname)" = *BSD ]; then
     MAKE=gmake
 else
     MAKE=make

--- a/compile.sh
+++ b/compile.sh
@@ -16,8 +16,8 @@ if [ "$USE_TESTENV_PROPERTIES" == true ]; then
     if [[ "$PLATFORM" == *"arm"* ]] && [[ "$JDK_VERSION" == "8" ]]; then
         testenv_file="./testenv/testenv_arm32.properties"
     fi
-    while read line; do
-        export $line
+    while read -r line; do
+        export "${line?}"
     done <$testenv_file
     if [ "$JDK_IMPL" == "openj9" ] || [ "$JDK_IMPL" == "ibm" ]; then
         repo=JDK${JDK_VERSION}_OPENJ9_REPO

--- a/compile.sh
+++ b/compile.sh
@@ -8,7 +8,7 @@ if [ "$(uname)" = AIX ] || [ "$(uname)" = SunOS ] || [ "$(uname)" = *BSD ]; then
 else
     MAKE=make
 fi
-if [ $USE_TESTENV_PROPERTIES == true ]; then
+if [ "$USE_TESTENV_PROPERTIES" == true ]; then
     testenv_file="./testenv/testenv.properties"
     if [[ "$PLATFORM" == *"zos"* ]]; then
         testenv_file="./testenv/testenv_zos.properties"
@@ -19,7 +19,7 @@ if [ $USE_TESTENV_PROPERTIES == true ]; then
     while read line; do
         export $line
     done <$testenv_file
-    if [ $JDK_IMPL == "openj9" ] || [ $JDK_IMPL == "ibm" ]; then
+    if [ "$JDK_IMPL" == "openj9" ] || [ "$JDK_IMPL" == "ibm" ]; then
         repo=JDK${JDK_VERSION}_OPENJ9_REPO
         branch=JDK${JDK_VERSION}_OPENJ9_BRANCH
     else
@@ -27,8 +27,8 @@ if [ $USE_TESTENV_PROPERTIES == true ]; then
         branch=JDK${JDK_VERSION}_BRANCH
     fi
 
-    eval repo2='$'$repo
-    eval branch2='$'$branch
+    eval repo2='$'"$repo"
+    eval branch2='$'"$branch"
 
     export JDK_REPO=$repo2
     export JDK_BRANCH=$branch2

--- a/compile.sh
+++ b/compile.sh
@@ -27,11 +27,8 @@ if [ "$USE_TESTENV_PROPERTIES" == true ]; then
         branch=JDK${JDK_VERSION}_BRANCH
     fi
 
-    eval repo2='$'"$repo"
-    eval branch2='$'"$branch"
-
-    export JDK_REPO=$repo2
-    export JDK_BRANCH=$branch2
+    export JDK_REPO="${!repo}"
+    export JDK_BRANCH="${!branch}"
     echo "Set values based on ${testenv_file}:"
     cat $testenv_file
     echo ""

--- a/compile.sh
+++ b/compile.sh
@@ -3,7 +3,7 @@ usage() {
     echo '                Please export USE_TESTENV_PROPERTIES, JDK_VERSION and JDK_IMPL before running the script locally.'
 
 }
-if [ "$(uname)" = AIX ] || [ "$(uname)" = SunOS ] || [ "$(uname)" = *BSD ]; then
+if [ "$(uname)" = AIX ] || [ "$(uname)" = SunOS ] || [[ "$(uname)" = *BSD ]]; then
     MAKE="gmake"
 else
     MAKE="make"

--- a/compile.sh
+++ b/compile.sh
@@ -39,5 +39,6 @@ if [ "$USE_TESTENV_PROPERTIES" == true ]; then
     echo "JDK_BRANCH=${JDK_BRANCH}"
 
 fi
+# shellcheck disable=SC2164
 cd ./TKG
 $MAKE compile

--- a/compile.sh
+++ b/compile.sh
@@ -4,9 +4,9 @@ usage() {
 
 }
 if [ "$(uname)" = AIX ] || [ "$(uname)" = SunOS ] || [ "$(uname)" = *BSD ]; then
-    MAKE=gmake
+    MAKE="gmake"
 else
-    MAKE=make
+    MAKE="make"
 fi
 if [ "$USE_TESTENV_PROPERTIES" == true ]; then
     testenv_file="./testenv/testenv.properties"


### PR DESCRIPTION
Use shellcheck to verify shell scripts work as intended. Apply fixes as needed to confirm intent and handle corner cases.