### PR TITLE
Exclude two jcstress tests for openj9 11

### DIFF
--- a/system/jcstress/playlist.xml
+++ b/system/jcstress/playlist.xml
@@ -237,6 +237,13 @@
 		<testCaseName>jcstress_FencedDekkerTest</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-tests-all-20220908.jar$(Q) $(APPLICATION_OPTIONS) -t FencedDekkerTest; \
 			$(TEST_STATUS)</command>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/16178</comment>
+				<impl>openj9</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -248,6 +255,13 @@
 		<testCaseName>jcstress_FencedAcquireReleaseTest</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-tests-all-20220908.jar$(Q) $(APPLICATION_OPTIONS) -t FencedAcquireReleaseTest; \
 			$(TEST_STATUS)</command>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/16178</comment>
+				<impl>openj9</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<levels>
 			<level>dev</level>
 		</levels>


### PR DESCRIPTION
- Exclude jcstress_FencedDekkerTest and jcstress_FencedAcquireReleaseTest for openj9 11
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/16178

Signed-off-by: LongyuZhang <longyu.zhang@ibm.com>