### PR TITLE
Exclude EC curves fo RH ojdk 17

### DIFF
--- a/openjdk/excludes/vendors/redhat/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/vendors/redhat/ProblemList_openjdk17.txt
@@ -54,8 +54,6 @@
 ############################################################################
 
 # jdk_net
-javax/net/ssl/ciphersuites/ECCurvesconstraints.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
-sun/security/ec/TestEC.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
 
 ############################################################################
 
@@ -74,6 +72,12 @@ sun/security/ec/TestEC.java https://github.com/adoptium/aqa-tests/issues/3683 ge
 # jdk_security
 
 ############################################################################
+
+# jdk_security3
+############################################################################
+javax/net/ssl/ciphersuites/ECCurvesconstraints.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
+sun/security/ec/TestEC.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
+
 
 # jdk_security4
 

--- a/openjdk/excludes/vendors/redhat/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/vendors/redhat/ProblemList_openjdk17.txt
@@ -54,6 +54,8 @@
 ############################################################################
 
 # jdk_net
+javax/net/ssl/ciphersuites/ECCurvesconstraints.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
+sun/security/ec/TestEC.java https://github.com/adoptium/aqa-tests/issues/3683 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
We are removing ECCurves on our version.

I'm not sure about proper exclusion syntax, pls feel free to point me to some source if exists. I guess it from the existing exclusions around.