### PR TITLE
Allow large jck test subsets to run longer before timeout

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -983,9 +983,9 @@ public class JavaTestRunner {
 			int jckRC = -1;
 			boolean endedWithinTimeLimit = false;
 			
-			// Use the presence of a '/' to signify that we are running a subset of tests.
-			// If one of the highest level test nodes is being run it is likely to take a long time.
-			if ( tests.contains("/") && !isRiscv ) {
+			// Use the presence of more than one '/' to signify that we are running a smaller subset of tests.
+			// If one of the highest level subsets of tests is being run it is likely to take a long time.
+			if ( tests.chars().filter(c -> c == '/').count() > 1 && !isRiscv ) {
 				timeout = 4;
 			}
 


### PR DESCRIPTION
Single jck subsets, eg. "api/java_awt", can still take a long time to run, sometimes longer than the default 4 hour timeout set by JavaTestRunner.
This PR uses the max timeout for root and single "/" test subsets.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>