### PR TITLE
Enhanced pre/post test job hung/leftover process checking

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -26,12 +26,7 @@ def setupEnv() {
 	env.JOBSTARTTIME = sh(script: 'LC_TIME=C date +"%a, %d %b %Y %T %z"', returnStdout: true).trim()
 
 	// Terminate any previous test related processes that are running
-	echo "PROCESSCATCH: Terminating previous test related processes which are currently on the machine:"
-	def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh ${env.USER} 2>&1", returnStatus:true)
-	echo "returnCode = ${statusCode}"
-	if (statusCode != 0) {
-		echo "Unable to terminate all processes."
-	}
+        terminateTestProcesses()
 
 	if ( params.JDK_VERSION ) {
 		env.ORIGIN_JDK_VERSION = params.JDK_VERSION
@@ -792,8 +787,8 @@ def testBuild() {
 				testExecution()
 			}
 		} finally {
-			// Terminate any left over java processes
-			terminateJavaProcesses()
+			// Terminate any left over test job processes
+			terminateTestProcesses()
 
 			if (!params.KEEP_WORKSPACE) {
 				// cleanWs() does not work in some cases, so set opts below
@@ -829,7 +824,7 @@ def testExecution() {
 	}
 }
 
-def terminateJavaProcesses() {
+def terminateTestProcesses() {
 	echo "PROCESSCATCH: Terminating any hung/left over test processes:"
 
         def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh ${env.USER} 2>&1", returnStatus:true)

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -828,9 +828,8 @@ def terminateTestProcesses() {
 	echo "PROCESSCATCH: Terminating any hung/left over test processes:"
 
         def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh ${env.USER} 2>&1", returnStatus:true)
-        echo "returnCode = ${statusCode}"
         if (statusCode != 0) {
-                echo "Unable to terminate all processes."
+                echo "rc = ${statusCode}, Unable to terminate all processes."
         } 
 }
 

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -27,7 +27,7 @@ def setupEnv() {
 
 	// Terminate any previous test related processes that are running
 	echo "PROCESSCATCH: Terminating previous test related processes which are currently on the machine:"
-	def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh 2>&1", returnStatus:true)
+	def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh ${env.USER} 2>&1", returnStatus:true)
 	echo "returnCode = ${statusCode}"
 	if (statusCode != 0) {
 		echo "Unable to terminate all processes."
@@ -832,7 +832,7 @@ def testExecution() {
 def terminateJavaProcesses() {
 	echo "PROCESSCATCH: Terminating any hung/left over test processes:"
 
-        def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh 2>&1", returnStatus:true)
+        def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh ${env.USER} 2>&1", returnStatus:true)
         echo "returnCode = ${statusCode}"
         if (statusCode != 0) {
                 echo "Unable to terminate all processes."

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -25,12 +25,12 @@ def makeTest(testParam) {
 def setupEnv() {
 	env.JOBSTARTTIME = sh(script: 'LC_TIME=C date +"%a, %d %b %Y %T %z"', returnStdout: true).trim()
 
-	// Check what existing java processes are running
-	echo "PROCESSCATCH: Java processes which are currently on the machine:"
-	if (PLATFORM.contains("windows")) {
-		sh(script:'powershell -c "Get-Process java | select id,processname,starttime"', returnStatus:true)
-	} else {
-		sh(script:'ps -fu '+"${env.USER}"+' | grep java | egrep -v "remoting.jar|agent.jar|grep"', returnStatus: true)
+	// Terminate any previous test related processes that are running
+	echo "PROCESSCATCH: Terminating previous test related processes which are currently on the machine:"
+	def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh 2>&1", returnStatus:true)
+	echo "returnCode = ${statusCode}"
+	if (statusCode != 0) {
+		echo "Unable to terminate all processes."
 	}
 
 	if ( params.JDK_VERSION ) {
@@ -830,49 +830,13 @@ def testExecution() {
 }
 
 def terminateJavaProcesses() {
-	// Attempt up to 30 times or until no more Java processes spawn...
-	for(int i=0; i<30; i++) {
-		echo 'terminateJavaProcesses iteration: '+(i+1)
+	echo "PROCESSCATCH: Terminating any hung/left over test processes:"
 
-		// Terminate Java processes
-		if (PLATFORM.contains("windows")) {
-			// Windows code based on https://github.com/adoptium/infrastructure/issues/1669#issuecomment-727863096
-			echo "PROCESSCATCH: Showing java processes - one will be the jenkins agent - removing any of these created since ${env.JOBSTARTTIME}:"
-			sh(script:'powershell -c "Get-Process java | select id,processname,starttime"', returnStatus:true)
-
-			def C=sh(script:'powershell -c "(Get-Process java | select id,processname,starttime | where {\\$_.StartTime -gt (Get-Date -Date \\"'+"${env.JOBSTARTTIME}"+'\\")} | measure).count" | tr -d \\\\r', returnStdout:true)
-			echo "Number of java processes = ${C}"
-			if (!C.trim().equals("0")) {
-				echo "PROCESSCATCH: Attempting to stop the following processes:"
-				sh(script:'powershell -c "Get-Process java | select id,processname,starttime | where {\\$_.StartTime -gt (Get-Date -Date \\"'+"${env.JOBSTARTTIME}"+'\\")}"', returnStatus:true)
-				def sh_rc=sh(script:'powershell -c "Get-Process java | select id,processname,starttime | where {\\$_.StartTime -gt (Get-Date -Date \\"'+"${env.JOBSTARTTIME}"+'\\")} | stop-process"', returnStatus:true)
-				echo "stop-process rc = ${sh_rc}"
-			} else {
-				// No more spawned, we are done...
-				break
-			}
-		} else {
-			// Non-Windows code from https://ci.adoptopenjdk.net/job/SXA-processCheck
-			echo "PROCESSCATCH: Checking for any leftover java processes on the machine"
-			def sh_rc=sh(script:'ps -fu '+"${env.USER}"+' | grep java | egrep -v "remoting.jar|agent.jar|grep"', returnStatus: true)
-			if (sh_rc == 0) {
-				echo "PROCESSCATCH: There are rogue processes still on the machine as per the list above"
-				// TODO: We could kill them, but SXA-processCheck covers this in the adoptopenjdk jenkins
-				// And this is likely to be replaced as part of https://github.com/adoptium/TKG/issues/45
-			}
-			break
-		}
-
-		// Pause between iterations in case of spawning processes
-		sleep(2)
-	}
-
-	echo "PROCESSCATCH: Removed processes - here is what is remaining:"
-	if (PLATFORM.contains("windows")) {
-		sh(script:'powershell -c "Get-Process java | select id,processname,starttime"', returnStatus:true)
-	} else {
-		sh(script:'ps -fu '+"${env.USER}"+' | grep java | egrep -v "remoting.jar|agent.jar|grep"', returnStatus:true)
-	}
+        def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh 2>&1", returnStatus:true)
+        echo "returnCode = ${statusCode}"
+        if (statusCode != 0) {
+                echo "Unable to terminate all processes."
+        } 
 }
 
 def getJDKImpl(jvm_version) {

--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -27,10 +27,8 @@ if [ "$OS" = "Windows_NT" ]; then
       echo Windows rogue processes detected, attempting to stop them..
       powershell -c "Get-WmiObject Win32_Process -Filter {${ignore_str} and ${match_str}}"
       powershell -c "(Get-WmiObject Win32_Process -Filter {${ignore_str} and ${match_str}}).Terminate()"
-      uname | grep CYGWIN 2>/dev/null || uptime
       echo Sleeping for 10 seconds...
       sleep 10
-      uname | grep CYGWIN 2>/dev/null || uptime
       count=`powershell -c "(Get-WmiObject Win32_Process -Filter {${ignore_str} and ${match_str}} | measure).count" | tr -d "\\\\r"`
       if [ $count -gt 0 ]; then
         echo "Cleanup failed, ${count} processes still remain..."
@@ -59,10 +57,8 @@ else
       echo Boooo - there are rogue processes kicking about
       echo Issuing a kill to all processes shown above
       $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}" | awk '{print $2}' | xargs -n1 kill
-      uname | grep CYGWIN 2>/dev/null || uptime
       echo Sleeping for 10 seconds...
       sleep 10
-      uname | grep CYGWIN 2>/dev/null || uptime
       if $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}"; then
         echo Still processes left going to remove those with kill -KILL ...
         $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}" | awk '{print $2}' | xargs -n1 kill -KILL

--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -51,11 +51,9 @@ else
 
   # Fix For Issue https://github.com/adoptium/infrastructure/issues/2442 - Solaris PS Command Truncation
   if [ `uname` = "SunOS" ]; then
-    PSCOMMAND="/usr/ucb/ps -auxww"
-  elif [ `uname` = "Darwin" ]; then
-    PSCOMMAND="ps -eo user,pid,lstart,command"
+      PSCOMMAND="/usr/ucb/ps -uxww"
   else
-    PSCOMMAND="ps -ef"
+      PSCOMMAND="ps -fu jenkins"
   fi
 
   if $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}"; then

--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -euxo pipefail
+
 # If Windows use PowerShell
 if [ "$OSTYPE" = "cygwin" ]; then
   echo "Windows machine, using powershell queries..."

--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-
-set -euxo pipefail
-
 # If Windows use PowerShell
 if [ "$OSTYPE" = "cygwin" ]; then
   echo "Windows machine, using powershell queries..."

--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -11,7 +11,6 @@ if [ "$OSTYPE" = "cygwin" ]; then
              CommandLine like '%openjdkbinary%java%' or \
              CommandLine like '%java%javatest%' or \
              CommandLine like '%java%-Xfuture%' or \
-             CommandLine like '%X%vfb%' or \
              CommandLine like '%rmid%' or \
              CommandLine like '%rmiregistry%' or \
              CommandLine like '%tnameserv%' or \

--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+
 set -euxo pipefail
 
 # If Windows use PowerShell

--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# Arg S1 : Unix current env.User
+
 # If Windows use PowerShell
 if [ "$OSTYPE" = "cygwin" ]; then
   echo "Windows machine, using powershell queries..."
@@ -53,7 +55,7 @@ else
   if [ `uname` = "SunOS" ]; then
       PSCOMMAND="/usr/ucb/ps -uxww"
   else
-      PSCOMMAND="ps -fu jenkins"
+      PSCOMMAND="ps -fu $1"
   fi
 
   if $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}"; then

--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+# If Windows use PowerShell
+if [ "$OSTYPE" = "cygwin" ]; then
+  echo "Windows machine, using powershell queries..."
+
+  # Match anything that most likely test job or process related
+  match_str="(CommandLine like '%java%jck%' or \
+             CommandLine like '%openjdkbinary%java%' or \
+             CommandLine like '%java%javatest%' or \
+             CommandLine like '%java%-Xfuture%' or \
+             CommandLine like '%X%vfb%' or \
+             CommandLine like '%rmid%' or \
+             CommandLine like '%rmiregistry%' or \
+             CommandLine like '%tnameserv%' or \
+             CommandLine like '%make.exe%')"
+
+  # Ignore Jenkins agent and grep cmd
+  ignore_str="not CommandLine like '%remoting.jar%' and \
+              not CommandLine like '%agent.jar%' and \
+              not CommandLine like '%grep%'"
+
+  C=`powershell -c "(Get-WmiObject Win32_Process -Filter {${ignore_str} and ${match_str}} | measure).count" | tr -d "\\\\r"`
+  
+  if [ $C -gt 0 ]; then
+      echo Windows rogue processes detected, attempting to stop them..
+      powershell -c "Get-WmiObject Win32_Process -Filter {${ignore_str} and ${match_str}}"
+      powershell -c "(Get-WmiObject Win32_Process -Filter {${ignore_str} and ${match_str}}).Terminate()"
+      uname | grep CYGWIN 2>/dev/null || uptime
+      sleep 10
+      uname | grep CYGWIN 2>/dev/null || uptime
+      C=`powershell -c "(Get-WmiObject Win32_Process -Filter {${ignore_str} and ${match_str}} | measure).count" | tr -d "\\\\r"`
+      if [ $C -gt 0 ]; then
+        echo "Cleanup failed, processes still remain..."
+        exit 127
+      fi 
+      echo "Processes stopped successfully"
+  else
+      echo Woohoo - no rogue processes detected
+  fi
+else
+  echo "Unix type machine.."
+
+  # Match anything that most likely jck test job or process related
+  # Note: On Solaris "other user" ps output trauncated to 80 chars, so this list
+  #       needs best attempt to match first part of command line
+  match_str="java.*jck|openjdkbinary.*java|java.*javatest|java.*-Xfuture|X.*vfb|rmid|rmiregistry|tnameserv|make"
+
+  # Ignore Jenkins agent and grep cmd
+  ignore_str="remoting.jar|agent.jar|grep"
+
+  # Fix For Issue https://github.com/adoptium/infrastructure/issues/2442 - Solaris PS Command Truncation
+  if [ `uname` = "SunOS" ]; then
+    PSCOMMAND="/usr/ucb/ps -auxww"
+  elif [ `uname` = "Darwin" ]; then
+    PSCOMMAND="ps -eo user,pid,lstart,command"
+  else
+    PSCOMMAND="ps -ef"
+  fi
+
+  if $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}"; then
+      echo Boooo - there are rogue processes kicking about
+      echo Issuing a kill to all processes shown above - though this will not terminate vfb processes on AIX as we are trying to debug source of leftovers there
+      $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}" | awk '{print $2}' | xargs -n1 kill
+      uname | grep CYGWIN 2>/dev/null || uptime
+      sleep 10
+      uname | grep CYGWIN 2>/dev/null || uptime
+      if $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}"; then
+        echo Still processes left going to remove those with kill -KILL ...
+        $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}" | awk '{print $2}' | xargs -n1 kill -KILL
+        echo DONE - One final check ...
+        if $PSCOMMAND | egrep "${match_str}" | egrep -v "${ignore_str}"; then
+          echo "Cleanup failed, processes still remain..."
+          exit 127
+        fi
+      fi
+      echo "Processes stopped successfully"
+  else
+      echo Woohoo - no rogue processes detected
+  fi
+fi
+
+exit 0
+

--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -3,7 +3,7 @@
 # Arg S1 : Unix current env.User
 
 # If Windows uses PowerShell
-if [ "$OSTYPE" = "cygwin" ]; then
+if [ "$OS" = "Windows_NT" ]; then
   echo "Windows machine, using powershell queries..."
 
   # Match anything that is most likely a test job or process related


### PR DESCRIPTION
Fixes: https://github.com/adoptium/aqa-tests/issues/4184

Enhances the pre/post PROCESSCATCH logic checking for more left over processes, in particular:
- "make" : stops repetitive process killing at end of failed/aborted test jobs
- "jck" extended processes
- more specific "java" process selection

Enhanced to better filter Jenkins Agent process, and utilise Windows enhanced powershell queries.
