### PR TITLE
Re-enable Loom tests with Invalid JIT return address

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -113,10 +113,7 @@ java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/
 java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/11930 generic-all
 java/lang/Thread/virtual/PreviewFeaturesNotEnabled.java https://github.com/eclipse-openj9/openj9/issues/16044 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
-java/lang/Thread/virtual/stress/PingPong.java https://github.com/eclipse-openj9/openj9/issues/15939 generic-all
-java/lang/Thread/virtual/stress/Skynet.java#id0 https://github.com/eclipse-openj9/openj9/issues/15938 generic-all
-java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15939 generic-all
-java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
+java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all


### PR DESCRIPTION
Tests excluded due https://github.com/eclipse-openj9/openj9/issues/15939 are fixed by https://github.com/eclipse-openj9/openj9/pull/16374

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>