### PR TITLE
Unexclude gc/metaspace/TestCapacityUntilGCWrapAround.java on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -20,7 +20,6 @@ compiler/intrinsics/sha/TestSHA.java	https://github.com/adoptium/aqa-tests/issue
 
 # hotspot_jre
 
-gc/metaspace/TestCapacityUntilGCWrapAround.java https://bugs.openjdk.java.net/browse/JDK-8226236 windows-x86
 gc/g1/TestShrinkAuxiliaryData05.java https://github.com/adoptium/aqa-tests/issues/110 generic-all
 gc/g1/TestShrinkAuxiliaryData10.java https://github.com/adoptium/aqa-tests/issues/110 generic-all
 gc/g1/TestShrinkAuxiliaryData15.java https://github.com/adoptium/aqa-tests/issues/110 generic-all


### PR DESCRIPTION
Failure of `gc/metaspace/TestCapacityUntilGCWrapAround.java` on windows x86 has been fixed by JDK-8226236 backport:
https://github.com/openjdk/jdk8u-dev/pull/192