### PR TITLE
Add rm -rf for TKG if cleanWs fails in openjdk_tests

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -311,7 +311,16 @@ def runTest() {
                 }
                 retry_count++
                 timeout(time: 1, unit: 'HOURS') {
-                    cleanWs disableDeferredWipeout: true, deleteDirs: true
+                    try {
+                        cleanWs disableDeferredWipeout: true, deleteDirs: true
+                    } catch (Exception e) {
+                        echo 'Exception: ' + e.toString()
+                        //cleanWs has issue to delete workspace that contains non-ASCII filename in TKG output https://issues.jenkins.io/browse/JENKINS-33478
+                        //cannot delete workspace directly. Otherwise, Jenkins job will abort due to missing workspace
+                        sh "rm -rf ${env.WORKSPACE}/aqa-tests/TKG"
+                        // call cleanWs() again
+                        cleanWs disableDeferredWipeout: true, deleteDirs: true
+                    }
                 }
                 checkout scm: [$class: 'GitSCM',
                     branches: [[name: "${scm.branches[0].name}"]],


### PR DESCRIPTION
Fixes pre-test cleanWs failure for non-ASCII characters on s390x sanity.openjdk: 
https://ci.adoptium.net/job/Test_openjdk20_hs_sanity.openjdk_s390x_linux/70/console

Successful clean with this PR: https://ci.adoptium.net/job/Test_openjdk20_hs_sanity.openjdk_s390x_linux/74/
```
Pipeline] cleanWs
10:52:37  [WS-CLEANUP] Deleting project workspace...
10:52:37  [WS-CLEANUP] Deferred wipeout is disabled by the job configuration...
10:52:39  ERROR: Cannot delete workspace :Malformed input or input contains unmappable characters: /home/jenkins/workspace/Test_openjdk20_hs_sanity.openjdk_s390x_linux/aqa-tests/TKG/output_16784648952959/jdk_lang_1/work/scratch/TestLambdaFileEncodingSerialization$ABC������.class
[Pipeline] echo
10:52:39  Exception: hudson.AbortException: Cannot delete workspace: Malformed input or input contains unmappable characters: /home/jenkins/workspace/Test_openjdk20_hs_sanity.openjdk_s390x_linux/aqa-tests/TKG/output_16784648952959/jdk_lang_1/work/scratch/TestLambdaFileEncodingSerialization$ABC������.class
[Pipeline] sh
10:52:40  + rm -rf /home/jenkins/workspace/Test_openjdk20_hs_sanity.openjdk_s390x_linux/aqa-tests/TKG
[Pipeline] cleanWs
10:52:41  [WS-CLEANUP] Deleting project workspace...
10:52:41  [WS-CLEANUP] Deferred wipeout is disabled by the job configuration...
10:52:48  [WS-CLEANUP] done
```
