### PR TITLE
Enable vthread/ContFramePopTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -597,7 +597,6 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https:/
 serviceability/jvmti/thread/GetThreadInfo/thrinfo01/thrinfo01.java https://github.com/eclipse-openj9/openj9/issues/16187 generic-all
 serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java https://github.com/eclipse-openj9/openj9/issues/16187 generic-all
 serviceability/jvmti/vthread/BreakpointInYieldTest/BreakpointInYieldTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
-serviceability/jvmti/vthread/ContFramePopTest/ContFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16187 generic-all
 serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.java https://github.com/eclipse-openj9/openj9/issues/16187 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/NullAsCurrentThreadTest/NullAsCurrentThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -639,7 +639,6 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https:/
 serviceability/jvmti/thread/GetThreadInfo/thrinfo01/thrinfo01.java https://github.com/eclipse-openj9/openj9/issues/16187 generic-all
 serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java https://github.com/eclipse-openj9/openj9/issues/16187 generic-all
 serviceability/jvmti/vthread/BreakpointInYieldTest/BreakpointInYieldTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
-serviceability/jvmti/vthread/ContFramePopTest/ContFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16187 generic-all
 serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.java https://github.com/eclipse-openj9/openj9/issues/16187 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/NullAsCurrentThreadTest/NullAsCurrentThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all


### PR DESCRIPTION
vthread/ContFramePopTest was fixed by eclipse-openj9/openj9#16241.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>