### PR TITLE
Remove duplicate and exclude jcstress_DekkerTest for openj9 11

### DIFF
--- a/system/jcstress/playlist.xml
+++ b/system/jcstress/playlist.xml
@@ -504,6 +504,13 @@
 		<testCaseName>jcstress_DekkerTest</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-tests-all-20220908.jar$(Q) $(APPLICATION_OPTIONS) -t DekkerTest; \
 			$(TEST_STATUS)</command>
+		<disables>
+			<disable>
+				<comment>git_ibm/runtimes/backlog/issues/973</comment>
+				<impl>openj9</impl>
+				<version>11</version>
+			</disable>
+		</disables>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1823,17 +1830,6 @@
 	<test>
 		<testCaseName>jcstress_DekkerRelaxation2Test</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-tests-all-20220908.jar$(Q) $(APPLICATION_OPTIONS) -t DekkerRelaxation2Test; \
-			$(TEST_STATUS)</command>
-		<levels>
-			<level>dev</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
-	<test>
-		<testCaseName>jcstress_DekkerTest</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-tests-all-20220908.jar$(Q) $(APPLICATION_OPTIONS) -t DekkerTest; \
 			$(TEST_STATUS)</command>
 		<levels>
 			<level>dev</level>


### PR DESCRIPTION
- Remove duplicate for jcstress_DekkerTest
- exclude jcstress_DekkerTest for openj9 11
- Related Issue: ibm_git/runtimes/backlog/issues/973

Signed-off-by: LongyuZhang <longyu.zhang@ibm.com>