### PR TITLE
[FFI/Jtreg]Exclude VaListTest in JDK20

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -485,6 +485,7 @@ java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issue
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/StdLibTest.java https://github.com/eclipse-openj9/openj9/issues/16386 aix-ppc64
+java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The change exclude this test suite as we no longer need VaList
as specified in the latest JEP442 at
https://github.com/eclipse-openj9/openj9/issues/16951

Fixes: eclipse-openj9/openj9/issues/17091

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>