### PR TITLE
Un-exclude jdk19+ java/util/concurrent/tck/JSR166TestCase.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -439,7 +439,6 @@ java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse-openj9/
 java/util/concurrent/ArrayBlockingQueue/WhiteBox.java  https://github.com/eclipse-openj9/openj9/issues/5988  macosx-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclipse-openj9/openj9/issues/3209 generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all
-java/util/concurrent/tck/JSR166TestCase.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -470,7 +470,6 @@ java/util/concurrent/ArrayBlockingQueue/WhiteBox.java  https://github.com/eclips
 java/util/concurrent/ExecutorService/CloseTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclipse-openj9/openj9/issues/3209 generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all
-java/util/concurrent/tck/JSR166TestCase.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all
 java/util/concurrent/ThreadPerTaskExecutor/ThreadPerTaskExecutorTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all


### PR DESCRIPTION
https://github.com/adoptium/aqa-tests/pull/4187 unexcluded JSR166TestCase except on jdk19+ for Windows, but the test passes on Openj9 although it's excluded for Hotspot on all versions 9+.

Tested via grinder https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1743