### PR TITLE
Disable TestDockerMemoryMetrics for OpenJ9 JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -384,3 +384,9 @@ com/sun/jndi/ldap/LdapDnsProviderTest.java https://github.com/adoptium/aqa-tests
 javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github.com/adoptium/aqa-tests/issues/2321 aix-all
 
 ############################################################################
+
+# jdk_docker
+
+jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/eclipse-openj9/openj9/issues/16460 generic-all
+
+############################################################################


### PR DESCRIPTION
OpenJDK needs to fix the implementation and test code.

Related: eclipse-openj9/openj9#16460

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>