### PR TITLE
Re-enable jdk_vector tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -534,15 +534,6 @@ java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issue
 
 ############################################################################
 
-# jdk_vector
-
-jdk/incubator/vector/Byte128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
-jdk/incubator/vector/Byte256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
-jdk/incubator/vector/Int128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
-jdk/incubator/vector/Short256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
-
-############################################################################
-
 # serviceability
 
 serviceability/jvmti/GetLocalVariable/GetLocalVars.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -575,15 +575,6 @@ java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issue
 
 ############################################################################
 
-# jdk_vector
-
-jdk/incubator/vector/Byte128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
-jdk/incubator/vector/Byte256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
-jdk/incubator/vector/Int128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
-jdk/incubator/vector/Short256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/15268 generic-all
-
-############################################################################
-
 # serviceability
 
 serviceability/jvmti/GetLocalVariable/GetLocalVars.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all


### PR DESCRIPTION
Re-enable jdk_vector tests which have been disabled for jdk19 and jdk20 by https://github.com/adoptium/aqa-tests/pull/3750

Signed-off-by: Akira Saitoh <saiaki@jp.ibm.com>