### PR TITLE
Unexclude compiler/rtm tests on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -88,10 +88,6 @@ runtime/SharedArchiveFile/SpaceUtilizationCheck.java https://github.com/adoptium
 serviceability/jvmti/TestRedefineWithUnresolvedClass.java	https://github.com/adoptium/aqa-tests/issues/124	generic-all
 serviceability/jvmti/GetObjectSizeOverflow.java	https://github.com/adoptium/aqa-tests/issues/124	linux-all
 serviceability/sa/jmap-hashcode/Test8028623.java	https://github.com/adoptium/aqa-tests/issues/124	linux-all
-compiler/rtm/locking/TestUseRTMAfterLockInflation.java https://bugs.openjdk.java.net/browse/JDK-8180723 generic-all
-compiler/rtm/locking/TestUseRTMForInflatedLocks.java https://bugs.openjdk.java.net/browse/JDK-8180723 generic-all
-compiler/rtm/locking/TestUseRTMForStackLocks.java https://bugs.openjdk.java.net/browse/JDK-8180723 generic-all
-compiler/rtm/method_options/TestUseRTMLockElidingOption.java https://bugs.openjdk.java.net/browse/JDK-8180723 generic-all
 runtime/7110720/Test7110720.sh https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/6894807/IsInstanceTest.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/8004051/Test8004051.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
@@ -131,7 +127,6 @@ runtime/NMT/HugeArenaTracking.java	https://github.com/adoptium/aqa-tests/issues/
 gc/concurrentMarkSweep/GuardShrinkWarning.java https://bugs.openjdk.java.net/browse/JDK-8023356 solaris-x64
 compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 compiler/floatingpoint/8165673/TestFloatJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
-compiler/rtm/locking/TestRTMTotalCountIncrRate.java https://github.com/adoptium/aqa-tests/issues/3050 linux-all,windows-all
 compiler/intrinsics/mathexact/LongMulOverflowTest.java https://bugs.openjdk.org/browse/JDK-8196568 solaris-x64
 #https://github.com/adoptium/aqa-tests/issues/3629,https://github.com/adoptium/aqa-tests/issues/3905
 runtime/containers/docker/TestMemoryAwareness.java https://bugs.openjdk.java.net/browse/JDK-8229182 generic-all


### PR DESCRIPTION
Compiler/rtm tests can be removed from exclude list of JDK8 in aqa-tests. They were excluded in jdk8u itself as part of effort to fix hotspot/tier1. See: https://bugs.openjdk.org/browse/JDK-8295915