### PR TITLE
(v0.9.6-release) - Update jdk20 exclude lists (#4443)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk20.txt
+++ b/openjdk/excludes/ProblemList_openjdk20.txt
@@ -204,6 +204,12 @@ java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.co
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
 java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
 com/sun/net/httpserver/simpleserver/StressDirListings.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+java/net/vthread/HttpALot.java https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+java/net/vthread/InterruptHttp.java https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+jdk/net/ExtendedSocketOption/DontFragmentTest https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+java/net/vthread/BlockingSocketOps.java#direct-register https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+java/net/vthread/BlockingSocketOps.java#default https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+
 ############################################################################
 
 # jdk_io
@@ -331,6 +337,7 @@ java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/adoptiu
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/util/concurrent/tck/JSR166TestCase.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
 java/util/regex/NegativeArraySize.java https://github.com/adoptium/aqa-tests/issues/3818 linux-all
+java/util/zip/DeInflate.java	https://bugs.openjdk.org/browse/JDK-8299748	linux-s390x
 ############################################################################
 
 # svc_tools


### PR DESCRIPTION
Pre-triage the jdk20 release - aix, s390x

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>