### PR TITLE
Permanently disable ContinuationTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -546,4 +546,4 @@ serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16751 generic-all
-serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/eclipse-openj9/openj9/issues/16792 generic-all
+serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -549,4 +549,4 @@ serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16751 generic-all
-serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/eclipse-openj9/openj9/issues/16792 generic-all
+serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
Refer to #1297 to permanently exclude.

Related: eclipse-openj9/openj9#16792
Related: #1297