### PR TITLE
Change reason for ignoring TimedGet.java in Java 19/20

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -114,7 +114,7 @@ java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/o
 java/lang/Thread/virtual/PreviewFeaturesNotEnabled.java https://github.com/eclipse-openj9/openj9/issues/16044 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/stress/Skynet.java#id0 https://github.com/eclipse-openj9/openj9/issues/16728 generic-all
-java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/16729 macosx-x64
+java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -114,7 +114,7 @@ java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/o
 java/lang/Thread/virtual/PreviewFeaturesNotEnabled.java https://github.com/eclipse-openj9/openj9/issues/16044 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/stress/Skynet.java#id0 https://github.com/eclipse-openj9/openj9/issues/16728 generic-all
-java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/16729 macosx-x64
+java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all


### PR DESCRIPTION
Changed due to eclipse-openj9/openj9/issues/16729 being resolved