### PR TITLE
Unexclude OutputAnalyzer failures on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -31,17 +31,12 @@ runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java https://github.com/adopt
 runtime/Metaspace/FragmentMetaspaceSimple.java https://github.com/adoptium/aqa-tests/issues/120	generic-all
 runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java	https://github.com/adoptium/aqa-tests/issues/121	generic-all
 runtime/ErrorHandling/TestExitOnOutOfMemoryError.java	https://github.com/adoptium/aqa-tests/issues/121	generic-all
-runtime/NMT/NMTWithCDS.java	https://github.com/adoptium/aqa-tests/issues/124	generic-all
-runtime/memory/ReserveMemory.java	https://github.com/adoptium/aqa-tests/issues/124	generic-all
 runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/SharedArchiveFile/CdsSameObjectAlignment.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/SharedArchiveFile/LimitSharedSizes.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/SharedArchiveFile/PrintSharedArchiveAndExit.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/SharedArchiveFile/SharedArchiveFile.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/SharedArchiveFile/SpaceUtilizationCheck.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-serviceability/jvmti/TestRedefineWithUnresolvedClass.java	https://github.com/adoptium/aqa-tests/issues/124	generic-all
-serviceability/jvmti/GetObjectSizeOverflow.java	https://github.com/adoptium/aqa-tests/issues/124	linux-all
-serviceability/sa/jmap-hashcode/Test8028623.java	https://github.com/adoptium/aqa-tests/issues/124	linux-all
 runtime/7110720/Test7110720.sh https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/6894807/IsInstanceTest.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/8004051/Test8004051.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all


### PR DESCRIPTION
All these tests/problems on openjdk 8 seem to be fixed now. One problem was fixed by [JDK-8055814](https://bugs.openjdk.org/browse/JDK-8055814) backport, what fixed others is unknown (See my comment in issue).

Issue: https://github.com/adoptium/aqa-tests/issues/124
Test passed (aarch64_linux, x86-64_mac, x86-64_windows): https://ci.adoptium.net/job/Grinder/7037/