### PR TITLE
exclude failing compiler tests for jdk19 and 20 s390x linux

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19.txt
+++ b/openjdk/excludes/ProblemList_openjdk19.txt
@@ -437,6 +437,9 @@ compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/i
 compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+
+compiler/codegen/aes/Test8292158.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
+compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
 ############################################################################
 
 # jdk_jfr

--- a/openjdk/excludes/ProblemList_openjdk20.txt
+++ b/openjdk/excludes/ProblemList_openjdk20.txt
@@ -432,6 +432,9 @@ compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adopti
 compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/codecache/MHIntrinsicAllocFailureTest.java https://bugs.openjdk.org/browse/JDK-8298947 linux-arm
 compiler/whitebox/ForceNMethodSweepTest.java https://bugs.openjdk.org/browse/JDK-8265181 linux-arm
+
+compiler/codegen/aes/Test8292158.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
+compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
 ############################################################################
 
 # jdk_jfr


### PR DESCRIPTION
ref https://github.com/adoptium/aqa-tests/issues/4470

Exclude compiler/codegen/aes/Test8292158.java and compiler/codegen/aes/TestAESMain.java for jdk19 and 20 for s390x linux