### PR TITLE
Unexclude compiler/criticalnatives/argumentcorruption/Test8167409.sh JDK8 linux-aarch64

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -46,7 +46,7 @@ runtime/7110720/Test7110720.sh https://github.com/adoptium/aqa-tests/issues/2818
 compiler/6894807/IsInstanceTest.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/8004051/Test8004051.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
-compiler/criticalnatives/argumentcorruption/Test8167409.sh https://github.com/adoptium/aqa-tests/issues/2984 linux-aarch64,linux-arm
+compiler/criticalnatives/argumentcorruption/Test8167409.sh https://github.com/adoptium/aqa-tests/issues/2984 linux-arm
 compiler/c2/cr6340864/TestByteVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
 compiler/c2/cr6340864/TestDoubleVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86


### PR DESCRIPTION
Problem on aarch64 was fixed by  [JDK-8299804](https://bugs.openjdk.org/browse/JDK-8299804).
(Testing supposed to be skipped on aarch64, but was not due to problems in shell code)