### PR TITLE
Add **/result/** as junit results dir

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -759,7 +759,7 @@ def post(output_name) {
 
 		step([$class: "TapPublisher", testResults: "aqa-tests/TKG/**/*.tap", outputTapToConsole: false, failIfNoResults: true])
 
-		junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/junitreports/**/*.xml, **/external_test_reports/**/*.xml'
+		junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/result/**/*.jtr.xml, **/junitreports/**/*.xml, **/external_test_reports/**/*.xml'
 
 		//call the archive function for each file
 		archiveFile("aqa-tests/testenv/testenv.properties", true)


### PR DESCRIPTION
Show windows installer tests results (*.jtr.xml) 

Support https://github.com/adoptium/installer/issues/559

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>