### PR TITLE
Re-enable auto-manuals that are disabled, use exclude files instead

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -342,13 +342,6 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_naming-spi</testCaseName>
-		<disables>
-		<disable>
-				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
-  				<impl>hotspot</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -413,21 +406,6 @@
 				<comment>backlog/issues/608 : To be run manually</comment>
 				<impl>openj9</impl>
 			</disable>
-			<disable>
-				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac|aarch64_mac</platform>
-				<impl>hotspot</impl>
-			</disable>
-			<disable>
-				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-32_windows</platform>
-				<impl>hotspot</impl>
- 			</disable>
- 			<disable>
-				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_windows</platform>
-				<impl>hotspot</impl>
- 			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -955,21 +933,6 @@
 			<disable>
 				<comment>backlog/issues/608 : To be run manually</comment>
 				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_mac</platform>
-				<impl>hotspot</impl>
-			</disable>
-			<disable>
-				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-32_windows</platform>
-				<impl>hotspot</impl>
-			</disable>
-			<disable>
-				<comment>Requires UI https://github.com/temurin-compliance/temurin-compliance/issues/29</comment>
-				<platform>x86-64_windows</platform>
-				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>


### PR DESCRIPTION
Re-enable the following that are currently DISABLED, and with current processes risk being missed:
- jck-runtime-api-javax_naming-spi : MacOS
- jck-runtime-api-java_awt : MacOS, Windows
- jck-runtime-api-javax_swing : MacOS, Windows

Signed-off-by: Andrew Leonard <anleonar@redhat.com>