### PR TITLE
Re-enable JVMTI tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -532,7 +532,6 @@ serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java https://githu
 serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
-serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/SetGetThreadLocalStorageStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://github.com/eclipse-openj9/openj9/issues/16185 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/eclipse-openj9/openj9/issues/16185 generic-all
@@ -540,15 +539,11 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https:/
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java https://github.com/eclipse-openj9/openj9/issues/16242 generic-all
-serviceability/jvmti/vthread/BreakpointInYieldTest/BreakpointInYieldTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.java https://github.com/eclipse-openj9/openj9/issues/16215 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
-serviceability/jvmti/vthread/NullAsCurrentThreadTest/NullAsCurrentThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
-serviceability/jvmti/vthread/RawMonitorTest/RawMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
-serviceability/jvmti/vthread/VThreadUnsupportedTest/VThreadUnsupportedTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -564,7 +564,6 @@ serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java https://githu
 serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
-serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/stress/ThreadLocalStorage/SetGetThreadLocalStorageStressTest/SetGetThreadLocalStorageStressTest.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://github.com/eclipse-openj9/openj9/issues/16185 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/eclipse-openj9/openj9/issues/16185 generic-all
@@ -572,15 +571,11 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https:/
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java https://github.com/eclipse-openj9/openj9/issues/16242 generic-all
-serviceability/jvmti/vthread/BreakpointInYieldTest/BreakpointInYieldTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.java https://github.com/eclipse-openj9/openj9/issues/16215 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
-serviceability/jvmti/vthread/NullAsCurrentThreadTest/NullAsCurrentThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
-serviceability/jvmti/vthread/RawMonitorTest/RawMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
-serviceability/jvmti/vthread/VThreadUnsupportedTest/VThreadUnsupportedTest.java https://github.com/eclipse-openj9/openj9/issues/16167 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 


### PR DESCRIPTION
The below tests successfully pass with the implementation of 
VirtualThread[M|Unm]ount and Get[Virtual|Carrier]Thread:

- BreakpointInYieldTest.java
- NullAsCurrentThreadTest.java
- VThreadUnsupportedTest.java
- GetStackTraceSuspendedStressTest.java
- RawMonitorTest.java

Related: https://github.com/eclipse-openj9/openj9/pull/16501
Related: https://github.com/eclipse-openj9/openj9/pull/16518

Signed-off-by: Dipak Bagadiya <dipak.bagadiya@ibm.com>