### PR TITLE
Better determine concurrency from host environment to use for JavaTestRunner

### DIFF
--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -130,6 +130,10 @@ ifeq ($(OS),SunOS)
         NPROCS:=$(shell psrinfo | wc -l)
         MEMORY_SIZE:=$(shell prtconf | awk '/^Memory size:/{print int($$3/1024)}')
 endif
+ifeq ($(OS),AIX)
+        NPROCS:=$(shell lparstat -m | grep lcpu= | sed "s/.*\(lcpu=[0-9]*\).*/\1/" | cut -d'=' -f2)
+        MEMORY_SIZE:=$(shell lparstat -m | grep mem= | sed "s/.*\(mem=[0-9]*\).*/\1/" | cut -d'=' -f2)
+endif
 
 # Concurrency for Jck runner: min(NPROCS, MEM_IN_GB).
 # Note: Any concurrency=<int> specified in APPLICATIONS_OPTIONS or testsuite playlist will take precedence.

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -121,10 +121,7 @@ ifeq ($(OS),FreeBSD)
 endif
 ifeq ($(CYGWIN),1)
         NPROCS:=$(NUMBER_OF_PROCESSORS)
-        MEMORY_SIZE:=$(shell \
-                expr `wmic computersystem get totalphysicalmemory -value | grep = \
-                | cut -d "=" -f 2-` / 1024 / 1024 \
-                )
+        MEMORY_SIZE:=$(shell expr `wmic computersystem get totalphysicalmemory -value | grep "=" | cut -d"=" -f2 | tr -d '[:space:]'` / 1024 / 1024)
 endif
 ifeq ($(OS),SunOS)
         NPROCS:=$(shell psrinfo | wc -l)

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -31,15 +31,16 @@ ifeq ($(OS),FreeBSD)
 endif
 ifeq ($(CYGWIN),1)
  	NPROCS:=$(NUMBER_OF_PROCESSORS)
-	MEMORY_SIZE:=$(shell \
-		expr `wmic computersystem get totalphysicalmemory -value | grep = \
-		| cut -d "=" -f 2-` / 1024 / 1024 \
-		)
+	MEMORY_SIZE:=$(shell expr `wmic computersystem get totalphysicalmemory -value | grep "=" | cut -d"=" -f2 | tr -d '[:space:]'` / 1024 / 1024)
 endif
 ifeq ($(OS),SunOS)	
 	NPROCS:=$(shell psrinfo | wc -l)
 	MEMORY_SIZE:=$(shell prtconf | awk '/^Memory size:/{print int($$3/1024)}')
 endif	
+ifeq ($(OS),AIX)
+	NPROCS:=$(shell lparstat -m | grep lcpu= | sed "s/.*\(lcpu=[0-9]*\).*/\1/" | cut -d'=' -f2)
+	MEMORY_SIZE:=$(shell lparstat -m | grep mem= | sed "s/.*\(mem=[0-9]*\).*/\1/" | cut -d'=' -f2)
+endif
 ifeq ($(OS),OS/390)
 	EXTRA_OPTIONS += -Dcom.ibm.tools.attach.enable=yes
 endif


### PR DESCRIPTION
JavaTestRunner can use too high a concurrency based purely on CPU count, if such a host has insufficient memory it can cause memory starvation and Jenkins channel failures.

This PR based off the logic used in openjdk/openjdk.mk, optimises the concurrency to min(CPUs,MemInGb)

Signed-off-by: Andrew Leonard <anleonar@redhat.com>