### PR TITLE
Unexclude runtime/ErrorHandling/*.java tests on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -26,8 +26,6 @@ compiler/6894807/IsInstanceTest.java https://github.com/adoptium/adoptium/issues
 gc/metaspace/TestMetaspaceMemoryPool.java https://github.com/adoptium/aqa-tests/issues/2708 generic-all
 runtime/CDSCompressedKPtrs/CDSCompressedKPtrs.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java	https://github.com/adoptium/aqa-tests/issues/121	generic-all
-runtime/ErrorHandling/TestExitOnOutOfMemoryError.java	https://github.com/adoptium/aqa-tests/issues/121	generic-all
 runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/SharedArchiveFile/CdsSameObjectAlignment.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/SharedArchiveFile/LimitSharedSizes.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all


### PR DESCRIPTION
Problem has been fixed for JDK8 by [JDK-8218613](https://bugs.openjdk.org/browse/JDK-8218613).

Issue: https://github.com/adoptium/aqa-tests/issues/121