### PR TITLE
Exclude jtreg testcase TestObjectDescription.java for jdk8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -413,7 +413,7 @@ jdk/jfr/event/gc/stacktrace/TestG1OldAllocationPendingStackTrace.java https://gi
 jdk/jfr/event/gc/stacktrace/TestG1YoungAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/stacktrace/TestMetaspaceG1GCAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
-jdk/jfr/event/oldobject/TestObjectDescription.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
+jdk/jfr/event/oldobject/TestObjectDescription.java https://github.com/adoptium/aqa-tests/issues/3301,https://github.com/adoptium/aqa-tests/issues/4342 generic-all
 jdk/jfr/event/os/TestCPUInformation.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/runtime/TestSizeTFlags.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/jvm/TestLargeJavaEvent512k.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -413,7 +413,7 @@ jdk/jfr/event/gc/stacktrace/TestG1OldAllocationPendingStackTrace.java https://gi
 jdk/jfr/event/gc/stacktrace/TestG1YoungAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/stacktrace/TestMetaspaceG1GCAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
-jdk/jfr/event/oldobject/TestObjectDescription.java https://github.com/adoptium/aqa-tests/issues/3301,https://github.com/adoptium/aqa-tests/issues/4342 generic-all
+jdk/jfr/event/oldobject/TestObjectDescription.java https://github.com/adoptium/aqa-tests/issues/3301,https://github.com/alibaba/dragonwell8/issues/473 linux-arm,generic-all
 jdk/jfr/event/os/TestCPUInformation.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/runtime/TestSizeTFlags.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/jvm/TestLargeJavaEvent512k.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -413,7 +413,7 @@ jdk/jfr/event/gc/stacktrace/TestG1OldAllocationPendingStackTrace.java https://gi
 jdk/jfr/event/gc/stacktrace/TestG1YoungAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/stacktrace/TestMetaspaceG1GCAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
-jdk/jfr/event/oldobject/TestObjectDescription.java https://github.com/adoptium/aqa-tests/issues/3301,https://github.com/alibaba/dragonwell8/issues/473 linux-arm,generic-all
+jdk/jfr/event/oldobject/TestObjectDescription.java https://github.com/adoptium/aqa-tests/issues/4352 generic-all
 jdk/jfr/event/os/TestCPUInformation.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/runtime/TestSizeTFlags.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/jvm/TestLargeJavaEvent512k.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm


### PR DESCRIPTION
Exclude jtreg testcase jdk/jfr/event/oldobject/TestObjectDescription.java for jdk8, which run timeout

Fixes: #4342