### PR TITLE
[FFI/Jtreg] Exclude TestResourceScope in JDK17

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -395,6 +395,7 @@ java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-op
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+java/foreign/TestResourceScope.java https://github.com/eclipse-openj9/openj9/issues/16551 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The change is to disable the test suite as the issue with the test code still exists in JDK17.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>