### PR TITLE
Exclude api/java/util target from aarch64 mac on jdk11

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -614,7 +614,7 @@
 		<disables>
 			<disable>
 				<comment>Disabled on osx and win for backlog/issues/489. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows|x86-64_mac</platform>
+				<platform>x86-64_windows|x86-64_mac|aarch64_mac</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>


### PR DESCRIPTION
- Exclude api/java/util target from aarch64 mac on jdk11
- Related backlog/issues/489

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>