### PR TITLE
Unexclude runtime/Metaspace/FragmentMetaspaceSimple.java on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -28,7 +28,6 @@ compiler/6894807/IsInstanceTest.java https://github.com/adoptium/adoptium/issues
 gc/metaspace/TestMetaspaceMemoryPool.java https://github.com/adoptium/aqa-tests/issues/2708 generic-all
 runtime/CDSCompressedKPtrs/CDSCompressedKPtrs.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/Metaspace/FragmentMetaspaceSimple.java https://github.com/adoptium/aqa-tests/issues/120	generic-all
 runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java	https://github.com/adoptium/aqa-tests/issues/121	generic-all
 runtime/ErrorHandling/TestExitOnOutOfMemoryError.java	https://github.com/adoptium/aqa-tests/issues/121	generic-all
 runtime/NMT/NMTWithCDS.java	https://github.com/adoptium/aqa-tests/issues/124	generic-all


### PR DESCRIPTION
Seems like this one was not re-enabled by accident after problem got fixed, see:  https://github.com/adoptium/aqa-tests/pull/200/files

Test passes:
https://ci.adoptium.net/view/Test_grinder/job/Grinder/7035/