### PR TITLE
JDK19+ AIX exclude sun/security/krb5/auto/Cleaners.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -403,6 +403,8 @@ sun/security/util/math/TestIntegerModuloP.java	https://github.com/eclipse-openj9
 
 # jdk_security4
 
+sun/security/krb5/auto/Cleaners.java https://github.com/eclipse-openj9/openj9/issues/16248 aix-all
+
 ########################################################################################################################################################
 
 # jdk_sound

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -443,6 +443,7 @@ sun/security/util/math/TestIntegerModuloP.java	https://github.com/eclipse-openj9
 # jdk_security4
 
 sun/security/krb5/ccache/Refresh.java https://github.com/eclipse-openj9/openj9/issues/15267 generic-all
+sun/security/krb5/auto/Cleaners.java https://github.com/eclipse-openj9/openj9/issues/16248 aix-all
 
 ########################################################################################################################################################
 


### PR DESCRIPTION
`JDK19+ AIX` exclude `sun/security/krb5/auto/Cleaners.java`

Related https://github.com/eclipse-openj9/openj9/issues/16248

Signed-off-by: Jason Feng <fengj@ca.ibm.com>