### PR TITLE
Exclude unstable Loom tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -113,6 +113,8 @@ java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/
 java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/11930 generic-all
 java/lang/Thread/virtual/PreviewFeaturesNotEnabled.java https://github.com/eclipse-openj9/openj9/issues/16044 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
+java/lang/Thread/virtual/stress/Skynet.java https://github.com/eclipse-openj9/openj9/issues/16728 generic-all
+java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/16729 macosx-x64
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all


### PR DESCRIPTION
- Skynet: timeout due to perf (https://github.com/eclipse-openj9/openj9/issues/16728)
- TimedGet: failure on mac-x86 (https://github.com/eclipse-openj9/openj9/issues/16729)

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>