### PR TITLE
Add jdk replacement for PingPerf Test

### DIFF
--- a/external/criu/playlist.xml
+++ b/external/criu/playlist.xml
@@ -15,7 +15,7 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
 	<test>
 		<testCaseName>criu_pingPerf_testCreateImageAndUnprivilegedRestore</testCaseName>
-		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndUnprivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip; \
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndUnprivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_JDK_HOME); \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>
@@ -31,7 +31,7 @@
 	</test>
 	<test>
 		<testCaseName>criu_pingPerf_testCreateImageAndPrivilegedRestore</testCaseName>
-		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndPrivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip; \
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndPrivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_JDK_HOME); \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>
@@ -52,7 +52,7 @@
 				<comment>runtimes_backlog_issues_879</comment>
 			</disable>
 		</disables>
-		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateRestoreImageOnly $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip; \
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateRestoreImageOnly $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_JDK_HOME); \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>


### PR DESCRIPTION
- Add PingPerf test jdk replacement
- Related Issue: git_ibm/runtimes/backlog/issues/989