### PR TITLE
Avoid using realpath for JCK_ROOT

### DIFF
--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -56,7 +56,11 @@ ifneq (,$(findstring zos,$(SPEC)))
 endif
 
 ifndef JCK_ROOT
-  export JCK_ROOT=$(realpath $(TEST_ROOT)/../../../jck_root/JCK$(JDK_VERSION)-unzipped)
+   ifeq ($(CYGWIN),1)
+      export JCK_ROOT=$(TEST_ROOT)/../../../jck_root/JCK$(JDK_VERSION)-unzipped
+   else
+      export JCK_ROOT=$(realpath $(TEST_ROOT)/../../../jck_root/JCK$(JDK_VERSION)-unzipped)
+   endif 
   $(info JCK_ROOT is $(JCK_ROOT))
 endif
 


### PR DESCRIPTION
- Avoid using realpath while on Cygwin 
- Fixes : backlog/issues/1016.

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>