### PR TITLE
add langtools_extpath for openj9/ibm

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -65,6 +65,40 @@
 			<group>openjdk</group>
 		</groups>
 	</test>
+	<!-- langtools_extpath_j9 is a subtest of langtools. Once langtools is fully enabled in openj9/ibm, the langtools_extpath_j9 below can be removed  -->
+	<test>
+		<testCaseName>langtools_extpath_j9</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/15264</comment>
+				<version>19+</version>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
+		<variations>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(CUSTOM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(TIMEOUT_HANDLER) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	$(Q)$(JTREG_LANGTOOLS_TEST_DIR)/tools/javap/ExtPath.java$(Q); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 	<test>
 		<testCaseName>hotspot_custom</testCaseName>
 		<variations>


### PR DESCRIPTION
related: https://github.com/adoptium/aqa-tests/issues/4405