### PR TITLE
Exclude TestMemoryWithCgroupV1 on JDK 11+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -338,3 +338,8 @@ javax/imageio/plugins/shared/ImageWriterCompressionTest.java	https://github.com/
 
 # jdk_build
 build/AbsPathsInImage.java https://github.com/adoptium/aqa-tests/issues/3234 linux-x64
+
+############################################################################
+
+# jdk_container/hotspot_container
+containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JDK-8297274 linux-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -507,3 +507,8 @@ compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium
 #runtime_nestmate
 
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
+
+############################################################################
+
+# jdk_container/hotspot_container
+containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JDK-8297274 linux-all

--- a/openjdk/excludes/ProblemList_openjdk19.txt
+++ b/openjdk/excludes/ProblemList_openjdk19.txt
@@ -514,3 +514,5 @@ sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java https://github.com/ad
 
 #####################################
 
+# jdk_container/hotspot_container
+containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JDK-8297274 linux-all

--- a/openjdk/excludes/ProblemList_openjdk20.txt
+++ b/openjdk/excludes/ProblemList_openjdk20.txt
@@ -501,3 +501,5 @@ sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java https://github.com/ad
 
 #####################################
 
+# jdk_container/hotspot_container
+containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JDK-8297274 linux-all


### PR DESCRIPTION
JDK-8284950 which introduced this test is in JDK 11+ Until the upstream bug is fixed, exclude the test.

/cc @ShelleyLambert 