### PR TITLE
Remove podman prune in pingPerf

### DIFF
--- a/external/criu/pingPerf.sh
+++ b/external/criu/pingPerf.sh
@@ -156,7 +156,6 @@ clean() {
     echo "clean ..."
     sudo podman stop --all
     sudo podman container rm --all -f
-    sudo podman system prune --all -f
 }
 
 testCreateRestoreImageOnly() {


### PR DESCRIPTION
podman prune in pingPerf will clean all images. Some of them are needed for other tests

related: runtimes/backlog/issues/1057