### PR TITLE
Unexclude container tests on JDK 8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -133,10 +133,6 @@ compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh https://github.com/adopti
 compiler/floatingpoint/8165673/TestFloatJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 compiler/rtm/locking/TestRTMTotalCountIncrRate.java https://github.com/adoptium/aqa-tests/issues/3050 linux-all,windows-all
 compiler/intrinsics/mathexact/LongMulOverflowTest.java https://bugs.openjdk.org/browse/JDK-8196568 solaris-x64
-runtime/containers/docker/DockerBasicTest.java https://github.com/adoptium/aqa-tests/issues/3629 linux-all
-runtime/containers/docker/TestCPUAwareness.java https://github.com/adoptium/aqa-tests/issues/3629 linux-all
-runtime/containers/docker/TestCPUSets.java https://github.com/adoptium/aqa-tests/issues/3629 linux-all
-runtime/containers/docker/TestMisc.java https://github.com/adoptium/aqa-tests/issues/3629 linux-all
 #https://github.com/adoptium/aqa-tests/issues/3629,https://github.com/adoptium/aqa-tests/issues/3905
 runtime/containers/docker/TestMemoryAwareness.java https://bugs.openjdk.java.net/browse/JDK-8229182 generic-all
 ############################################################################


### PR DESCRIPTION
The dev.openjdk target (#4147) has been introduced since and that uses a custom base image which should work on x86_64, ppc64le, aarch64 and s390x on Linux for the purpose of the tests.

I don't think excluding those container tests on Linux wholesale is warranted.

/cc @sendaoYan