### PR TITLE
[Jtreg/FFI]Disable FFI test suites for JDK20+

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1453,6 +1453,13 @@
 	</test>
 	<test>
 		<testCaseName>jdk_foreign</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/16565</comment>
+				<version>20+</version>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>


### PR DESCRIPTION
The change is to exclude all FFI specific test suites for the moment as we have
been working on the changes based on the latest APIs in JEP424/JDK20.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>