### PR TITLE
Enable MauveMultiThrdLoad_5m

### DIFF
--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -99,13 +99,6 @@
 	</test>
 	<test>
 		<testCaseName>MauveMultiThrdLoad_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15253</comment>
-				<version>19+</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>


### PR DESCRIPTION
Enable `MauveMultiThrdLoad_5m`

closes https://github.com/eclipse-openj9/openj9/issues/15253

Signed-off-by: Jason Feng <fengj@ca.ibm.com>