### PR TITLE
[Jtreg/FFI] update the issue no for FFI test suites in JDK20

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -160,7 +160,7 @@ jdk/modules/etc/DefaultModules.java https://github.com/eclipse-openj9/openj9/iss
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/16656 generic-all
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/16565 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The change updates the issue no by replacing
#16656 with #16565 as #16656 will be closed
as duplicate of #16565, in which case #16565
serves as the only issue that keeps track of
the excluded FFI test suites in JDK20.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>