### PR TITLE
Implement MultiJVM tck in one node

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -129,7 +129,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=api/java_rmi testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=api/java_rmi testsuite=COMPILER$(USEQ); \
 			$(START_MULTI_JVM_COMP_TEST); \
 			$(GEN_SUMMARY) tests=api/java_rmi testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -149,7 +149,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=api/javax_annotation testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=api/javax_annotation testsuite=COMPILER$(USEQ); \
 			$(START_MULTI_JVM_COMP_TEST); \
 			$(GEN_SUMMARY) tests=api/javax_annotation testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -165,7 +165,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=api/javax_lang testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=api/javax_lang testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=api/javax_lang testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -189,7 +189,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=api/javax_tools testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=api/javax_tools testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=api/javax_tools testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -213,7 +213,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=api/signaturetest testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=api/signaturetest testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=api/signaturetest testsuite=COMPILER; \
 		$(TEST_STATUS)</command>

--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -590,7 +590,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/BINC testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/BINC testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/BINC testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -606,7 +606,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -622,7 +622,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -644,7 +644,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -666,7 +666,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -688,7 +688,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -710,7 +710,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -732,7 +732,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -754,7 +754,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -776,7 +776,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -798,7 +798,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -814,7 +814,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -830,7 +830,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -852,7 +852,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -874,7 +874,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -896,7 +896,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -912,7 +912,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -928,7 +928,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -950,7 +950,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -972,7 +972,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -994,7 +994,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1016,7 +1016,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1038,7 +1038,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1060,7 +1060,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1082,7 +1082,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1104,7 +1104,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1126,7 +1126,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1142,7 +1142,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1158,7 +1158,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP2) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP2) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1180,7 +1180,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP3) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP3) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1202,7 +1202,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP4) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP4) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1224,7 +1224,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP5) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP5) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1240,7 +1240,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1256,7 +1256,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP2) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP2) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1278,7 +1278,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP3) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP3) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1300,7 +1300,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP4) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP4) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1322,7 +1322,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP5) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP5) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1344,7 +1344,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP6) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP6) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP6) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1366,7 +1366,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP7) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP7) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP7) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1382,7 +1382,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/ARR testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/ARR testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/ARR testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1398,7 +1398,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1414,7 +1414,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP2) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP2) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1436,7 +1436,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP3) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP3) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1458,7 +1458,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP4) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP4) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1480,7 +1480,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP5) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP5) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1496,7 +1496,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/EXCP testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/EXCP testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/EXCP testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1512,7 +1512,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/EXEC testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/EXEC testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/EXEC testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1528,7 +1528,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/FP testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/FP testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/FP testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1550,7 +1550,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/ICLS testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/ICLS testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/ICLS testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1572,7 +1572,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/INFR testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/INFR testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/INFR testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1594,7 +1594,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/MOD testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/MOD testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/MOD testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1613,7 +1613,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1629,7 +1629,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP2) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP2) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1651,7 +1651,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP3) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP3) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1673,7 +1673,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP4) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP4) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1695,7 +1695,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP5) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP5) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1711,7 +1711,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/PKGS testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/PKGS testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/PKGS testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1727,7 +1727,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/THRD testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/THRD testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/THRD testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1743,7 +1743,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1759,7 +1759,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP2) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP2) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1781,7 +1781,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP3) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP3) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1803,7 +1803,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP4) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP4) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1825,7 +1825,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP5) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP5) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1847,7 +1847,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1869,7 +1869,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP2) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP2) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1891,7 +1891,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP3) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP3) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1913,7 +1913,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP4) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP4) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1935,7 +1935,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP5) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP5) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1951,7 +1951,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=lang/LEX testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=lang/LEX testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=lang/LEX testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1967,7 +1967,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP1) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP1) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -1983,7 +1983,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP2) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP2) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -2005,7 +2005,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP3) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP3) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -2027,7 +2027,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP4) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP4) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>
@@ -2049,7 +2049,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP5) testsuite=COMPILER'; \
+		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
 		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP5) testsuite=COMPILER; \
 		$(TEST_STATUS)</command>

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -111,11 +111,19 @@ JCK_CMD_TEMPLATE = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.
 REFERENCE_JAVA_CMD=/home/jenkins/jckshare/ri/jdk-11.0.19/bin/java
 WORKSPACE=/home/jenkins/jckshare/workspace/output_$(UNIQUEID)/$@
 
-PREP = mkdir -p $(WORKSPACE); cp -rf $(CONFIG_ALT_PATH)$(D)jck$(JCK_VERSION_NUMBER)$(D)compiler.jti $(WORKSPACE)$(D); cp -rf $(TEST_ROOT)$(D)jck$(D)jtrunner $(WORKSPACE)
-GEN_JTB = $(PREP); ssh -o StrictHostKeyChecking=no jenkins@$(AGENT_NODE) '$(REFERENCE_JAVA_CMD) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(WORKSPACE)$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) testJava=$(JAVA_TO_TEST) riJava=$(REFERENCE_JAVA_CMD) workdir=$(WORKSPACE) configAltPath=$(CONFIG_ALT_PATH) agentHost=$(NODE_NAME) task=cmdfilegen testExecutionType=multijvm
-GEN_SUMMARY = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) workdir=$(WORKSPACE) task=summarygen
-START_AGENT = $(JAVA_TO_TEST) -Djavatest.security.allowPropertiesAccess=true -Djava.security.policy=$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)jck.policy -classpath $(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar:$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)classes com.sun.javatest.agent.AgentMain -passive -trace &> $(WORKSPACE)$(D)agent.log &
-START_HARNESS = ssh -o StrictHostKeyChecking=no jenkins@$(AGENT_NODE) $(REFERENCE_JAVA_CMD) -jar $(JCK_ROOT)$(D)JCK-runtime-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar -config $(WORKSPACE)$(D)compiler.jti @$(WORKSPACE)$(D)generated.jtb
+ifneq ($(filter aix_ppc-64 zos_390 linux_ppc-64_le linux_390-64, $(SPEC)),)
+   USEQ='
+   PREP = mkdir -p $(WORKSPACE); cp -rf $(CONFIG_ALT_PATH)$(D)jck$(JCK_VERSION_NUMBER)$(D)compiler.jti $(WORKSPACE)$(D); cp -rf $(TEST_ROOT)$(D)jck$(D)jtrunner $(WORKSPACE)
+   GEN_JTB = $(PREP); ssh -o StrictHostKeyChecking=no jenkins@$(AGENT_NODE) $(USEQ)$(REFERENCE_JAVA_CMD) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(WORKSPACE)$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) testJava=$(JAVA_TO_TEST) riJava=$(REFERENCE_JAVA_CMD) workdir=$(WORKSPACE) configAltPath=$(CONFIG_ALT_PATH) agentHost=$(NODE_NAME) task=cmdfilegen testExecutionType=multijvm
+   GEN_SUMMARY = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) workdir=$(WORKSPACE) task=summarygen
+   START_AGENT = $(JAVA_TO_TEST) -Djavatest.security.allowPropertiesAccess=true -Djava.security.policy=$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)jck.policy -classpath $(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar$(P)$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)classes com.sun.javatest.agent.AgentMain -passive -trace &> $(WORKSPACE)$(D)agent.log &
+   START_HARNESS = ssh -o StrictHostKeyChecking=no jenkins@$(AGENT_NODE) $(REFERENCE_JAVA_CMD) -jar $(JCK_ROOT)$(D)JCK-runtime-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar -config $(WORKSPACE)$(D)compiler.jti @$(WORKSPACE)$(D)generated.jtb
+else
+   GEN_JTB = $(REFERENCE_JAVA_CMD) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) testJava=$(JAVA_TO_TEST) riJava=$(REFERENCE_JAVA_CMD) workdir=$(REPORTDIR) configAltPath=$(CONFIG_ALT_PATH) agentHost=localhost task=cmdfilegen testExecutionType=multijvm
+   GEN_SUMMARY = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) workdir=$(REPORTDIR) task=summarygen
+   START_AGENT = $(JAVA_TO_TEST) -Djavatest.security.allowPropertiesAccess=true -Djava.security.policy=$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)jck.policy -classpath $(Q)$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar$(P)$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)classes$(Q) com.sun.javatest.agent.AgentMain -passive -trace &> $(REPORTDIR)$(D)agent.log &
+   START_HARNESS = $(REFERENCE_JAVA_CMD) -jar $(JCK_ROOT)$(D)JCK-runtime-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar -config $(CONFIG_ALT_PATH)$(D)jck$(JCK_VERSION_NUMBER)$(D)compiler.jti @$(REPORTDIR)$(D)generated.jtb
+endif
 
 define START_MULTI_JVM_COMP_TEST
 chmod +x $(TEST_ROOT)$(D)jck$(D)agent-drive.sh; \


### PR DESCRIPTION
- For AIX, z/OS, zLinux and pLinux, we'd run the multijvm compiler tests using two nodes. 
- For the rest of the platforms, for which there exist RI JDKs, we'd use a single-node approach. 

Implements backlog/issues/1035

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>