### PR TITLE
Set AQA_TEST_PIPELINE Jenkins displayName if set

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -17,7 +17,7 @@ def TEST_FLAG = (params.TEST_FLAG) ?: ""
 
 // Use BUILD_USER_ID if set and jdk-JDK_VERSIONS
 def DEFAULT_SUFFIX = (env.BUILD_USER_ID) ? "${env.BUILD_USER_ID} - jdk-${params.JDK_VERSIONS}" : "jdk-${params.JDK_VERSIONS}"
-def PIPELINE_DISPLAY_NAME = (params.aaaPIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number} - ${DEFAULT_SUFFIX}"
+def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number} - ${DEFAULT_SUFFIX}"
 
 def JOBS = [:]
 

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -14,8 +14,14 @@ def TRSS_URL = params.TRSS_URL ? params.TRSS_URL : "https://trss.adoptium.net/"
 def LABEL = (params.LABEL) ?: ""
 def LABEL_ADDITION = (params.LABEL_ADDITION) ?: ""
 def TEST_FLAG = (params.TEST_FLAG) ?: ""
+def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ?: ""
 
 def JOBS = [:]
+
+// Set the AQA_TEST_PIPELINE Jenkins job displayName if set
+if (PIPELINE_DISPLAY_NAME != "") {
+    currentBuild.setDisplayName(PIPELINE_DISPLAY_NAME)
+}
 
 def suffix = ""
 if (TEST_FLAG) {

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -16,8 +16,8 @@ def LABEL_ADDITION = (params.LABEL_ADDITION) ?: ""
 def TEST_FLAG = (params.TEST_FLAG) ?: ""
 
 // Use BUILD_USER_ID if set as default PIPELINE_DISPLAY_NAME suffix
-def BUILD_USER_SUFFIX = (BUILD_USER_IDD) ? " - ${BUILD_USER_IDD}" : ""
-def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number}${BUILD_USER_SUFFIX}"
+//def BUILD_USER_SUFFIX = (BUILD_USER_IDD) ? " - ${BUILD_USER_IDD}" : ""
+def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number}${BUILD_USER_ID}"
 
 def JOBS = [:]
 

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -15,10 +15,9 @@ def LABEL = (params.LABEL) ?: ""
 def LABEL_ADDITION = (params.LABEL_ADDITION) ?: ""
 def TEST_FLAG = (params.TEST_FLAG) ?: ""
 
-// Use BUILD_USER_ID if set as default PIPELINE_DISPLAY_NAME suffix
-//def BUILD_USER_SUFFIX = (BUILD_USER_IDD) ? " - ${BUILD_USER_IDD}" : ""
-def BUILD_USER_SUFFIX = (env.BUILD_USER_ID) ? "${env.BUILD_USER_ID}" : "?"
-def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number}${BUILD_USER_SUFFIX}"
+// Use BUILD_USER_ID if set as default PIPELINE_DISPLAY_NAME suffix, otherwise use JDK_VERSIONS
+def DEFAULT_SUFFIX = (BUILD_USER_ID) ? "${BUILD_USER_ID}" : "jdk-${params.JDK_VERSIONS}"
+def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number} - ${DEFAULT_SUFFIX}"
 
 def JOBS = [:]
 

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -14,14 +14,15 @@ def TRSS_URL = params.TRSS_URL ? params.TRSS_URL : "https://trss.adoptium.net/"
 def LABEL = (params.LABEL) ?: ""
 def LABEL_ADDITION = (params.LABEL_ADDITION) ?: ""
 def TEST_FLAG = (params.TEST_FLAG) ?: ""
-def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ?: ""
+
+// Use BUILD_USER_ID if set as default PIPELINE_DISPLAY_NAME suffix
+def BUILD_USER_SUFFIX = (BUILD_USER_IDD) ? " - ${BUILD_USER_IDD}" : ""
+def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number}${BUILD_USER_SUFFIX}"
 
 def JOBS = [:]
 
-// Set the AQA_TEST_PIPELINE Jenkins job displayName if set
-if (PIPELINE_DISPLAY_NAME != "") {
-    currentBuild.setDisplayName(PIPELINE_DISPLAY_NAME)
-}
+// Set the AQA_TEST_PIPELINE Jenkins job displayName
+currentBuild.setDisplayName(PIPELINE_DISPLAY_NAME)
 
 def suffix = ""
 if (TEST_FLAG) {

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -17,7 +17,7 @@ def TEST_FLAG = (params.TEST_FLAG) ?: ""
 
 // Use BUILD_USER_ID if set as default PIPELINE_DISPLAY_NAME suffix
 //def BUILD_USER_SUFFIX = (BUILD_USER_IDD) ? " - ${BUILD_USER_IDD}" : ""
-def BUILD_USER_SUFFIX = (BUILD_USER_ID) ? "${BUILD_USER_ID}" : "?"
+def BUILD_USER_SUFFIX = (env.BUILD_USER_ID) ? "${env.BUILD_USER_ID}" : "?"
 def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number}${BUILD_USER_SUFFIX}"
 
 def JOBS = [:]

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -17,7 +17,8 @@ def TEST_FLAG = (params.TEST_FLAG) ?: ""
 
 // Use BUILD_USER_ID if set as default PIPELINE_DISPLAY_NAME suffix
 //def BUILD_USER_SUFFIX = (BUILD_USER_IDD) ? " - ${BUILD_USER_IDD}" : ""
-def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number}${BUILD_USER_ID}"
+def BUILD_USER_SUFFIX = (BUILD_USER_ID) ? "${BUILD_USER_ID}" : "?"
+def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number}${BUILD_USER_SUFFIX}"
 
 def JOBS = [:]
 

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -17,7 +17,7 @@ def TEST_FLAG = (params.TEST_FLAG) ?: ""
 
 // Use BUILD_USER_ID if set and jdk-JDK_VERSIONS
 def DEFAULT_SUFFIX = (env.BUILD_USER_ID) ? "${env.BUILD_USER_ID} - jdk-${params.JDK_VERSIONS}" : "jdk-${params.JDK_VERSIONS}"
-def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number} - ${DEFAULT_SUFFIX}"
+def PIPELINE_DISPLAY_NAME = (params.aaaPIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number} - ${DEFAULT_SUFFIX}"
 
 def JOBS = [:]
 

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -15,8 +15,8 @@ def LABEL = (params.LABEL) ?: ""
 def LABEL_ADDITION = (params.LABEL_ADDITION) ?: ""
 def TEST_FLAG = (params.TEST_FLAG) ?: ""
 
-// Use BUILD_USER_ID if set as default PIPELINE_DISPLAY_NAME suffix, otherwise use JDK_VERSIONS
-def DEFAULT_SUFFIX = (BUILD_USER_ID) ? "${BUILD_USER_ID}" : "jdk-${params.JDK_VERSIONS}"
+// Use BUILD_USER_ID if set and jdk-JDK_VERSIONS
+def DEFAULT_SUFFIX = (env.BUILD_USER_ID) ? "${env.BUILD_USER_ID} - jdk-${params.JDK_VERSIONS}" : "jdk-${params.JDK_VERSIONS}"
 def PIPELINE_DISPLAY_NAME = (params.PIPELINE_DISPLAY_NAME) ? "#${currentBuild.number} - ${params.PIPELINE_DISPLAY_NAME}" : "#${currentBuild.number} - ${DEFAULT_SUFFIX}"
 
 def JOBS = [:]


### PR DESCRIPTION
Add optional PIPELINE_DISPLAY_NAME to aqaTestPipeline to allow callers to optionally set the Jenkins displayName of the top level job to distinguish it.

Fixes #4181

Signed-off-by: Andrew Leonard <anleonar@redhat.com>