### PR TITLE
Exclude AIX java/nio/channels/vthread/BlockingChannelOps.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -332,6 +332,8 @@ java/nio/channels/SocketChannel/VectorIO.java https://github.ibm.com/runtimes/ba
 java/nio/channels/SocketChannel/VectorParams.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/SocketChannel/Write.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
+java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
 java/nio/file/Files/probeContentType/Basic.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -366,8 +366,8 @@ java/nio/channels/SocketChannel/VectorIO.java https://github.ibm.com/runtimes/ba
 java/nio/channels/SocketChannel/VectorParams.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/SocketChannel/Write.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/eclipse-openj9/openj9/issues/15265 generic-all
-java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
+java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
+java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
 java/nio/file/Files/probeContentType/Basic.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all


### PR DESCRIPTION
Exclude `AIX java/nio/channels/vthread/BlockingChannelOps.java`

Related https://github.com/eclipse-openj9/openj9/issues/16279

Signed-off-by: Jason Feng <fengj@ca.ibm.com>