### PR TITLE
Reenable JDK19 tests after the fix for eclipse-openj9/openj9#15251

### DIFF
--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -6,7 +6,7 @@
 	In order to save machine resources, exclude sharedClasses subfolder in parallel mode
 	To enable it, please update excludes array in JenkinsfileBase
 	-->
-	<!-- 
+	<!--
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	<test>
@@ -108,13 +108,6 @@
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClassesWorkloadTest_Softmx_Increase_JitAot; \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
-				<impl>openj9</impl>
-				<version>19+</version>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -129,13 +122,6 @@
 	</test>
 	<test>
 		<testCaseName>SC_Softmx_JitAot_Linux</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
-				<impl>openj9</impl>
-				<version>19+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -288,13 +274,6 @@
 		{ MXP_FLAG=$$(test $$(ulimit -u 2>/dev/null) $(AND_IF_SUCCESS) echo "-u" || echo "-p"); REQD_MXP=2048; if [ ! "$$(ulimit $$MXP_FLAG)" = "unlimited" ] $(AND_IF_SUCCESS) [ ! $$(ulimit $$MXP_FLAG) -gt $$REQD_MXP ]; then echo Attempting to increase max user processes from $$(ulimit $$MXP_FLAG) to $$REQD_MXP; ulimit $$MXP_FLAG $$REQD_MXP; echo max user processes now $$(ulimit $$MXP_FLAG); fi; }; \
 		$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM23,sharedClassTest=MultiThread$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
-				<impl>openj9</impl>
-				<version>19+</version>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -314,13 +293,6 @@
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=SharedClasses -test-args=$(Q)sharedClassMode=SCM23,sharedClassTest=MultiThreadMultiCL$(Q); \
 	$(TEST_STATUS)</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/15251</comment>
-				<impl>openj9</impl>
-				<version>19+</version>
-			</disable>
-		</disables>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
The following four tests are reenabled since
eclipse-openj9/openj9#15251 has been fixed.
Previously they were exclude in adoptium/aqa-tests#3750

SC_Softmx_JitAot
SC_Softmx_JitAot_Linux
SharedClasses.SCM23.MultiThread
SharedClasses.SCM23.MultiThreadMultiCL

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>