### PR TITLE
Unexclude compiler/intrinsics/bmi/verifycode/*.java on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -21,8 +21,6 @@ compiler/intrinsics/sha/TestSHA.java	https://github.com/adoptium/aqa-tests/issue
 # hotspot_jre
 
 runtime/7110720/Test7110720.sh https://github.com/adoptium/adoptium/issues/58 aix-all
-compiler/intrinsics/bmi/verifycode/LZcntTestI.java https://github.com/adoptium/aqa-tests/issues/2669 windows-all
-compiler/intrinsics/bmi/verifycode/TZcntTestI.java https://github.com/adoptium/aqa-tests/issues/2669 windows-all
 compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tests/issues/2671 linux-ppc64le,aix-all,linux-arm,windows-x86
 compiler/6894807/IsInstanceTest.java https://github.com/adoptium/adoptium/issues/58 aix-all
 gc/metaspace/TestMetaspaceMemoryPool.java https://github.com/adoptium/aqa-tests/issues/2708 generic-all


### PR DESCRIPTION
This was fixed on openjdk 8 by [JDK-8049348](https://bugs.openjdk.org/browse/JDK-8049348) backport.

Issue: https://github.com/adoptium/aqa-tests/issues/2669

Tests passed (x86-64_windows, x86-32_windows):
https://ci.adoptium.net/job/Grinder/7045/