### PR TITLE
Re-enable ThreadAPI test in JDK 20

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -152,9 +152,6 @@ java/lang/Thread/virtual/stress/Skynet.java#id0 https://github.com/eclipse-openj
 java/lang/Thread/virtual/stress/SleepALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/lang/Thread/virtual/stress/YieldALot.java#id0 https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
-java/lang/Thread/virtual/ThreadAPI.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
-java/lang/Thread/virtual/ThreadAPI.java#id0 https://github.com/eclipse-openj9/openj9/issues/15503 generic-all
-java/lang/Thread/virtual/ThreadAPI.java#id1 https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
 java/lang/Thread/virtual/ThreadLocals.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/lang/Thread/virtual/WaitNotify.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all


### PR DESCRIPTION
Closes: https://github.com/eclipse-openj9/openj9/issues/15503

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>