### PR TITLE
Fix exclusion platform value for mac for tck targets 

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -895,7 +895,7 @@
 		<disables>
 			<disable>
 				<comment>Temporarily disabled on x64 + aarch64 Mac for backlog/issues/718</comment>
-				<platform>aarch64_mac|x86-64_mac</platform>
+				<platform>(?:aarch64_mac.*|x86-64_mac.*)</platform>
 				<impl>openj9</impl>
 				<version>11+</version>
 			</disable>
@@ -1034,7 +1034,7 @@
 			</disable>
 			<disable>
 				<comment>Temporarily disabled on x64 + aarch64 Mac for infrastructure/issues/7151</comment>
-				<platform>aarch64_mac|x86-64_mac</platform>
+				<platform>(?:aarch64_mac.*|x86-64_mac.*)</platform>
 				<impl>openj9</impl>
 				<version>11</version>
 			</disable>


### PR DESCRIPTION
Related : backlog/issues/1007