### PR TITLE
Exclude jdk/internal/platform/docker/TestDockerCpuMetrics.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -374,3 +374,6 @@ sun/nio/ch/TestMaxCachedBufferSize.java		https://github.com/eclipse-openj9/openj
 vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse-openj9/openj9/issues/7336	generic-all
 
 ############################################################################
+
+# jdk_container
+jdk/internal/platform/docker/TestDockerCpuMetrics.java https://github.com/eclipse-openj9/openj9/issues/16462 generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -402,3 +402,6 @@ java/foreign/TestResourceScope.java https://github.com/eclipse-openj9/openj9/iss
 # com_sun_crypto
 
 ############################################################################
+
+# jdk_container
+jdk/internal/platform/docker/TestDockerCpuMetrics.java https://github.com/eclipse-openj9/openj9/issues/16462 generic-all

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -546,3 +546,6 @@ serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/ecl
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16751 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+
+# jdk_container
+jdk/internal/platform/docker/TestDockerCpuMetrics.java https://github.com/eclipse-openj9/openj9/issues/16462 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -549,3 +549,6 @@ serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/ecl
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16751 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+
+# jdk_container
+jdk/internal/platform/docker/TestDockerCpuMetrics.java https://github.com/eclipse-openj9/openj9/issues/16462 generic-all

--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -390,3 +390,6 @@ javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github
 jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/eclipse-openj9/openj9/issues/16460 generic-all
 
 ############################################################################
+
+# jdk_container
+jdk/internal/platform/docker/TestDockerCpuMetrics.java https://github.com/eclipse-openj9/openj9/issues/16462 generic-all


### PR DESCRIPTION
Exclude `jdk/internal/platform/docker/TestDockerCpuMetrics.java`

Related https://github.com/eclipse-openj9/openj9/issues/16462

Signed-off-by: Jason Feng <fengj@ca.ibm.com>