### PR TITLE
Explicitly exit the jenkins job if setting the wrong owner branch format

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1291,6 +1291,8 @@ def getGitRepoBranch(ownerBranch, defaultOwnerBranch, repo) {
 		String[] tokens = ownerBranch.split(":")
 		if (tokens.size() == 2 ) {
 			actualRepoBranch = tokens;
+		} else {
+			error "[ERROR]: Wrong format of XXX_OWNER_BRANCH value: ${ownerBranch}. The expected format is [owner]:[branch]"
 		}
 	}
 

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -200,6 +200,15 @@ timestamps{
             println "LABEL: ${LABEL}"
 
             stage('Queue') {
+            	if (!areNodesWithLabelOnline(LABEL)) {
+            		node(LABEL) {
+            			echo "shouldn't be here"
+            		}
+            	} else {
+            		node(LABEL) {
+            			echo "should be here"
+            		}
+            	}
                 if (!areNodesWithLabelOnline(LABEL)) {
                     int ACTIVE_NODE_TIMEOUT = params.ACTIVE_NODE_TIMEOUT ? params.ACTIVE_NODE_TIMEOUT.toInteger() : 15
                     timeout(ACTIVE_NODE_TIMEOUT) {

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -200,15 +200,6 @@ timestamps{
             println "LABEL: ${LABEL}"
 
             stage('Queue') {
-            	if (!areNodesWithLabelOnline(LABEL)) {
-            		node(LABEL) {
-            			echo "shouldn't be here"
-            		}
-            	} else {
-            		node(LABEL) {
-            			echo "should be here"
-            		}
-            	}
                 if (!areNodesWithLabelOnline(LABEL)) {
                     int ACTIVE_NODE_TIMEOUT = params.ACTIVE_NODE_TIMEOUT ? params.ACTIVE_NODE_TIMEOUT.toInteger() : 15
                     timeout(ACTIVE_NODE_TIMEOUT) {


### PR DESCRIPTION
[owner]:[branch] format is required to set user specified repo and branch. In case of the wrong format is set, explicitly exit the jenkins job with ERROR message to help user get quickly notice the issue.


Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>