### PR TITLE
Exclude jcstress_FencedDekkerTest for jdk 8+

### DIFF
--- a/system/jcstress/playlist.xml
+++ b/system/jcstress/playlist.xml
@@ -215,6 +215,13 @@
 		<testCaseName>jcstress_ThreadMXBeanAlloc</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(LIB_DIR)$(D)jcstress-tests-all-20220908.jar$(Q) $(APPLICATION_OPTIONS) -t ThreadMXBeanAlloc; \
 			$(TEST_STATUS)</command>
+		<disables>
+			<disable>
+				<comment>git_ibm/runtimes/backlog/issues/979</comment>
+				<impl>openj9</impl>
+				<version>8+</version>
+			</disable>
+		</disables>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -239,9 +246,9 @@
 			$(TEST_STATUS)</command>
 		<disables>
 			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/16178</comment>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/16178 runtimes/backlog/979</comment>
 				<impl>openj9</impl>
-				<version>11</version>
+				<version>8+</version>
 			</disable>
 		</disables>
 		<levels>
@@ -506,9 +513,9 @@
 			$(TEST_STATUS)</command>
 		<disables>
 			<disable>
-				<comment>git_ibm/runtimes/backlog/issues/973</comment>
+				<comment>git_ibm/runtimes/backlog/issues/973 and 979</comment>
 				<impl>openj9</impl>
-				<version>11</version>
+				<version>8+</version>
 			</disable>
 		</disables>
 		<levels>


### PR DESCRIPTION
- Exclude multiple jcstress tests for jdk 8+
- Related Issue: ibm_git/runtimes/backlog/issues/979

Signed-off-by: LongyuZhang <longyu.zhang@ibm.com>