### PR TITLE
Unexclude runtime/NMT/HugeArenaTracking.java windows-x86 on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -126,8 +126,7 @@ gc/arguments/TestCMSHeapSizeFlags.java https://github.com/adoptium/aqa-tests/iss
 gc/arguments/TestG1HeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
 gc/arguments/TestParallelHeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
 gc/arguments/TestSerialHeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
-#runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/infrastructure/issues/2565 solaris-x64
-runtime/NMT/HugeArenaTracking.java	https://github.com/adoptium/aqa-tests/issues/2650 windows-x86,solaris-x64
+runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/infrastructure/issues/2565 solaris-x64
 gc/concurrentMarkSweep/GuardShrinkWarning.java https://bugs.openjdk.java.net/browse/JDK-8023356 solaris-x64
 compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 compiler/floatingpoint/8165673/TestFloatJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all


### PR DESCRIPTION
Test `runtime/NMT/HugeArenaTracking.java` was fixed on windows-x86 + JDK8 by JDK-8241086 backport:
https://github.com/openjdk/jdk8u-dev/pull/182

Fixes https://github.com/adoptium/aqa-tests/issues/2650 

(kept excluded on solaris-x64 - that is separate issue)