### PR TITLE
Add APPLICATION_OPTIONS as a test job parameter

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -70,6 +70,7 @@ def setupEnv() {
 	env.TEST_JDK_HOME = "$WORKSPACE/openjdkbinary/j2sdk-image"
 	env.JVM_VERSION = params.JVM_VERSION ? params.JVM_VERSION : ""
 	env.JVM_OPTIONS = params.JVM_OPTIONS ? params.JVM_OPTIONS : ""
+        env.APPLICATION_OPTIONS = params.APPLICATION_OPTIONS ? params.APPLICATION_OPTIONS : ""
 	env.EXTRA_DOCKER_ARGS = params.EXTRA_DOCKER_ARGS ? params.EXTRA_DOCKER_ARGS : ""
 	env.OPENJDK_SHA = params.OPENJDK_SHA ? params.OPENJDK_SHA : ""
 	env.TEST_FLAG = params.TEST_FLAG ? params.TEST_FLAG : ''
@@ -638,7 +639,7 @@ def checkTestResults() {
 	def results = [:]
 	def summary = null
 
-	def matcher = manager.getLogMatcher(".*(TOTAL: \\d+)   (EXECUTED: \\d+)   (PASSED: \\d+)   (FAILED: \\d+)   (DISABLED: \\d+)   (SKIPPED: \\d+).*")
+	def matcher = manager.getLogMatcher(".*(TOTAL: \\d+)\\s*(EXECUTED: \\d+)\\s*(PASSED: \\d+)\\s*(FAILED: \\d+)\\s*(DISABLED: \\d+)?\\s*(SKIPPED: \\d+).*")
 	if (!matcher?.matches()) {
 		currentBuild.result = 'FAILURE'
 		echo 'Could not find test result, set build result to FAILURE.'
@@ -648,8 +649,10 @@ def checkTestResults() {
 	}
 
 	for (int i = 1; i < matcher.groupCount(); i++) {
-		def matchVals = matcher.group(i).split(": ")
-		results[matchVals[0]] = matchVals[1]
+                if (matcher.group(i) != null) {
+  		    def matchVals = matcher.group(i).split(": ")
+  		    results[matchVals[0]] = matchVals[1]
+                }
 	}
 
 	if (results["TOTAL"].equals("0")) {

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -375,6 +375,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							choiceParam('TEST_FLAG', ['', 'JITAAS', 'AOT', 'FIPS'], "Optional. Only set for feature testing. (i.e.,  JITAAS, AOT, FIPS, etc)")
 							stringParam('EXTRA_OPTIONS', "", "Use this to append options to the test command")
 							stringParam('JVM_OPTIONS', "", "Use this to replace the test original command line options")
+                                                        stringParam('APPLICATION_OPTIONS', "", "Use this to append options to the test application")
 							stringParam('BUILD_IDENTIFIER', "", "build identifier")
 							stringParam('ITERATIONS',"1", '''Optional. Number of times to repeat execution of make target. <br/>
 								Use ITERATIONS with PARALLEL=None, run the same test(s) in a loop on one machine <br/>

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -92,12 +92,17 @@ ifeq (,$(findstring testsuite, $(JCK_CUSTOM_TARGET)))
    override JCK_CUSTOM_TARGET := $(JCK_CUSTOM_TARGET) testsuite=RUNTIME
 endif
 
+# Additional JavaTestRunner options can be added via APPLICATION_OPTIONS
+ifndef APPLICATION_OPTIONS
+   APPLICATION_OPTIONS :=
+endif
+
 JCK_CMD_TEMPLATE = $(JAVA_COMMAND)
 ifeq ($(USE_JRE),1)
   JCK_CMD_TEMPLATE = $(JRE_COMMAND)
 endif
 
-JCK_CMD_TEMPLATE += -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavaTestRunner resultsRoot=$(REPORTDIR) testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH)
+JCK_CMD_TEMPLATE += -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavaTestRunner resultsRoot=$(REPORTDIR) testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) $(APPLICATION_OPTIONS)
 
 VERIFIER_INSTRUCTIONS_TESTS_GROUP1=$(Q)vm/verifier/instructions/aaload;vm/verifier/instructions/aastore;vm/verifier/instructions/anewarray;vm/verifier/instructions/areturn;vm/verifier/instructions/baload;vm/verifier/instructions/bastore;vm/verifier/instructions/bipush;vm/verifier/instructions/caload;vm/verifier/instructions/castore;vm/verifier/instructions/d2f;vm/verifier/instructions/d2i;vm/verifier/instructions/d2l;vm/verifier/instructions/dadd;vm/verifier/instructions/daload;vm/verifier/instructions/dastore;vm/verifier/instructions/dcmp;vm/verifier/instructions/dconst;vm/verifier/instructions/ddiv;vm/verifier/instructions/dmul;vm/verifier/instructions/dneg;vm/verifier/instructions/drem;vm/verifier/instructions/dreturn;vm/verifier/instructions/dsub;vm/verifier/instructions/dup;vm/verifier/instructions/dup2$(Q)
 VERIFIER_INSTRUCTIONS_TESTS_GROUP2=$(Q)vm/verifier/instructions/dup2x1;vm/verifier/instructions/dup2x2;vm/verifier/instructions/dupx1;vm/verifier/instructions/dupx2;vm/verifier/instructions/f2d;vm/verifier/instructions/f2i;vm/verifier/instructions/f2l;vm/verifier/instructions/fadd;vm/verifier/instructions/faload;vm/verifier/instructions/fastore;vm/verifier/instructions/fcmp;vm/verifier/instructions/fconst;vm/verifier/instructions/fdiv;vm/verifier/instructions/fmul;vm/verifier/instructions/fneg;vm/verifier/instructions/frem;vm/verifier/instructions/freturn;vm/verifier/instructions/fsub;vm/verifier/instructions/getfield;vm/verifier/instructions/getstatic;vm/verifier/instructions/i2b;vm/verifier/instructions/i2c;vm/verifier/instructions/i2d;vm/verifier/instructions/i2f;vm/verifier/instructions/i2l$(Q)

--- a/system/system.mk
+++ b/system/system.mk
@@ -64,9 +64,11 @@ ifeq (,$(findstring $(JDK_IMPL),hotspot))
   JAVA_ARGS += -Xdump:system:events=user
 endif
 
-APPLICATION_OPTIONS :=
+ifndef APPLICATION_OPTIONS
+  APPLICATION_OPTIONS :=
+endif
 ifdef JVM_OPTIONS
-  APPLICATION_OPTIONS := -jvmArgs $(Q)$(JVM_OPTIONS)$(Q)
+  APPLICATION_OPTIONS := $(APPLICATION_OPTIONS) -jvmArgs $(Q)$(JVM_OPTIONS)$(Q)
 endif
 
 define SYSTEMTEST_CMD_TEMPLATE


### PR DESCRIPTION
Adds a new APPLICATION_OPTIONS test job parameter which is used optionally by Jck and System to pass additional "test application" options.

Also fixed Jenkins result parsing of logMatcher() as it was failing with the disabled.<target> as (DISABLED:) is not printed in that format.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>