### PR TITLE
Unexclude compiler tests with 64K page size fix on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -111,12 +111,6 @@ compiler/gcbarriers/PreserveFPRegistersTest.java https://github.com/adoptium/aqa
 gc/TestMemoryMXBeansAndPoolsPresence.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/g1/mixedgc/TestOldGenCollectionUsage.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 runtime/CompressedOops/CompressedClassPointers.java https://bugs.openjdk.org/browse/JDK-8234058 linux-ppc64le,aix-all
-compiler/6865265/StackOverflowBug.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
-compiler/8009761/Test8009761.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
-compiler/exceptions/TestRecursiveReplacedException.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
-compiler/uncommontrap/StackOverflowGuardPagesOff.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
-compiler/uncommontrap/TestStackBangMonitorOwned.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
-compiler/uncommontrap/TestStackBangRbp.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
 gc/arguments/TestCMSHeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
 gc/arguments/TestG1HeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
 gc/arguments/TestParallelHeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le


### PR DESCRIPTION
Few compiler tests used to fail on systems with 64K page size as requested stack size was too small. (We have also seen these failures on rhel-8 aarch64, which uses 64K page size.) Problem has been fixed for JDK8 by [JDK-8067941](https://bugs.openjdk.org/browse/JDK-8067941) backport.

This fixes one category of failures described in: https://github.com/adoptium/aqa-tests/issues/3059