### PR TITLE
Correct jck stage material checkout when target jck root not the same as the repo folder

### DIFF
--- a/jck/build.xml
+++ b/jck/build.xml
@@ -134,6 +134,7 @@
 					<arg value="-b"/>
 					<arg value="${jck_branch}"/>
 					<arg value="${JCK_GIT_REPO_USED}" />
+					<arg value="${JCK_ROOT_USED}" />
 				</exec>
 			</then>
 			<!-- jck materials exist, update jck materials if needed-->

--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -223,6 +223,7 @@ public class JavaTestRunner {
 					if (!jckVersion.equals(actualJckVersion)) {
 						System.out.println("test-args jckversion " + jckVersion + " does not match actual jckversion " + actualJckVersion + ". Using actual jckversion " + actualJckVersion);
 						jckVersion = actualJckVersion;
+						jckVersionNo = jckVersion.replace("jck", "");
 					}
 				}
 			}


### PR DESCRIPTION
Ensure jck material stage checkout specifies the target folder for the clone.
Fixes https://github.com/adoptium/aqa-tests/issues/4223

Signed-off-by: Andrew Leonard <anleonar@redhat.com>