### PR TITLE
Unexclude gc tests with 64K page size fix on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -66,10 +66,6 @@ compiler/gcbarriers/PreserveFPRegistersTest.java https://github.com/adoptium/aqa
 gc/TestMemoryMXBeansAndPoolsPresence.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/g1/mixedgc/TestOldGenCollectionUsage.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 runtime/CompressedOops/CompressedClassPointers.java https://bugs.openjdk.org/browse/JDK-8234058 linux-ppc64le,aix-all
-gc/arguments/TestCMSHeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
-gc/arguments/TestG1HeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
-gc/arguments/TestParallelHeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
-gc/arguments/TestSerialHeapSizeFlags.java https://github.com/adoptium/aqa-tests/issues/3059 linux-ppc64le
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/infrastructure/issues/2565 solaris-x64
 gc/concurrentMarkSweep/GuardShrinkWarning.java https://bugs.openjdk.java.net/browse/JDK-8023356 solaris-x64
 compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all


### PR DESCRIPTION
For more details see: https://github.com/adoptium/aqa-tests/pull/4317
These were not re-enabled by previous PR, but were actually also fixed by [JDK-8067941](https://bugs.openjdk.org/browse/JDK-8067941) backport.

Issue: https://github.com/adoptium/aqa-tests/issues/3059

passes (ppc64le_linux):
https://ci.adoptium.net/job/Grinder/7036/