### PR TITLE
Unexclude com/sun/jdi/DoubleAgentTest.java on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -426,7 +426,6 @@ com/sun/jdi/RedefineFinal.sh			https://github.com/adoptium/aqa-tests/issues/2415
 com/sun/jdi/RedefineImplementor.sh		https://github.com/adoptium/aqa-tests/issues/2415 windows-all
 com/sun/jdi/RedefineIntConstantToLong.sh	https://github.com/adoptium/aqa-tests/issues/2415 windows-all
 com/sun/jdi/PrivateTransportTest.sh             https://github.com/adoptium/aqa-tests/issues/2154 windows-all
-com/sun/jdi/DoubleAgentTest.java https://github.com/adoptium/aqa-tests/issues/155 generic-all
 ############################################################################
 
 # jdk_util


### PR DESCRIPTION
Test used to be unstable, but backport of JDK-8054066 was done to fix it [1]. (Backport basically rewrites it from scratch.) It seems it is stable now.

Fixes #155 

[1] https://github.com/openjdk/jdk8u-dev/pull/143
