### PR TITLE
Unexclude com/sun/jdi tests on windows for JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -380,8 +380,8 @@ sun/jvmstat/monitor/MonitoredVm/CR6672135.java https://github.com/adoptium/aqa-t
 ###############################################################################
 # jdk_jdi
 
-com/sun/jdi/JdbMethodExitTest.sh                https://github.com/adoptium/aqa-tests/issues/2415 windows-all,linux-s390x
-com/sun/jdi/Redefine-g.sh                       https://github.com/adoptium/aqa-tests/issues/2415 windows-all,linux-s390x
+com/sun/jdi/JdbMethodExitTest.sh                https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/Redefine-g.sh                       https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
 com/sun/jdi/AllLineLocations.java               https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
 com/sun/jdi/EarlyReturnTest.java                https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
 com/sun/jdi/MethodExitReturnValuesTest.java     https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
@@ -391,40 +391,6 @@ com/sun/jdi/PopAsynchronousTest.java            https://github.com/adoptium/aqa-
 com/sun/jdi/PopSynchronousTest.java             https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
 com/sun/jdi/RedefineCrossStart.java             https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
 com/sun/jdi/redefineMethod/RedefineTest.java    https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/RedefineMulti.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefinePop.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineStep.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineTTYLineNumber.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/StringConvertTest.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/WatchFramePop.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/ArrayLengthDumpTest.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/BreakpointWithFullGC.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/CatchAllTest.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/CatchCaughtTest.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/CatchPatternTest.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/CommandCommentDelimiter.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/DeoptimizeWalk.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/EvalArgs.sh				https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/EvalArraysAsList.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/EvalInterfaceStatic.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/GetLocalVariables3Test.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/GetLocalVariables4Test.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/JdbLockTest.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/JdbMissStep.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/JdbVarargsTest.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/MixedSuspendTest.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/NotAField.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/NullLocalVariable.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineAbstractClass.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineAddPrivateMethod.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineAnnotation.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineChangeClassOrder.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineClasses.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineClearBreakpoint.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineException.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineFinal.sh			https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineImplementor.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
-com/sun/jdi/RedefineIntConstantToLong.sh	https://github.com/adoptium/aqa-tests/issues/2415 windows-all
 com/sun/jdi/PrivateTransportTest.sh             https://github.com/adoptium/aqa-tests/issues/2154 windows-all
 com/sun/jdi/DoubleAgentTest.java https://github.com/adoptium/aqa-tests/issues/155 generic-all
 ############################################################################


### PR DESCRIPTION
Problem with jdi tests on windows has been fixed by  JDK-8295164 [1]. These tests are part of jdk/tier1 and are being ran as part of testing in GitHub CI on jdk8u-dev since.  Also comment in referenced aqa-tests issue says, that tests can be removed from list, once that JDK issue is fixed.

Fixes https://github.com/adoptium/aqa-tests/issues/2415

[1] https://bugs.openjdk.org/browse/JDK-8295164
[2] https://github.com/adoptium/aqa-tests/issues/2415#issuecomment-1277685526