### PR TITLE
LoongArch64 support locally test

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1516,7 +1516,7 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<platformRequirements>bits.64,^arch.ppc,^arch.390,^arch.riscv,^os.zos,^os.sunos</platformRequirements>
+		<platformRequirements>bits.64,^arch.ppc,^arch.390,^arch.riscv,^arch.loongarch,^os.zos,^os.sunos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>jdk_instrument</testCaseName>

--- a/scripts/disabled_tests/tests/test_exclude_parser.py
+++ b/scripts/disabled_tests/tests/test_exclude_parser.py
@@ -17,6 +17,7 @@ platform_map = {
     "linux-ppc32": "ppc32_linux",
     "linux-ppc64": "ppc64_linux",
     "linux-riscv64": "riscv64_linux",
+    "linux-loongarch64": "loongarch64_linux",
     "linux-s390": "s390_linux",
     "solaris-sparcv9": "sparcv9_solaris",
     "solaris-x86-64": "x86-64_solaris",


### PR DESCRIPTION
Due to the lack of machine resources, this PR is only used to support LoongArch locally test.