### PR TITLE
Re-enable tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -584,9 +584,7 @@ serviceability/jvmti/SuspendWithObjectMonitorEnter/SuspendWithObjectMonitorEnter
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java https://github.com/eclipse-openj9/openj9/issues/15994 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
-serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/16229 generic-all
-serviceability/jvmti/events/SingleStep/singlestep01/singlestep01.java https://github.com/eclipse-openj9/openj9/issues/16229 generic-all
-serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java https://github.com/eclipse-openj9/openj9/issues/16275 generic-all
+serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/SetGetThreadLocalStorageStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
@@ -602,7 +600,6 @@ serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.jav
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/NullAsCurrentThreadTest/NullAsCurrentThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
-serviceability/jvmti/vthread/RedefineClasses/RedefineRunningMethods.java https://github.com/eclipse-openj9/openj9/issues/16212 generic-all
 serviceability/jvmti/vthread/RawMonitorTest/RawMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16279 aix-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -624,9 +624,7 @@ serviceability/jvmti/SuspendWithObjectMonitorEnter/SuspendWithObjectMonitorEnter
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java https://github.com/eclipse-openj9/openj9/issues/15994 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
-serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/16229 generic-all
-serviceability/jvmti/events/SingleStep/singlestep01/singlestep01.java https://github.com/eclipse-openj9/openj9/issues/16229 generic-all
-serviceability/jvmti/RedefineClasses/RedefineRunningMethodsWithBacktrace.java https://github.com/eclipse-openj9/openj9/issues/16275 generic-all
+serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/SetGetThreadLocalStorageStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
@@ -642,7 +640,6 @@ serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.jav
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/NullAsCurrentThreadTest/NullAsCurrentThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
-serviceability/jvmti/vthread/RedefineClasses/RedefineRunningMethods.java https://github.com/eclipse-openj9/openj9/issues/16212 generic-all
 serviceability/jvmti/vthread/RawMonitorTest/RawMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16279 aix-all


### PR DESCRIPTION
- eclipse-openj9/openj9#16212 was fixed by
   1. eclipse-openj9/openj9#16290; and
   2. eclipse-openj9/openj9#16293.

- eclipse-openj9/openj9#16275 is a duplicate of eclipse-openj9/openj9#16212.

- eclipse-openj9/openj9#16229 was fixed by eclipse-openj9/openj9#16323.

- `FramePop/framepop02` fails with another issue, which is reported in eclipse-openj9/openj9#16346.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>