### PR TITLE
Re-enable JVMTI test SuspendResume1

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -540,7 +540,6 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https:/
 serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java https://github.com/eclipse-openj9/openj9/issues/16242 generic-all
 serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.java https://github.com/eclipse-openj9/openj9/issues/16215 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
-serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -543,7 +543,6 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https:/
 serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java https://github.com/eclipse-openj9/openj9/issues/16242 generic-all
 serviceability/jvmti/vthread/ContYieldBreakPointTest/ContYieldBreakPointTest.java https://github.com/eclipse-openj9/openj9/issues/16215 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
-serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java https://github.com/eclipse-openj9/openj9/issues/16203 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all


### PR DESCRIPTION
The test has been fixed by eclipse-openj9/openj9#16805.

Signed-off-by: Dipak Bagadiya dipak.bagadiya@ibm.com