### PR TITLE
Un-exclude java/util/concurrent/ArrayBlockingQueue/WhiteBox.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -352,7 +352,6 @@ java/util/Arrays/TimSortStackSize2.java	https://github.com/eclipse-openj9/openj9
 java/util/Arrays/largeMemory/ParallelPrefix.java https://github.com/eclipse-openj9/openj9/issues/4100 linux-ppc64le
 java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse-openj9/openj9/issues/4720 linux-all
 java/util/Spliterator/SpliteratorCollisions.java	https://github.com/eclipse-openj9/openj9/issues/7090	generic-all
-java/util/concurrent/ArrayBlockingQueue/WhiteBox.java 	https://github.com/eclipse-openj9/openj9/issues/5988 	macosx-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclipse-openj9/openj9/issues/3209	generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse-openj9/openj9/issues/7125	macosx-all,linux-all,aix-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -436,7 +436,6 @@ sun/security/krb5/auto/Cleaners.java https://github.com/eclipse-openj9/openj9/is
 java/util/Arrays/largeMemory/ParallelPrefix.java https://github.com/eclipse-openj9/openj9/issues/4100 linux-ppc64le
 java/util/Arrays/TimSortStackSize2.java https://github.com/eclipse-openj9/openj9/issues/7086 generic-all
 java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse-openj9/openj9/issues/4720 linux-all
-java/util/concurrent/ArrayBlockingQueue/WhiteBox.java  https://github.com/eclipse-openj9/openj9/issues/5988  macosx-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclipse-openj9/openj9/issues/3209 generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all
 java/util/concurrent/tck/JSR166TestCase.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -466,7 +466,6 @@ sun/security/krb5/auto/Cleaners.java https://github.com/eclipse-openj9/openj9/is
 java/util/Arrays/largeMemory/ParallelPrefix.java https://github.com/eclipse-openj9/openj9/issues/4100 linux-ppc64le
 java/util/Arrays/TimSortStackSize2.java https://github.com/eclipse-openj9/openj9/issues/7086 generic-all
 java/util/BitSet/stream/BitSetStreamTest.java https://github.com/eclipse-openj9/openj9/issues/4720 linux-all
-java/util/concurrent/ArrayBlockingQueue/WhiteBox.java  https://github.com/eclipse-openj9/openj9/issues/5988  macosx-all
 java/util/concurrent/ExecutorService/CloseTest.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclipse-openj9/openj9/issues/3209 generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all


### PR DESCRIPTION
It was unexcluded via https://github.com/adoptium/aqa-tests/pull/1350 but seems to have been accidentally re-excluded via
https://github.com/adoptium/aqa-tests/pull/1348

Tested via grinders
17: https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1744/
19: https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/1747/