### PR TITLE
Update problemlist files to refer to upstream issue

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -185,7 +185,7 @@ java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
 java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
-java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
+java/nio/channels/Channels/ReadXBytes.java https://bugs.openjdk.org/browse/JDK-8277361 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 generic-all
 java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
@@ -237,7 +237,7 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
-java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x
+java/nio/channels/Channels/ReadXBytes.java  https://bugs.openjdk.org/browse/JDK-8277361  linux-aarch64,linux-ppc64le,linux-s390x
  
 
 ############################################################################ 

--- a/openjdk/excludes/ProblemList_openjdk19.txt
+++ b/openjdk/excludes/ProblemList_openjdk19.txt
@@ -186,7 +186,7 @@ java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
 java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
-java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
+java/nio/channels/Channels/ReadXBytes.java https://bugs.openjdk.org/browse/JDK-8277361 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 generic-all
 java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
@@ -240,7 +240,7 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
-java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x
+java/nio/channels/Channels/ReadXBytes.java  https://bugs.openjdk.org/browse/JDK-8277361  linux-aarch64,linux-ppc64le,linux-s390x
 java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/adoptium/aqa-tests/issues/4024 aix-all
 
 

--- a/openjdk/excludes/ProblemList_openjdk20.txt
+++ b/openjdk/excludes/ProblemList_openjdk20.txt
@@ -185,7 +185,7 @@ java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.
 java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
 java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
-java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
+java/nio/channels/Channels/ReadXBytes.java https://bugs.openjdk.org/browse/JDK-8277361 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 generic-all
 java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
@@ -233,7 +233,7 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
-java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x
+java/nio/channels/Channels/ReadXBytes.java  https://bugs.openjdk.org/browse/JDK-8277361  linux-aarch64,linux-ppc64le,linux-s390x
  
 
 ############################################################################ 


### PR DESCRIPTION
We prefer to reference the 'real' issue and close our placeholder issues when possible.  https://github.com/adoptium/aqa-tests/issues/3034 was a placeholder but now that the correct upstream issue is found, refer to it in ProblemList files instead.

https://bugs.openjdk.org/browse/JDK-8277361 appears to be fixed, which would imply we could reenable the test.  I want to make this update and then use this example to test our re-enablement automation (upcoming feature).

Closes #3034 