### PR TITLE
Ensure multiJVM set to plain Yes for jck17+ Windows

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -565,6 +565,11 @@ public class JavaTestRunner {
 			extraJvmOptions += " -Dfile.encoding=US-ASCII";
 		}
 
+                // testExecutionType of multiJVM_group on Windows causes memory exhaustion, so limit to plain multiJVM
+                if (getJckVersionInt(jckVersionNo) >= 17 && platform.contains("win")) {
+			fileContent += "set jck.env.testPlatform.multiJVM \"Yes\";\n";
+                }
+
 		// Set the operating system as 'Windows' for Windows and 'other' for all other operating systems.
 		// If 'other' is specified when executing on Windows, then Windows specific settings such
 		// as systemRoot are rejected, and the JCK harness assumes that DISPLAY is required for GUI tests.


### PR DESCRIPTION
MultiJVM=group option for jck17+ causes memory exhaustion on Windows platform, so ensure for multiJVM execution type that MultiJVM is set to just "Yes"