### PR TITLE
Move targets that take 30s or less to sanity

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -86,7 +86,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_tools testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>
@@ -108,7 +108,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=api/signaturetest testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>

--- a/jck/devtools.java2schema/playlist.xml
+++ b/jck/devtools.java2schema/playlist.xml
@@ -38,7 +38,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=java2schema/DefaultMapping testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>

--- a/jck/devtools.schema_bind/playlist.xml
+++ b/jck/devtools.schema_bind/playlist.xml
@@ -56,7 +56,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=schema_bind/bind_factoryMethod testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -389,7 +389,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=api/java_applet testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>
@@ -646,7 +646,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_accessibility testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>
@@ -677,7 +677,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_activity testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>
@@ -694,7 +694,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_annotation testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>
@@ -966,7 +966,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_tools testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>

--- a/jck/runtime.xml_schema/playlist.xml
+++ b/jck/runtime.xml_schema/playlist.xml
@@ -22,7 +22,7 @@
 		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/boeingData testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>jck</group>


### PR DESCRIPTION
Since extended build runs only weekly, while sanity runs daily, it's a good idea to move fast running (e.g. duration <=30s) targets to sanity, to increase daily test coverage. This PR proposes to move the following targets to sanity bucket: 

- jck-runtime-api-javax_accessibility - takes ~23s on z/OS 
- jck-runtime-api-java_applet - 30s on z/OS 
- jck-compiler-api-signaturetest ~26s on z/OS 
- jck-runtime-api-javax_annotation ~30s on z/OS 
- jck-devtools-java2schema-DefaultMapping ~22s on Win 
- jck-devtools-schema_bind-bind_factoryMethod ~ 25s on Win
- jck-compiler-api-javax_tools ~25s on Win 
- jck-runtime-api-javax_tools ~29s on Win
- jck-runtime-api-javax_activity ~20s on Win 
- jck-runtime-xml_schema-boeingData ~24s on Win 

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>