### PR TITLE
Exclude java/lang/annotation/LoaderLeakTest on OpenJ9 jdk11

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -70,6 +70,7 @@ java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse-openj9/open
 java/lang/Throwable/SuppressedExceptions.java	https://github.com/eclipse-openj9/openj9/issues/6692	generic-all
 java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/annotation/loaderLeak/Main.java	https://github.com/eclipse-openj9/openj9/issues/6701	generic-all
+java/lang/annotation/LoaderLeakTest.java	https://github.com/eclipse-openj9/openj9/issues/13201	generic-all
 java/lang/invoke/AccessControlTest.java	https://github.com/adoptium/aqa-tests/issues/1285	generic-all
 java/lang/invoke/ArrayConstructorTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/invoke/CallerSensitiveAccess.java	https://github.com/eclipse-openj9/openj9/issues/6768	generic-all


### PR DESCRIPTION
It's excluded on jdk17+. The test is added to jdk11 in 11.0.19.

Issue https://github.com/eclipse-openj9/openj9/issues/13201