### PR TITLE
Add GLIBC_TUNABLES values for criu portable tests

### DIFF
--- a/external/criu-portable-checkpoint/test_restore.sh
+++ b/external/criu-portable-checkpoint/test_restore.sh
@@ -15,6 +15,12 @@
 source $(dirname "$0")/test_base_functions.sh
 # This script is used as the new entrypoint for saved criu-restore-ready-with-jdk docker image
 echo "Restore tests from Checkpoint"
+
+echo "export GLIBC_TUNABLES=glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load";
+export GLIBC_TUNABLES=glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load
+echo "export LD_BIND_NOT=on";
+export LD_BIND_NOT=on
+
 checkpoint_folders="/aqa-tests/TKG/output_*/cmdLineTester_criu_keepCheckpoint*"
 output_file="testOutput" # File "testOutput" is used to store all outputs
 result_code=0

--- a/external/criu-ubi-portable-checkpoint/test_restore.sh
+++ b/external/criu-ubi-portable-checkpoint/test_restore.sh
@@ -19,6 +19,11 @@ checkpoint_folders="/aqa-tests/TKG/output_*/cmdLineTester_criu_keepCheckpoint*"
 output_file="testOutput" # File "testOutput" is used to store all outputs
 result_code=0
 
+echo "export GLIBC_TUNABLES=glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load";
+export GLIBC_TUNABLES=glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load
+echo "export LD_BIND_NOT=on";
+export LD_BIND_NOT=on
+
 for checkpoint_folder in $checkpoint_folders
 do
     cd $checkpoint_folder


### PR DESCRIPTION
- Add GLIBC_TUNABLES values for criu portable tests
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/16382 This PR alone will not solve this issue, but it is required for portable test on various micro-architectures.

Signed-off-by: LongyuZhang <longyu.zhang@ibm.com>