### PR TITLE
Add APPLICATION_OPTIONS to AqaTestPipeline

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -14,6 +14,7 @@ def TRSS_URL = params.TRSS_URL ? params.TRSS_URL : "https://trss.adoptium.net/"
 def LABEL = (params.LABEL) ?: ""
 def LABEL_ADDITION = (params.LABEL_ADDITION) ?: ""
 def TEST_FLAG = (params.TEST_FLAG) ?: ""
+def APPLICATION_OPTIONS = (params.APPLICATION_OPTIONS) ?: ""
 
 // Use BUILD_USER_ID if set and jdk-JDK_VERSIONS
 def DEFAULT_SUFFIX = (env.BUILD_USER_ID) ? "${env.BUILD_USER_ID} - jdk-${params.JDK_VERSIONS}" : "jdk-${params.JDK_VERSIONS}"
@@ -114,6 +115,7 @@ JDK_VERSIONS.each { JDK_VERSION ->
                         string(name: 'LABEL', value: LABEL),
                         string(name: 'LABEL_ADDITION', value: LABEL_ADDITION),
                         string(name: 'TEST_FLAG', value: TEST_FLAG),
+                        string(name: 'APPLICATION_OPTIONS', value: APPLICATION_OPTIONS),
                         booleanParam(name: 'KEEP_REPORTDIR', value: keep_reportdir)
                     ], wait: true
                     def result = downstreamJob.getResult()


### PR DESCRIPTION
Add the ability to pass APPLICATION_OPTIONS to AQA_TEST_PIPELINE for triggered test jobs.

Prereq for: https://github.com/adoptium/ci-jenkins-pipelines/pull/533

Signed-off-by: Andrew Leonard <anleonar@redhat.com>