### PR TITLE
Only display left over processes during end of test process check

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -830,7 +830,8 @@ def testExecution() {
 def terminateTestProcesses() {
 	echo "PROCESSCATCH: Terminating any hung/left over test processes:"
 
-        def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh ${env.USER} 2>&1", returnStatus:true)
+        // Only "DISPLAY" left over processes to avoid accidental sub-container process termination
+        def statusCode=sh(script:"aqa-tests/terminateTestProcesses.sh ${env.USER} DISPLAY 2>&1", returnStatus:true)
         if (statusCode != 0) {
                 echo "rc = ${statusCode}, Unable to terminate all processes."
         } 


### PR DESCRIPTION
The end of test left over process check that kills any remaining test processes, has the unfortunate consequence in an host environment where test sub-containers are also running tests, whereby the container processes are visible and can be accidentally terminated. So for the moment just display the left over processes, and not terminate them.

Resolves temurin-compliance issue: 282

Signed-off-by: Andrew Leonard <anleonar@redhat.com>