### PR TITLE
Add portable PingPerf tests for CRIU unprivileged and privileged restore

### DIFF
--- a/external/criu/pingPerf.sh
+++ b/external/criu/pingPerf.sh
@@ -16,6 +16,21 @@ set -e
 
 pingPerfZipPath=""
 testJDKPath=""
+restoreImage="ol-instanton-test-pingperf-restore"
+job_name=""
+build_number=""
+docker_registry_dir=""
+docker_os="ubi"
+node_label_current_os=""
+node_label_micro_architecture=""
+restore_docker_image_name_list=()
+
+getCriuseccompproFile() {
+    if [[ ! -f "criuseccompprofile.json" ]]; then
+        curl -OLJSks https://github.com/eclipse-openj9/openj9/files/8774222/criuseccompprofile.json.txt
+        mv criuseccompprofile.json.txt criuseccompprofile.json
+    fi
+}
 
 prepare() {
     echo "prepare at $(pwd)..."
@@ -28,8 +43,8 @@ prepare() {
         exit 1
     fi
 
-    curl -OLJSks https://github.com/eclipse-openj9/openj9/files/8774222/criuseccompprofile.json.txt
-    mv criuseccompprofile.json.txt criuseccompprofile.json
+    getCriuseccompproFile
+
     git clone https://github.com/OpenLiberty/ci.docker.git
     (
         cd ci.docker || exit
@@ -58,14 +73,14 @@ buildImage() {
 }
 
 createRestoreImage() {
-    echo "create restore image ..."
+    echo "create restore image $restoreImage ..."
     sudo podman run --name ol-instanton-test-checkpoint-container --privileged --env WLP_CHECKPOINT=applications ol-instanton-test-pingperf:latest
-    sudo podman commit ol-instanton-test-checkpoint-container ol-instanton-test-pingperf-restore
+    sudo podman commit ol-instanton-test-checkpoint-container $restoreImage
     sudo podman rm ol-instanton-test-checkpoint-container
 }
 
 unprivilegedRestore() {
-    echo "unprivileged restore ..."
+    echo "unprivileged restore $restoreImage ..."
     echo -ne "CONTAINER_ID=" > containerId.log
     sudo podman run \
         --rm \
@@ -75,18 +90,18 @@ unprivilegedRestore() {
         --cap-add=NET_ADMIN \
         --cap-add=SYS_PTRACE \
         --security-opt seccomp=criuseccompprofile.json \
-        ol-instanton-test-pingperf-restore >> containerId.log
+        $restoreImage >> containerId.log
 }
 
 privilegedRestore() {
-    echo "privileged restore ..."
+    echo "privileged restore $restoreImage ..."
     echo -ne "CONTAINER_ID=" > containerId.log
     sudo podman run \
         --rm \
         --detach \
         --privileged \
         -p 9080:9080 \
-        ol-instanton-test-pingperf-restore >> containerId.log
+        $restoreImage >> containerId.log
 }
 
 response() {
@@ -123,6 +138,101 @@ testCreateRestoreImageOnly() {
     createRestoreImage
 }
 
+dockerRegistryLogin() {
+    if [[ $DOCKER_REGISTRY_URL ]]; then
+        echo "Private Docker Registry $DOCKER_REGISTRY_URL login..."
+        echo $DOCKER_REGISTRY_CREDENTIALS_PSW | sudo podman login --username=$DOCKER_REGISTRY_CREDENTIALS_USR --password-stdin $DOCKER_REGISTRY_URL
+    else
+        echo "DOCKER_REGISTRY_URL is not set. Cannot lgoin."
+        exit 1
+    fi
+}
+
+dockerRegistryLogout() {
+    if [[ $DOCKER_REGISTRY_URL ]]; then
+        sudo podman logout $DOCKER_REGISTRY_URL
+    else
+        echo "DOCKER_REGISTRY_URL is not set. Cannot logout."
+        exit 1
+    fi
+}
+
+pushImage() {
+    dockerRegistryLogin
+    echo "Pushing docker image..."
+
+    restore_ready_checkpoint_image_folder="${DOCKER_REGISTRY_URL}/${job_name}/pingperf_${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${PLATFORM}-${node_label_current_os}-${node_label_micro_architecture}"
+    tagged_restore_ready_checkpoint_image_num="${restore_ready_checkpoint_image_folder}:${build_number}"
+    tagged_restore_ready_checkpoint_image_latest="${restore_ready_checkpoint_image_folder}:latest"
+
+    # Push a docker image with build_num for records
+    echo "tag $restoreImage $tagged_restore_ready_checkpoint_image_num"
+    sudo podman tag $restoreImage $tagged_restore_ready_checkpoint_image_num
+    echo "Pushing docker image ${tagged_restore_ready_checkpoint_image_num}"
+    sudo podman push $tagged_restore_ready_checkpoint_image_num
+
+    if [[ "$job_name" == *"criu_image_upload"* ]]; then
+        # Push another copy as the nightly default latest
+        echo "tag $tagged_restore_ready_checkpoint_image_num $tagged_restore_ready_checkpoint_image_latest"
+        sudo podman tag $tagged_restore_ready_checkpoint_image_num $tagged_restore_ready_checkpoint_image_latest
+        echo "Pushing docker image ${tagged_restore_ready_checkpoint_image_latest} to docker registry"
+        sudo podman push $tagged_restore_ready_checkpoint_image_latest
+    fi
+
+    dockerRegistryLogout
+}
+
+getImageNameList() {
+    if [ ! -z "${docker_registry_dir}" ]; then
+        echo "Testing image from specified docker_registry_dir: $docker_registry_dir"
+        restore_docker_image_name_list+=("${DOCKER_REGISTRY_URL}/${docker_registry_dir}")
+	else
+        echo "Testing images from nightly builds"
+        image_os_combo_list=($CRIU_XLINUX_COMBO_LIST)
+        for image_os_combo in ${image_os_combo_list[@]}
+        do
+            restore_docker_image_name_list+=("${DOCKER_REGISTRY_URL}/criu_image_upload/pingperf_${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${PLATFORM}-${image_os_combo}:latest")
+        done
+    fi
+}
+
+pullImageUnprivilegedRestore() {
+    dockerRegistryLogin
+    getImageNameList
+    echo "The host machine micro-architecture is ${node_label_micro_architecture}"
+    for restore_docker_image_name in ${restore_docker_image_name_list[@]}
+    do
+        echo "Pulling image $restore_docker_image_name"
+        sudo podman pull $restore_docker_image_name
+        getCriuseccompproFile
+
+        # restore
+        restoreImage=$restore_docker_image_name
+        testUnprivilegedRestoreOnly
+        clean
+    done
+
+    dockerRegistryLogout
+}
+
+pullImagePrivilegedRestore() {
+    dockerRegistryLogin
+    getImageNameList
+    echo "The host machine micro-architecture is ${node_label_micro_architecture}"
+    for restore_docker_image_name in ${restore_docker_image_name_list[@]}
+    do
+        echo "Pulling image $restore_docker_image_name"
+        sudo podman pull $restore_docker_image_name
+
+        # restore
+        restoreImage=$restore_docker_image_name
+        testPrivilegedRestoreOnly
+        clean
+    done
+
+    dockerRegistryLogout
+}
+
 testUnprivilegedRestoreOnly() {
     unprivilegedRestore
     response
@@ -143,6 +253,40 @@ testCreateImageAndUnprivilegedRestore() {
 testCreateImageAndPrivilegedRestore() {
     testCreateRestoreImageOnly
     testPrivilegedRestoreOnly
+}
+
+setup() {
+    echo "NODE_LABELS: $NODE_LABELS"
+    echo "PLATFORM: $PLATFORM"
+    echo "uname -a: $(uname -a)"
+    
+    if [ -n "$(cat /etc/redhat-release | grep 'Red Hat')" ]; then
+        cat /etc/redhat-release
+    fi
+
+    if [ ! -z "${docker_registry_dir}" ]; then
+        docker_registry_dir=$(echo "$docker_registry_dir" | tr '[:upper:]' '[:lower:]')  # docker registry link must be lowercase
+        IFS=':' read -r -a dir_array <<< "$docker_registry_dir"
+        job_name=${dir_array[0]}
+        build_number=${dir_array[1]}
+        echo "job_name: $job_name"
+        echo "build_number: $build_number"
+    fi
+
+    node_label_micro_architecture=""
+    node_label_current_os=""
+    for label in $NODE_LABELS
+    do 
+        if [[ -z "$node_label_micro_architecture" && "$label" == "hw.arch."*"."* ]]; then #hw.arch.x86.skylake
+            node_label_micro_architecture=$label
+            echo "node_label_micro_architecture is $node_label_micro_architecture"
+        elif [[ -z "$node_label_current_os" && "$label" == "sw.os."*"."* ]]; then # sw.os.ubuntu.22 sw.os.rhel.8
+            node_label_current_os=$label
+            echo "node_label_current_os is $node_label_current_os"
+        elif [[ -n "$node_label_current_os" && -n "$node_label_micro_architecture" ]]; then
+            break
+        fi
+    done
 }
 
 if [ "$1" == "prepare" ]; then
@@ -171,6 +315,21 @@ elif [ "$1" == "testUnprivilegedRestoreOnly" ]; then
     testUnprivilegedRestoreOnly
 elif [ "$1" == "testPrivilegedRestoreOnly" ]; then
     testPrivilegedRestoreOnly
+elif [ "$1" == "pullImageUnprivilegedRestore" ]; then
+    docker_registry_dir=$2 #docker_registry_dir can be empty
+    setup
+    pullImageUnprivilegedRestore
+elif [ "$1" == "pullImagePrivilegedRestore" ]; then
+    docker_registry_dir=$2 #docker_registry_dir can be empty
+    setup
+    pullImagePrivilegedRestore
+elif [ "$1" == "testCreateRestoreImageAndPushToRegistry" ]; then
+    pingPerfZipPath=$2
+    testJDKPath=$3
+    docker_registry_dir=$4
+    setup
+    testCreateRestoreImageOnly
+    pushImage
 elif [ "$1" == "testCreateImageAndUnprivilegedRestore" ]; then
     pingPerfZipPath=$2
     testJDKPath=$3

--- a/external/criu/playlist.xml
+++ b/external/criu/playlist.xml
@@ -13,6 +13,7 @@
 # limitations under the License.
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
+	<include>../criuSettings.mk</include>
 	<test>
 		<testCaseName>criu_pingPerf_testCreateImageAndUnprivilegedRestore</testCaseName>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndUnprivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_JDK_HOME); \
@@ -46,13 +47,45 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>criu_pingPerf_testCreateRestoreImageOnly</testCaseName>
+		<testCaseName>criu_pingPerf_testCreateRestoreImageAndPushToRegistry</testCaseName>
 		<disables>
 			<disable>
 				<comment>runtimes_backlog_issues_879</comment>
 			</disable>
 		</disables>
-		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateRestoreImageOnly $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_JDK_HOME); \
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateRestoreImageAndPushToRegistry $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_JDK_HOME) "$(DOCKER_REGISTRY_DIR)"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)/external/criu/pingPerf.sh clean
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>criu_pingPerf_pullImageUnprivilegedRestore</testCaseName>
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh pullImageUnprivilegedRestore "$(DOCKER_REGISTRY_DIR)"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)/external/criu/pingPerf.sh clean
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>criu_pingPerf_pullImagePrivilegedRestore</testCaseName>
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh pullImagePrivilegedRestore "$(DOCKER_REGISTRY_DIR)"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>

--- a/external/criuSettings.mk
+++ b/external/criuSettings.mk
@@ -13,4 +13,6 @@
 ##############################################################################
 
 export CRIU_MICRO_ARCHITECTURE_LIST=hw.arch.x86.skylake hw.arch.x86.amd
+export CRIU_XLINUX_COMBO_LIST=sw.os.ubuntu.22-hw.arch.x86.broadwell sw.os.rhel.8-hw.arch.x86.broadwell sw.os.rhel.8-hw.arch.x86.amd sw.os.rhel.8-hw.arch.x86.skylake
+# not available: sw.os.ubuntu.22-hw.arch.x86.amd sw.os.ubuntu.22-hw.arch.x86.skylake
 export CRIU_DEFAULT_IMAGE_JOB_NAME=criu_image_upload


### PR DESCRIPTION
Add the following tests:
- criu_pingPerf_testCreateRestoreImageAndPushToRegistry
- criu_pingPerf_pullImageUnprivilegedRestore
- criu_pingPerf_pullImagePrivilegedRestore

related: runtimes/backlog/issues/1033