### PR TITLE
Add check for testFlag to be nonempty before using testFlag jtx + Add README for tck exclude list types

### DIFF
--- a/jck/README.md
+++ b/jck/README.md
@@ -101,3 +101,15 @@ cd TKG
 make compile
 make _sanity.jck
 ```
+
+## TCK exclude lists 
+
+We have three types of tck exclude lists: 
+
+1. Dev excludes: This exclude file, ending with `-dev` (e.g. jck8c-dev.jtx), contains vendor specific excludes. All excludes related to automation run by a specific vendor would go into the `*dev.jtx` files in tck repositories maintained by that vendor for use during development not certification.
+
+2. Test-flag specific excludes: These exclude files support development work by allowing developers to add feature specific temporary excludes. For example, the FIPS specific exclude file (e.g., jck8c-fips.jtx) contains list of excludes specific to FIPS that will only be in effect if `TEST_FLAG` is set to `fips`. These files are used for development, not for certification.
+
+3. Standard excludes: These are the 3 standard exclude files (jtx and kfl) that come with tck materials. These constitute known failures and are not updated by vendors.
+
+Note In regular automated runs in Jenkins, we will only see the exclude list of type 1 and 3. In grinder runs where `jck_custom` is used, Dev exclude is ignored. Type 1 and 2 are used during development, not for certification.

--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -307,7 +307,7 @@ public class JavaTestRunner {
 
 		if (task == null || !task.equals("custom")) {
 			testFlagJtxFullPath = "";
-			if (testFlag != null) {
+			if (testFlag != null && testFlag.length() > 0 ) {
 				// Look for a known failures list file specific to TEST_FLAG testing
 				testFlagJtxFullPath = jckRoot + File.separator + "excludes" + File.separator + jckVersion + "-" + testFlag.toLowerCase() + ".jtx";
 				File testFlagJtxFile = new File(testFlagJtxFullPath);


### PR DESCRIPTION
- Add a second check for TEST_FLAG value to be non-empty before attempting to use TEST_FLAG specific exclude files in tck automated nightly / weeklies. 
- Add README for tck exclude list types.
- Resolves backlog/issues/974. 

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>