### PR TITLE
Re-enable GetStackTraceSuspendedStressTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -542,7 +542,6 @@ serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.c
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
-serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16751 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 # jdk_container

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -546,7 +546,6 @@ serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.c
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
-serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/16751 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 # jdk_container


### PR DESCRIPTION
Enabled JDK19/JDK29 `serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java`

Related https://github.com/eclipse-openj9/openj9/issues/16751

Signed-off-by: Jason Feng <fengj@ca.ibm.com>