### PR TITLE
Unexclude com/sun/jdi/RedefineCrossEvent.java on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -380,8 +380,6 @@ sun/jvmstat/monitor/MonitoredVm/CR6672135.java https://github.com/adoptium/aqa-t
 ###############################################################################
 # jdk_jdi
 
-com/sun/jdi/RedefineCrossEvent.java	https://bugs.openjdk.java.net/browse/JDK-8283479	generic-all
-
 com/sun/jdi/JdbMethodExitTest.sh                https://github.com/adoptium/aqa-tests/issues/2415 windows-all,linux-s390x
 com/sun/jdi/Redefine-g.sh                       https://github.com/adoptium/aqa-tests/issues/2415 windows-all,linux-s390x
 com/sun/jdi/AllLineLocations.java               https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x


### PR DESCRIPTION
Test com/sun/jdi/RedefineCrossEvent.java should no longer be excluded on JDK 8. It was fixed by:
https://bugs.openjdk.org/browse/JDK-8279669