### PR TITLE
Enable tests JSR166TestCase.java & HCRLateAttachWorkload_previewEnabled

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -439,7 +439,7 @@ java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse-openj9/
 java/util/concurrent/ArrayBlockingQueue/WhiteBox.java  https://github.com/eclipse-openj9/openj9/issues/5988  macosx-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclipse-openj9/openj9/issues/3209 generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all
-java/util/concurrent/tck/JSR166TestCase.java https://github.com/eclipse-openj9/openj9/issues/15465 generic-all
+java/util/concurrent/tck/JSR166TestCase.java https://github.com/eclipse-openj9/openj9/issues/15465 windows-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -480,7 +480,7 @@ java/util/concurrent/ArrayBlockingQueue/WhiteBox.java  https://github.com/eclips
 java/util/concurrent/ExecutorService/CloseTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclipse-openj9/openj9/issues/3209 generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all
-java/util/concurrent/tck/JSR166TestCase.java https://github.com/eclipse-openj9/openj9/issues/15465 generic-all
+java/util/concurrent/tck/JSR166TestCase.java https://github.com/eclipse-openj9/openj9/issues/15465 windows-all
 java/util/concurrent/ThreadPerTaskExecutor/ThreadPerTaskExecutorTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -292,13 +292,6 @@
 	</test>
 	<test>
 		<testCaseName>HCRLateAttachWorkload_previewEnabled</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15250</comment>
-				<impl>openj9</impl>
-				<version>19+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>


### PR DESCRIPTION
Enable tests `JSR166TestCase.java` & `HCRLateAttachWorkload_previewEnabled`

Enable `java/util/concurrent/tck/JSR166TestCase.java` except `windows` which matches `ProblemList_openjdk19.txt`;
Enable `HCRLateAttachWorkload_previewEnabled`.

Related https://github.com/eclipse-openj9/openj9/issues/15250 https://github.com/eclipse-openj9/openj9/issues/15465

Signed-off-by: Jason Feng <fengj@ca.ibm.com>