### PR TITLE
Remove suffix #id\d{1} as part of openjdk testcase name

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1102,7 +1102,7 @@ def addFailedTestsGrinderLink(paths=""){
 								failedTestCasesInfo = failedTestCasesInfo.substring(failedTestCasesInfo.indexOf('TEST:'))
 								failedTestCasesInfo = failedTestCasesInfo.substring(0, failedTestCasesInfo.indexOf('Test results:'))
 								failedTestCasesInfo = failedTestCasesInfo.split("\\n").join(" ").replaceAll("TEST: ", "")
-								//Remove #id suffixed to the openjdk testcase name. Jtreg doesn't work with it.
+								// Remove #id suffixed to the openjdk testcase name. Jtreg doesn't work with it.
 								failedTestCasesInfo = failedTestCasesInfo.replaceAll(/#id\d{1,}/, "")
 								if (failedtest.startsWith("jdk_")) {
 									jdkFailedTestCaseList += "${failedTestCasesInfo} "

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1102,6 +1102,8 @@ def addFailedTestsGrinderLink(paths=""){
 								failedTestCasesInfo = failedTestCasesInfo.substring(failedTestCasesInfo.indexOf('TEST:'))
 								failedTestCasesInfo = failedTestCasesInfo.substring(0, failedTestCasesInfo.indexOf('Test results:'))
 								failedTestCasesInfo = failedTestCasesInfo.split("\\n").join(" ").replaceAll("TEST: ", "")
+								//Remove #id suffixed to the openjdk testcase name. Jtreg doesn't work with it.
+								failedTestCasesInfo = failedTestCasesInfo.replaceAll(/#id\d{1,}/, "")
 								if (failedtest.startsWith("jdk_")) {
 									jdkFailedTestCaseList += "${failedTestCasesInfo} "
 								} else {


### PR DESCRIPTION
- Jtreg doesn't support to specify testcase name suffixed with #id\d{1}
- the special character in url without encoding will also lead to wrong behaviour

Fix #4385 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>