### PR TITLE
Enable MBCS_Tests_i18n_zh_CN tests

### DIFF
--- a/functional/MBCS_Tests/i18n/playlist.xml
+++ b/functional/MBCS_Tests/i18n/playlist.xml
@@ -45,13 +45,6 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_i18n_zh_CN_linux</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15249</comment>
-				<impl>openj9</impl>
-				<version>19+</version>
-			</disable>
-		</disables>
 		<command>LANG=zh_CN.UTF-8 perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.linux</platformRequirements>
@@ -157,13 +150,6 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_i18n_zh_CN_aix</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15249</comment>
-				<impl>openj9</impl>
-				<version>19+</version>
-			</disable>
-		</disables>
 		<command>LANG=zh_CN perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>


### PR DESCRIPTION
Re-enable `MBCS_Tests_i18n_zh_CN_linux` & `MBCS_Tests_i18n_zh_CN_aix`.

Related https://github.com/eclipse-openj9/openj9/issues/15249

Signed-off-by: Jason Feng <fengj@ca.ibm.com>