### PR TITLE
Unexclude runtime/containers/docker/TestMemoryAwareness.java on JDK8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -75,8 +75,6 @@ gc/concurrentMarkSweep/GuardShrinkWarning.java https://bugs.openjdk.java.net/bro
 compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 compiler/floatingpoint/8165673/TestFloatJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 compiler/intrinsics/mathexact/LongMulOverflowTest.java https://bugs.openjdk.org/browse/JDK-8196568 solaris-x64
-#https://github.com/adoptium/aqa-tests/issues/3629,https://github.com/adoptium/aqa-tests/issues/3905
-runtime/containers/docker/TestMemoryAwareness.java https://bugs.openjdk.java.net/browse/JDK-8229182 generic-all
 ############################################################################
 
 # jdk_awt

--- a/openjdk/excludes/vendors/azul/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/vendors/azul/ProblemList_openjdk8.txt
@@ -17,7 +17,7 @@
 ############################################################################
 
 # hotspot_jre
-runtime/containers/docker/TestMemoryAwareness.java https://bugs.openjdk.java.net/browse/JDK-8229182 generic-all
+
 ############################################################################
 
 # jdk_awt


### PR DESCRIPTION
Problems in `runtime/containers/docker/TestMemoryAwareness.java` were fixed by [JDK-8229182](https://bugs.openjdk.java.net/browse/JDK-8229182) backport.

Test passed (aarch64_linux):
https://ci.adoptium.net/job/Grinder/7043/