### PR TITLE
[Jtreg/FFI] Disable FFI related test suite in JDK20

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -160,6 +160,8 @@ jdk/modules/etc/DefaultModules.java https://github.com/eclipse-openj9/openj9/iss
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/16656 generic-all
+
 ############################################################################
 
 # jdk_internal


### PR DESCRIPTION
The change is to exclude the FFI related test cases in AttachTest.java captured at
https://github.com/eclipse-openj9/openj9/issues/16656 given the FFI related code
in JDK20 has been disabled for the moment and will be enabled once the code
has been updated against the latest APIs.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>