### PR TITLE
Re-enable JTReg test thrinfo01

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -592,7 +592,6 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https:/
 serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/eclipse-openj9/openj9/issues/16185 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
-serviceability/jvmti/thread/GetThreadInfo/thrinfo01/thrinfo01.java https://github.com/eclipse-openj9/openj9/issues/16226 generic-all
 serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java https://github.com/eclipse-openj9/openj9/issues/16242 generic-all
 serviceability/jvmti/vthread/BreakpointInYieldTest/BreakpointInYieldTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.java https://github.com/eclipse-openj9/openj9/issues/16215 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -633,7 +633,6 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https:/
 serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/eclipse-openj9/openj9/issues/16185 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
-serviceability/jvmti/thread/GetThreadInfo/thrinfo01/thrinfo01.java https://github.com/eclipse-openj9/openj9/issues/16226 generic-all
 serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java https://github.com/eclipse-openj9/openj9/issues/16242 generic-all
 serviceability/jvmti/vthread/BreakpointInYieldTest/BreakpointInYieldTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.java https://github.com/eclipse-openj9/openj9/issues/16215 generic-all


### PR DESCRIPTION
Re-enable JTReg test thrinfo01

Test had been fixed by https://github.com/eclipse-openj9/openj9/pull/16376

Signed-off-by: Dipak Bagadiya dipak.bagadiya@ibm.com