### PR TITLE
Un-exclude api-java_util on win and mac

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -613,12 +613,6 @@
 		<testCaseName>jck-runtime-api-java_util</testCaseName>
 		<disables>
 			<disable>
-				<comment>Disabled on osx and win for backlog/issues/489. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
-				<platform>x86-64_windows|x86-64_mac</platform>
-				<version>11</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
 				<comment>Disabled on z/OS due to backlog/issues/732</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>


### PR DESCRIPTION
Un-exclude api-java_util on win and mac as related issue is fixed : backlog/issues/489

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>

FYI @JasonFengJ9 