### PR TITLE
Exclude DisableCurve on z/OS

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -291,6 +291,7 @@ sun/security/provider/SecureRandom/StrongSecureRandom.java	https://github.ibm.co
 sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
+#sun/security/ssl/CipherSuite/DisabledCurve.java is excluded as Invalid scenario after removing unsupported binary curves from SSLSocketTemplate.java
 sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all,z/OS-s390x
 sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all

--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -291,7 +291,7 @@ sun/security/provider/SecureRandom/StrongSecureRandom.java	https://github.ibm.co
 sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
-sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all,z/OS-s390x
 sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all


### PR DESCRIPTION
This PR is to exclude sun/security/ssl/CipherSuite/DisabledCurve.java on z/OS