### PR TITLE
Re-enable ActiviateSpareCarrier test

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -126,7 +126,6 @@ java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://git
 java/lang/System/PropertyTest.java https://github.com/eclipse-openj9/openj9/issues/15129 linux-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
 java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/11930 generic-all
-java/lang/Thread/virtual/ActiviateSpareCarrier.java https://github.com/eclipse-openj9/openj9/issues/16198 generic-all
 java/lang/Thread/virtual/PreviewFeaturesNotEnabled.java https://github.com/eclipse-openj9/openj9/issues/16044 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/stress/PingPong.java https://github.com/eclipse-openj9/openj9/issues/15939 generic-all


### PR DESCRIPTION
Test fixed by https://github.com/eclipse-openj9/openj9/pull/16324

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>