### PR TITLE
Jck vm/jdwp & jvmti needs to run concurrency=1 as not thread safe

### DIFF
--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -51,7 +51,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/jdwp testsuite=RUNTIME; \
+		<command>$(JCK_CMD_TEMPLATE) tests=vm/jdwp testsuite=RUNTIME concurrency=1; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -65,7 +65,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/jvmti testsuite=RUNTIME; \
+		<command>$(JCK_CMD_TEMPLATE) tests=vm/jvmti testsuite=RUNTIME concurrency=1; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
Jck19 jdwp is potentially hanging or encountering:
```
java.lang.IllegalStateException: This section of the test result is now immutable.
```
I believe this is because jdwp by design is not thread/process safe.
This PR sets the vm/jdwp concurrency to 1.


Signed-off-by: Andrew Leonard <anleonar@redhat.com>