### PR TITLE
Enable FFI test suites for JDK17, 19 and beyond

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -385,39 +385,15 @@ vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse-openj9/op
 ############################################################################
 
 # jdk_foreign
-java/foreign/TestArrays.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
-java/foreign/TestLayouts.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
-java/foreign/TestLayoutPaths.java	https://github.com/adoptium/aqa-tests/issues/1701	generic-all
-java/foreign/TestLayoutConstants.java	https://github.com/adoptium/aqa-tests/issues/1702	generic-all
-java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
+
 java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestDowncall.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestIntrinsics.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestMemoryAccess.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestNulls.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestResourceScope.java https://github.com/eclipse-openj9/openj9/issues/13234 generic-all
-java/foreign/TestUpcall.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestUpcallHighArity.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
-
-java/foreign/SafeFunctionAccessTest.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
-java/foreign/TestFree.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
-java/foreign/TestNULLAddress.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
-java/foreign/malloc/TestMixedMallocFree.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
-java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
-java/foreign/TestUpcallException.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
-java/foreign/ThrowingUpcall.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
-java/foreign/TestUpcallStructScope.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
-
+java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
+java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -472,44 +472,17 @@ vm/verifier/VerifyProtectedConstructor.java https://github.com/eclipse-openj9/op
 
 # jdk_foreign
 
-java/foreign/channels/TestAsyncSocketChannels.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj9/openj9/issues/14135 generic-all
-java/foreign/malloc/TestMixedMallocFree.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/SafeFunctionAccessTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
-java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestDowncall.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
-java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
-java/foreign/TestIntrinsics.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestMemoryAccess.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestNative.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestNULLAddress.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestNulls.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestSegmentAllocators.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
-java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
-java/foreign/TestUpcall.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcall.java#async https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestUpcall.java#no_scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestUpcall.java#scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestUpcallException.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcallHighArity.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcallStructScope.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-
-java/foreign/TestDowncallStack.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
+java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
+java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/16386 aix-ppc64
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -504,44 +504,17 @@ vm/verifier/VerifyProtectedConstructor.java https://github.com/eclipse-openj9/op
 
 # jdk_foreign
 
-java/foreign/channels/TestAsyncSocketChannels.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/loaderLookup/TestLoaderLookup.java https://github.com/eclipse-openj9/openj9/issues/14135 generic-all
-java/foreign/malloc/TestMixedMallocFree.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/SafeFunctionAccessTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
-java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestDowncall.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
-java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
-java/foreign/TestIntrinsics.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestMemoryAccess.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestNative.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestNULLAddress.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestNulls.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestSegmentAllocators.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestSegmentCopy.java https://github.com/eclipse-openj9/openj9/issues/14148 generic-all
-java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
-java/foreign/TestUpcall.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcall.java#async https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestUpcall.java#no_scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestUpcall.java#scope https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/TestUpcallException.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcallHighArity.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestUpcallStructScope.java https://github.com/eclipse-openj9/openj9/issues/13999 generic-all
-java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/14134 generic-all
-java/foreign/valist/VaListTest.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/virtual/TestVirtualCalls.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-
-java/foreign/TestDowncallStack.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
-java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issues/13994 generic-all
+java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
+java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
+java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/16386 aix-ppc64
 
 ############################################################################
 


### PR DESCRIPTION
The change is to enable the majority of FFI specific test suites except the Hotspot related tests plus
a couple of failing tests being investigated given everything intended for FFI has been implemented
in OpenJ9.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>