### PR TITLE
Use JavaTestUtil for all tck

### DIFF
--- a/jck/agent-drive.sh
+++ b/jck/agent-drive.sh
@@ -1,14 +1,84 @@
-#!/bin/bash
+#!/bin/bash -ue
 
-echo "Starting JCK agent.."
-eval $1
+jckAgentPID=0
+rmiRegistryPID=0
+rmidPID=0
+tnameservPID=0
 
-pid=$!
+startJCKAgent() {
+	echo "Starting JCK agent.."
+	eval $1
+	jckAgentPID=$!
+	echo "Agent started with PID $jckAgentPID"
+}
 
-echo "Agent started with PID $pid" 
+stopJCKAgent() {
+	echo "Test complete. Stopping JCK Agent.."
+	kill -9 $jckAgentPID
+}
 
-echo "Starting JCK harness.."
-eval $2
+startJCKHarness() {
+	echo "Starting JCK harness.."
+	eval $1
+}
 
-echo "Test complete. Stopping JCK Agent.." 
-kill -9 $pid
+startRMIRegistry() {
+	echo "Starting RMI Registry.."
+	eval $1
+	rmiRegistryPID=$!
+	echo "RMI Registry started with PID $rmiRegistryPID"
+} 
+
+stopRMIRegistry() {
+	echo "Stopping RMI Registry.."
+	kill -9 $rmiRegistryPID
+}
+
+startRMID() {
+	echo "Starting RMID.."
+	eval $1
+	rmidPID=$!	
+	echo "RMID started with PID $rmidPID"
+}
+
+stopRMID() {
+	echo "Stopping RMID.."
+	kill -9 $rmidPID
+}
+
+startTNameServ() {
+	echo "Starting TNAMESERV.."
+	eval $1
+	tnameservPID=$!	
+	echo "TNAMESERV started with PID $tnameservPID"
+}
+
+stopTNameServ() {
+	echo "Stopping TNAMESERV.."
+	kill -9 $tnameservPID
+}
+
+if [ $# -eq 2 ]; then
+	startJCKAgent "$1"
+	startJCKHarness "$2"
+	stopJCKAgent
+elif [ $# -eq 4 ]; then
+	startRMIRegistry "$1"
+	startRMID "$2"
+	startJCKAgent "$3"
+	startJCKHarness "$4"
+	stopRMIRegistry
+	stopRMID
+	stopJCKAgent
+elif [ $# -eq 5 ]; then
+	startRMIRegistry "$1"
+	startRMID "$2"
+	startTNameServ "$3"
+	startJCKAgent "$4"
+	startJCKHarness "$5"
+	stopRMIRegistry
+	stopRMID
+	stopJCKAgent
+	stopTNameServ
+	stopJCKAgent
+fi

--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -29,7 +29,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_rmi testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_rmi testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_rmi testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -47,7 +49,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_annotation testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_annotation testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_annotation testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -61,7 +65,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_lang testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_lang testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_lang testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -83,7 +89,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_tools testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_tools testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_tools testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -105,7 +113,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/signaturetest testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=api/signaturetest testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/signaturetest testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -19,7 +19,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/BINC testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/BINC testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/BINC testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -33,7 +35,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -47,7 +51,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -61,7 +67,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -75,7 +83,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -89,7 +99,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -103,7 +115,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -117,7 +131,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -131,7 +147,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -145,7 +163,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -159,7 +179,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -173,7 +195,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/CONV testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/CONV testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CONV testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -187,7 +211,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -201,7 +227,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -215,7 +243,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -229,7 +259,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -243,7 +275,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -257,7 +291,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -271,7 +307,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -285,7 +323,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -299,7 +339,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -313,7 +355,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -327,7 +371,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -341,7 +387,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/INTF testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/INTF testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/INTF testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -355,7 +403,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/LMBD testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/LMBD testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/LMBD testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -369,7 +419,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/ARR testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/ARR testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ARR testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -383,7 +435,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/DASG testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/DASG testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/DASG testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -397,7 +451,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/EXCP testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/EXCP testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXCP testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -411,7 +467,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/EXEC testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/EXEC testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXEC testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -425,7 +483,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/FP testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/FP  testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/FP  testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -439,7 +499,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/ICLS testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/ICLS testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ICLS testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -453,7 +515,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/INFR testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/INFR testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/INFR testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -467,7 +531,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/MOD testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/MOD testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/MOD testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -484,7 +550,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/NAME testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/NAME testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/NAME testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -498,7 +566,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/PKGS testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/PKGS testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/PKGS testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -512,7 +582,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/THRD testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/THRD testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/THRD testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -526,7 +598,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/TYPE testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/TYPE testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/TYPE testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -548,7 +622,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/ANNOT testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/ANNOT testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ANNOT testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -562,7 +638,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/LEX testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/LEX testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/LEX testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -576,7 +654,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/STMT testsuite=COMPILER; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/STMT testsuite=COMPILER; \
+		$(EXEC_COMPILER_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/STMT testsuite=COMPILER; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/jck/devtools.java2schema/playlist.xml
+++ b/jck/devtools.java2schema/playlist.xml
@@ -18,7 +18,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=java2schema/CustomizedMapping testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=java2schema/CustomizedMapping testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=java2schema/CustomizedMapping testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -35,7 +37,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=java2schema/DefaultMapping testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=java2schema/DefaultMapping testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=java2schema/DefaultMapping testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/jck/devtools.jaxws/playlist.xml
+++ b/jck/devtools.jaxws/playlist.xml
@@ -19,7 +19,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=jaxws/mapping testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=jaxws/mapping testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=jaxws/mapping testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/jck/devtools.schema2java/playlist.xml
+++ b/jck/devtools.schema2java/playlist.xml
@@ -19,7 +19,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema2java/nisttest testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema2java/nisttest testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema2java/nisttest testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -36,7 +38,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema2java/structures testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema2java/structures testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema2java/structures testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/jck/devtools.schema_bind/playlist.xml
+++ b/jck/devtools.schema_bind/playlist.xml
@@ -19,7 +19,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema_bind/bind_class testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_class testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_class testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -36,7 +38,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema_bind/bind_dom testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_dom testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_dom testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -53,7 +57,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema_bind/bind_factoryMethod testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_factoryMethod testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_factoryMethod testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -70,7 +76,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema_bind/bind_globalBindings testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_globalBindings testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_globalBindings testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -87,7 +95,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema_bind/bind_inlineBinaryData testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_inlineBinaryData testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_inlineBinaryData testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -104,7 +114,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema_bind/bind_javaType testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_javaType testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_javaType testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -121,7 +133,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema_bind/bind_property testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_property testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_property testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -138,7 +152,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=schema_bind/bind_schemaBindings testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_schemaBindings testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_schemaBindings testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/jck/devtools.xml_schema/playlist.xml
+++ b/jck/devtools.xml_schema/playlist.xml
@@ -19,7 +19,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/boeingData testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=xml_schema/boeingData testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/boeingData testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -36,7 +38,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP1) testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP1) testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP1) testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -53,7 +57,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP2) testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP2) testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP2) testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -70,7 +76,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP3) testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP3) testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP3) testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -87,7 +95,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP4) testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP4) testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP4) testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -104,7 +114,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/nistData testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=xml_schema/nistData testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -121,7 +133,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/sunData testsuite=DEVTOOLS; \
+		<command>$(GEN_JTB_GENERIC) tests=xml_schema/sunData testsuite=DEVTOOLS; \
+		$(EXEC_DEVTOOLS_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/sunData testsuite=DEVTOOLS; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -131,22 +131,40 @@ ifneq ($(filter aix_ppc-64 zos_390 linux_ppc-64_le linux_390-64, $(SPEC)),)
    REFERENCE_JAVA_CMD=/home/jenkins/jckshare/ri/jdk-11.0.19/bin/java
    USEQ='
    PREP = mkdir -p $(WORKSPACE); cp -rf $(CONFIG_ALT_PATH)$(D)jck$(JCK_VERSION_NUMBER)$(D)compiler.jti $(WORKSPACE)$(D); cp -rf $(TEST_ROOT)$(D)jck$(D)jtrunner $(WORKSPACE)
-   GEN_JTB = $(PREP); ssh -o StrictHostKeyChecking=no jenkins@$(AGENT_NODE) $(USEQ)$(REFERENCE_JAVA_CMD) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(WORKSPACE)$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) testJava=$(JAVA_TO_TEST) riJava=$(REFERENCE_JAVA_CMD) workdir=$(WORKSPACE) configAltPath=$(CONFIG_ALT_PATH) agentHost=$(NODE_NAME) task=cmdfilegen testExecutionType=multijvm
-   GEN_SUMMARY = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) workdir=$(WORKSPACE) task=summarygen
+   GEN_JTB = $(PREP); ssh -o StrictHostKeyChecking=no jenkins@$(AGENT_NODE) $(USEQ)$(REFERENCE_JAVA_CMD) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(WORKSPACE)$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) testJava=$(JAVA_TO_TEST) riJava=$(REFERENCE_JAVA_CMD) workdir=$(WORKSPACE) configAltPath=$(CONFIG_ALT_PATH) agentHost=$(NODE_NAME) task=cmdfilegen spec=$(SPEC) testExecutionType=multijvm
+   GEN_SUMMARY = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) workdir=$(WORKSPACE) spec=$(SPEC) task=summarygen
    START_AGENT = $(JAVA_TO_TEST) -Djavatest.security.allowPropertiesAccess=true -Djava.security.policy=$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)jck.policy -classpath $(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar$(P)$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)classes com.sun.javatest.agent.AgentMain -passive -trace &> $(WORKSPACE)$(D)agent.log &
    START_HARNESS = ssh -o StrictHostKeyChecking=no jenkins@$(AGENT_NODE) $(REFERENCE_JAVA_CMD) -jar $(JCK_ROOT)$(D)JCK-runtime-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar -config $(WORKSPACE)$(D)compiler.jti @$(WORKSPACE)$(D)generated.jtb
 else
    REFERENCE_JAVA_CMD=$(TEST_ROOT)/../additionaljdkbinary/bin/java
-   GEN_JTB = $(REFERENCE_JAVA_CMD) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) testJava=$(JAVA_TO_TEST) riJava=$(REFERENCE_JAVA_CMD) workdir=$(REPORTDIR) configAltPath=$(CONFIG_ALT_PATH) agentHost=localhost task=cmdfilegen testExecutionType=multijvm
-   GEN_SUMMARY = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) workdir=$(REPORTDIR) task=summarygen
+   GEN_JTB = $(REFERENCE_JAVA_CMD) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) testJava=$(JAVA_TO_TEST) riJava=$(REFERENCE_JAVA_CMD) workdir=$(REPORTDIR) configAltPath=$(CONFIG_ALT_PATH) task=cmdfilegen spec=$(SPEC) testExecutionType=multijvm 
+   GEN_SUMMARY = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)$(D)jck$(D)jtrunner$(D)bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) workdir=$(REPORTDIR) spec=$(SPEC) task=summarygen
    START_AGENT = $(JAVA_TO_TEST) -Djavatest.security.allowPropertiesAccess=true -Djava.security.policy=$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)jck.policy -classpath $(Q)$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar$(P)$(JCK_ROOT)$(D)JCK-compiler-$(JCK_VERSION_NUMBER)$(D)classes$(Q) com.sun.javatest.agent.AgentMain -passive -trace &> $(REPORTDIR)$(D)agent.log &
    START_HARNESS = $(REFERENCE_JAVA_CMD) -jar $(JCK_ROOT)$(D)JCK-runtime-$(JCK_VERSION_NUMBER)$(D)lib$(D)javatest.jar -config $(CONFIG_ALT_PATH)$(D)jck$(JCK_VERSION_NUMBER)$(D)compiler.jti @$(REPORTDIR)$(D)generated.jtb
 endif
 
-define START_MULTI_JVM_COMP_TEST
-chmod +x $(TEST_ROOT)$(D)jck$(D)agent-drive.sh; \
-$(TEST_ROOT)$(D)jck$(D)agent-drive.sh '$(START_AGENT)' '$(START_HARNESS)'
-endef
+$(shell chmod +x $(TEST_ROOT)$(D)jck$(D)agent-drive.sh)
+
+START_MULTI_JVM_COMP_TEST = $(TEST_ROOT)$(D)jck$(D)agent-drive.sh '$(START_AGENT)' '$(START_HARNESS)'
+GEN_JTB_GENERIC = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) workdir=$(REPORTDIR) configAltPath=$(CONFIG_ALT_PATH) testJava=$(JAVA_TO_TEST) riJava=$(JAVA_TO_TEST) task=cmdfilegen spec=$(SPEC) $(APPLICATION_OPTIONS)
+GEN_SUMMARY_GENERIC = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) workdir=$(REPORTDIR) spec=$(SPEC) task=summarygen
+START_AGENT_GENERIC = $(JAVA_TO_TEST) -Djavatest.security.allowPropertiesAccess=true -Djava.security.policy=$(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/lib/jck.policy -classpath $(Q)$(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/lib/javatest.jar$(P)$(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/classes$(Q) com.sun.javatest.agent.AgentMain -passive -trace &> $(REPORTDIR)/agent.log &
+START_RMIREG = $(TEST_JDK_HOME)/bin/rmiregistry > $(REPORTDIR)$(D)rmiregistry.log &
+START_RMID = $(TEST_JDK_HOME)/bin/rmid -J-Dsun.rmi.activation.execPolicy=none -J-Djava.security.policy=$(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/lib/jck.policym > $(REPORTDIR)$(D)rmid.log &
+START_TNAMESRV = $(TEST_JDK_HOME)/bin/tnameserv -ORBInitialPort 9876 > $(REPORTDIR)$(D)tnameserv.log &
+EXEC_RUNTIME_TEST = $(JAVA_TO_TEST) -jar $(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/lib/javatest.jar -config $(CONFIG_ALT_PATH)/$(JCK_VERSION)/runtime.jti @$(REPORTDIR)/generated.jtb
+EXEC_COMPILER_TEST = $(JAVA_TO_TEST) -jar $(JCK_ROOT)/JCK-compiler-$(JCK_VERSION_NUMBER)/lib/javatest.jar -config $(CONFIG_ALT_PATH)/$(JCK_VERSION)/compiler.jti @$(REPORTDIR)/generated.jtb
+EXEC_DEVTOOLS_TEST = $(JAVA_TO_TEST) -jar $(JCK_ROOT)/JCK-devtools-$(JCK_VERSION_NUMBER)/lib/javatest.jar -config $(CONFIG_ALT_PATH)/$(JCK_VERSION)/devtools.jti @$(REPORTDIR)/generated.jtb
+EXEC_RUNTIME_TEST_WITH_AGENT = $(TEST_ROOT)/jck/agent-drive.sh '$(START_AGENT_GENERIC)' '$(EXEC_RUNTIME_TEST)'
+EXEC_RUNTIME_TEST_WITH_SERVICES = $(EXEC_RUNTIME_TEST)
+
+ifeq ($(JDK_VERSION), 8)
+	EXEC_RUNTIME_TEST_WITH_SERVICES = $(TEST_ROOT)/jck/agent-drive.sh '$(START_AGENT_GENERIC)' '$(START_RMIREG)' '$(START_RMID)' '$(START_TNAMESRV)' '$(EXEC_RUNTIME_TEST)'
+endif
+
+ifeq ($(JDK_VERSION), 11)
+	EXEC_RUNTIME_TEST_WITH_SERVICES = $(TEST_ROOT)/jck/agent-drive.sh '$(START_RMIREG)' '$(START_RMID)' '$(START_AGENT_GENERIC)' '$(EXEC_RUNTIME_TEST)'
+endif
 
 ifeq (8, $(JDK_VERSION))
    COMPILER_LANG_CLASS_TESTS_GROUP1=$(Q)lang/CLSS/clss426;lang/CLSS/clss419;lang/CLSS/clss089;lang/CLSS/clss421;lang/CLSS/clss045;lang/CLSS/clss087;lang/CLSS/clss073;lang/CLSS/clss417;lang/CLSS/clss428;lang/CLSS/clss410;lang/CLSS/clss074;lang/CLSS/clss444;lang/CLSS/clss020;lang/CLSS/clss212;lang/CLSS/clss018;lang/CLSS/clss215;lang/CLSS/clss027;lang/CLSS/clss443;lang/CLSS/clss481;lang/CLSS/clss475;lang/CLSS/clss223;lang/CLSS/clss011;lang/CLSS/clss029;lang/CLSS/clss016;lang/CLSS/clss224;lang/CLSS/clss472;lang/CLSS/clss411;lang/CLSS/clss075;lang/CLSS/clss072;lang/CLSS/clss416;lang/CLSS/clss086$(Q)

--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -11,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -58,19 +57,17 @@ public class JavatestUtil {
 	private static String config;
 	private static String configAltPath;
 	private static String jckRoot;
-
 	private static String testSuite;
 	private static String jckBase;
 	private static String jtiFile;
 	private static String nativesLoc;
 	private static String jckConfigLoc;
-	private static String initialJtxFullPath;
-	private static String jtxFullPath;
-	private static String kflFullPath;
-	private static String fipsJtxFullPath;
-	private static String krbConfFile;
+	private static String initialJtxFullPath = "";
+	private static String defaultJtxFullPath = "";
+	private static String kflFullPath = "";
+	private static String customJtx = "";
+	private static String krbConfFile = "";
 	private static String fileUrl;
-
 	private static String jckPolicyFileFullPath;
 	private static String jtliteJarFullPath; 
 	private static String javatestJarFullPath;
@@ -99,17 +96,12 @@ public class JavatestUtil {
 	private static String agentHost;
 	private static String testJavaForMultiJVMCompTest;
 	private static String riJavaForMultiJVMCompTest;
-
+	private static String spec;
+	private static String osShortName;
 	private static HashMap<String, String> testArgs = new HashMap<String, String>();
 	private static String jvmOpts = ""; 
-
-	// Variables to contain the JVM options required to suppress dumps being taken for OutOfMemory exceptions
-	private static String suppressOutOfMemoryDumpOptions = "";
-
 	private static int freePort;
-	private static String archName = System.getProperty("os.arch");
-	private static String platform = getOSNameShort();
-	
+	private static String suppressOutOfMemoryDumpOptions = ""; // Contains JVM options to suppress dumps being taken for OutOfMemory exceptions
 	private static final String TEST_ROOT = "testRoot";
 	private static final String JCK_ROOT = "jckRoot";
 	private static final String TESTS = "tests";
@@ -128,6 +120,8 @@ public class JavatestUtil {
 	private static final String TEST_JAVA_FOR_MULTIJVM_COMP_TEST = "testJava";
 	private static final String RI_JAVA_FOR_MULTIJVM_COMP_TEST = "riJava";
 	private static final String WORK_DIR = "workdir";
+	private static final String SPEC = "spec";
+	private static final String CUSTOM_JTX = "customJtx";
 
 	public static void main(String args[]) throws Exception {
 		ArrayList<String> essentialParameters = new ArrayList<String>(); 
@@ -147,6 +141,8 @@ public class JavatestUtil {
 		essentialParameters.add(TEST_JAVA_FOR_MULTIJVM_COMP_TEST);
 		essentialParameters.add(RI_JAVA_FOR_MULTIJVM_COMP_TEST);
 		essentialParameters.add(WORK_DIR);
+		essentialParameters.add(SPEC);
+		essentialParameters.add(CUSTOM_JTX);
 
 		for (String arg : args) {
 			if (arg.contains("=")) {
@@ -183,51 +179,49 @@ public class JavatestUtil {
 		jvmOpts = System.getProperty("jvm.options").trim() + " " + System.getProperty("other.opts");
 		testFlag = System.getenv("TEST_FLAG");
 		task = testArgs.get(TASK).trim();
+		customJtx = testArgs.get(CUSTOM_JTX) == null ? "" : testArgs.get(CUSTOM_JTX);
+		spec = testArgs.get(SPEC);
+		osShortName = getOSNameShort();
 		
-		if (task.equals("cmdfilegen")) { 
-			agentHost = testArgs.get(AGENT_HOST).trim();
+		if (osShortName == null) {
+			System.out.println("Unknown spec value supplied : " + spec);
+			System.exit(1);
 		}
 		
 		testJdk = System.getenv("JAVA_HOME");
+		pathToJava = testJdk + File.separator + "bin" + File.separator + "java";
 		tests = testArgs.get(TESTS).trim();
 		jckVersion = testArgs.get(JCK_VERSION);
 		jckRoot = new File(testArgs.get(JCK_ROOT)).getCanonicalPath();
 		testSuite = testArgs.get(TEST_SUITE);
-		testExecutionType = testArgs.get(TEST_EXECUTION_TYPE) == null ? "multijvm" : testArgs.get(TEST_EXECUTION_TYPE);
+		testExecutionType = testArgs.get(TEST_EXECUTION_TYPE) == null ? "default" : testArgs.get(TEST_EXECUTION_TYPE);
 		withAgent = testArgs.get(WITH_AGENT) == null ? "off" : testArgs.get(WITH_AGENT);
 		interactive = testArgs.get(INTERACTIVE) == null ? "no" : testArgs.get(INTERACTIVE);
 		concurrencyString = testArgs.get("concurrency") == null ? "NULL" : testArgs.get("concurrency");
 		config = testArgs.get(CONFIG) == null ? "NULL" : testArgs.get(CONFIG);
 		configAltPath = testArgs.get(CONFIG_ALT_PATH) == null ? "NULL" : testArgs.get(CONFIG_ALT_PATH);
+		agentHost = testArgs.get(AGENT_HOST) == null ? "localhost" : testArgs.get(AGENT_HOST).trim();
 		testRoot = new File(testArgs.get(TEST_ROOT)).getCanonicalPath();
-		testJavaForMultiJVMCompTest = testArgs.get(TEST_JAVA_FOR_MULTIJVM_COMP_TEST);
-		riJavaForMultiJVMCompTest = testArgs.get(RI_JAVA_FOR_MULTIJVM_COMP_TEST);
+		testJavaForMultiJVMCompTest = testArgs.get(TEST_JAVA_FOR_MULTIJVM_COMP_TEST) == null ? pathToJava : testArgs.get(TEST_JAVA_FOR_MULTIJVM_COMP_TEST);
+		riJavaForMultiJVMCompTest = testArgs.get(RI_JAVA_FOR_MULTIJVM_COMP_TEST) == null ? pathToJava : testArgs.get(RI_JAVA_FOR_MULTIJVM_COMP_TEST);  
 		workDir = testArgs.get(WORK_DIR);
-		
 		jckVersionNo = jckVersion.replace("jck", "");
-		
 		testSuiteFolder = "JCK-" + testSuite.toString().toLowerCase() + "-" + jckVersionNo;
 		jckBase = jckRoot + File.separator + testSuiteFolder;
 		jckPolicyFileFullPath = jckBase + File.separator + "lib" + File.separator + "jck.policy";
 		javatestJarFullPath = jckBase + File.separator + "lib" + File.separator + "javatest.jar";
 		jtliteJarFullPath = jckBase + File.separator + "lib" + File.separator + "jtlite.jar"; 
 		classesFullPath = jckBase + File.separator + "classes";
-		nativesLoc = jckRoot + File.separator + "natives" + File.separator + platform;
-
+		nativesLoc = jckRoot + File.separator + "natives" + File.separator + osShortName;
 		reportDir = workDir + File.separator + "report";
 		newJtbFileRef = workDir + File.separator + "generated.jtb";
 		
-		jtiFile = configAltPath + File.separator + jckVersion + File.separator + testSuite.toLowerCase() + ".jti"; 
-		fileUrl = "file:///" + jckBase + "/testsuite.jtt";
+		// Solaris natives are in /natives/sunos
+		if (spec.contains("solaris")) {
+			nativesLoc = jckRoot + File.separator + "natives" + File.separator + "sunos";
+		}
 		
-		// The first release of a JCK will have an initial excludes (.jtx) file in test-suite/lib - e.g. JCK-runtime-8b/lib/jck8b.jtx.
-		// Updates to the excludes list may subsequently be supplied as a separate file, which supersedes the initial file.
-		// A known failures list (.kfl) file is optional.
-		// The automation here adds any files found (initial or updates) as 'custom' files. 
-		initialJtxFullPath = jckBase + "/lib/" + jckVersion + ".jtx";
-		
-		File f = new File(jckRoot);
-		File[] files = f.listFiles();
+		File[] files = new File(jckRoot).listFiles();
 		boolean found = false;
 		for (File file : files) {
 			if (file.isDirectory() && (file.getName().contains("JCK-runtime")) ) {
@@ -247,12 +241,7 @@ public class JavatestUtil {
 			System.out.println("Cannot locate the JCK artifacts under : " + jckRoot);
 			System.exit(1);
 		}
-
-		// Solaris natives are in /natives/sunos
-		if (platform.equals("solaris")) {
-			nativesLoc = jckRoot + File.separator + "natives" + File.separator + "sunos";
-		}
-	
+		
 		try { 
 			if (task.equals(TASK_GENERATE_SUMMARY_REPORT)) { 
 				if (!generateSummary()) {
@@ -260,59 +249,7 @@ public class JavatestUtil {
 				}
 				System.exit(0);
 			}	
-		} catch (Exception e) {
-			e.printStackTrace(); 
-			System.exit(1);
-		}
-		
-		System.out.println("Using jti file "+ jtiFile);
-		
-		File initialJtxFile = new File(initialJtxFullPath);
-
-		if (initialJtxFile.exists()) {
-			System.out.println("Using initial excludes list file " + initialJtxFullPath);
-		} else {
-			System.out.println("Unable to find initial excludes list file " + initialJtxFullPath);
-			initialJtxFullPath = "";
-		}
-
-		jtxFullPath = jckRoot + File.separator + "excludes" + File.separator + jckVersion + ".jtx";
-		File jtxFile = new File(jtxFullPath);
-		
-		if (jtxFile.exists()) {
-			System.out.println("Using additional excludes list file " + jtxFullPath);
-		} else {
-			System.out.println("Unable to find additional excludes list file " + jtxFullPath);
-			jtxFullPath = "";
-		}
-
-		// Look for a known failures list file
-		kflFullPath = jckRoot + File.separator + "excludes" + File.separator + jckVersion + ".kfl";
-		File kflFile = new File(kflFullPath);
-		
-		if (kflFile.exists()) { 
-			System.out.println("Using known failures list file " + kflFullPath);
-		} else {
-			System.out.println("Unable to find known failures list file " + kflFullPath);
-			kflFullPath = "";
-		}
-		
-		fipsJtxFullPath = "";
-		if (testFlag != null && testFlag.equals("FIPS")) {
-			// Look for a known failures list file specific to FIPS testing
-			fipsJtxFullPath = jckRoot + File.separator + "excludes" + File.separator + jckVersion + "-fips.jtx";
-			File fipsJtxFile = new File(fipsJtxFullPath);
-			
-			if (fipsJtxFile.exists()) {
-				System.out.println("Using FIPS specific failures list file " + fipsJtxFullPath);
-			} else {
-				System.out.println("Unable to find FIPS specific failures list file " + fipsJtxFullPath);
-				fipsJtxFullPath = "";
-			}
-		}
-		
-		try { 
-			if (task.equals(TASK_CMD_FILE_GENERATION)) { 
+			else if (task.equals(TASK_CMD_FILE_GENERATION)) { 
 				if (!generateJTB()) {
 					System.exit(1);
 				}
@@ -325,6 +262,49 @@ public class JavatestUtil {
 	}
 	
 	private static boolean generateJTB() throws Exception {
+		jtiFile = configAltPath + File.separator + jckVersion + File.separator + testSuite.toLowerCase() + ".jti";
+		System.out.println("Using jti file "+ jtiFile);
+		
+		if (spec.contains("win")) {
+			// Jck fileURL validator validates using java.net.URI, so must use forward slashes "/" 
+			fileUrl = "file:///" + jckBase.replace("\\","/") + "/testsuite.jtt";
+		} else {
+			fileUrl = "file:///" + jckBase + "/testsuite.jtt";
+		}
+		
+		// The first release of a JCK will have an initial excludes (.jtx) file in test-suite/lib - e.g. JCK-runtime-8b/lib/jck8b.jtx.
+		// Updates to the excludes list may subsequently be supplied as a separate file, which supersedes the initial file.
+		// A known failures list (.kfl) file is optional.
+		// The automation here adds any files found (initial or updates) as 'custom' files. 
+		initialJtxFullPath = jckBase + "/lib/" + jckVersion + ".jtx";
+		if (new File(initialJtxFullPath).exists()) {
+			System.out.println("Using initial jtx file:" + initialJtxFullPath);
+		} else {
+			initialJtxFullPath = "";
+		}
+		
+		// Include any default jtx file that came as part of tck repo 
+		defaultJtxFullPath = jckRoot + File.separator + "excludes" + File.separator + jckVersion + ".jtx";
+		if (new File(defaultJtxFullPath).exists()) {
+			System.out.println("Using default jtx file:" + defaultJtxFullPath);
+		} else {
+			defaultJtxFullPath = "";
+		}
+		
+		// Include any known failures list(kfl) file if it came with the tck repo
+		kflFullPath = jckRoot + File.separator + "excludes" + File.separator + jckVersion + ".kfl";
+		if (new File(kflFullPath).exists()) { 
+			System.out.println("Using kfl file: " + kflFullPath);
+		} else {
+			kflFullPath = "";
+		}
+		
+		if (customJtx != "") { 
+			System.out.println("Using custom exclude file(s): " + customJtx);
+		} else {
+			customJtx = "";
+		}
+		
 		if (testSuite.equals("RUNTIME") && (tests.contains("api/java_net") || tests.contains("api/java_nio") || tests.contains("api/org_ietf") || tests.contains("api/javax_security") || tests.equals("api"))) {
 			if (!configAltPath.equals("NULL")) {
 				jckConfigLoc = configAltPath + File.separator + "default";
@@ -425,22 +405,10 @@ public class JavatestUtil {
 		fileContent += "workDirectory -create " + workDir + File.separator +  "work" + ";\n";
 		fileContent += "tests " + tests + ";\n";
 
-		pathToJava = testJdk + File.separator + "bin" + File.separator + "java";
 		String pathToRmic = testJdk + File.separator + "bin" + File.separator + "rmic";
 		String pathToLib = testJdk + File.separator + "jre" + File.separator + "lib";
 		String pathToJavac = testJdk + File.separator + "bin" + File.separator + "javac";
 		String pathToToolsJar = testJdk + File.separator + "lib" + File.separator + "tools.jar";
-		// Use escaped backslashes for paths on Windows
-		if (platform.contains("win")) {
-			pathToJava = pathToJava.replace("/", "\\") + ".exe";
-			pathToRmic = pathToRmic.replace("/", "\\") + ".exe";
-			pathToLib = pathToLib.replace("/", "\\");
-			pathToJavac = pathToJavac.replace("/", "\\") + ".exe";
-			pathToToolsJar = pathToToolsJar.replace("/", "\\");
-		}
-
-		String jckRuntimeNativeLibValue = nativesLoc;
-		String jckRuntimeJmxLibValue = nativesLoc;
 		int concurrency;
 		String keyword = "";
 		String libPath = "";
@@ -448,13 +416,21 @@ public class JavatestUtil {
 		String hostname = "";
 		String ipAddress = "";
 		extraJvmOptions = jvmOpts;
+		
+		// Use escaped backslashes for paths on Windows
+		if (spec.contains("win")) {
+			pathToJava = pathToJava.replace("/", "\\") + ".exe";
+			pathToRmic = pathToRmic.replace("/", "\\") + ".exe";
+			pathToLib = pathToLib.replace("/", "\\");
+			pathToJavac = pathToJavac.replace("/", "\\") + ".exe";
+			pathToToolsJar = pathToToolsJar.replace("/", "\\");
+		}
 
 		InetAddress addr = InetAddress.getLocalHost();
 		ipAddress = addr.getHostAddress();
 		hostname = addr.getHostName();
-
 		freePort = getFreePort();
-
+		
 		if (freePort == -1) {
 			System.out.println("Unable to get a free port");
 			return false; 
@@ -472,8 +448,13 @@ public class JavatestUtil {
 			concurrencyString = String.valueOf(concurrency);
 		}
 		
-		if (platform.contains("zos")) {
+		if (spec.contains("zos")) {
 			extraJvmOptions += " -Dfile.encoding=US-ASCII";
+		}
+		
+		// testExecutionType of multiJVM_group on Windows and AIX causes memory exhaustion, so limit to non-group multiJVM
+		if (getJckVersionInt(jckVersionNo) >= 17 && (spec.contains("win") || spec.contains("aix"))) {
+			fileContent += "set jck.env.testPlatform.multiJVM \"Yes\";\n";
 		}
 
 		// Set the operating system as 'Windows' for Windows and 'other' for all other operating systems.
@@ -489,30 +470,30 @@ public class JavatestUtil {
 				keyword = "keywords !interactive";
 			}
 
-			if (platform.contains("win")) {
+			if (spec.contains("win")) {
 				libPath = "PATH";
 				robotAvailable = "Yes";
-			} else if (platform.contains("alpine-linux")) {
+			} else if (spec.contains("alpine-linux")) {
 				libPath = "LD_LIBRARY_PATH";
 				robotAvailable = "No";
-			} else if (platform.contains("linux")) {
+			} else if (spec.contains("linux")) {
 				libPath = "LD_LIBRARY_PATH";
 				robotAvailable = "Yes";
-			} else if (platform.contains("aix")) {
+			} else if (spec.contains("aix")) {
 				libPath = "LIBPATH";
 				robotAvailable = "Yes";
-			} else if (platform.contains("zos")) {
+			} else if (spec.contains("zos")) {
 				pathToLib = testJdk + File.separator + "lib";
 				libPath = "LIBPATH";
 				robotAvailable = "No";
-			} else if (platform.contains("osx")) {
+			} else if (spec.contains("osx")) {
 				libPath = "DYLD_LIBRARY_PATH";
 				robotAvailable = "Yes";
-			} else if (platform.contains("solaris")) {
+			} else if (spec.contains("sunos")) {
 				libPath = "LD_LIBRARY_PATH";
 				robotAvailable = "Yes";
 			} else {
-				System.out.println("Unknown platform:: " + platform);
+				System.out.println("Unknown spec: " + spec);
 				return false; 
 			}
 			
@@ -520,7 +501,7 @@ public class JavatestUtil {
 			fileContent += "timeoutfactor 4" + ";\n";	// 4 base time limit equal 40 minutes
 			fileContent += keyword + ";\n";
 
-			if (platform.equals("win")) {
+			if (spec.contains("win")) {
 				// On Windows set the testplatform.os to Windows and set systemRoot, but do not
 				// set the file and path separators (an error is thrown if they are set).
 				fileContent += "set jck.env.testPlatform.os \"Windows\";\n";
@@ -534,17 +515,17 @@ public class JavatestUtil {
 			}
 
 			if ( testsRequireDisplay(tests) ) {
-				if (platform.equals("zos") || platform.equals("alpine-linux")) {
+				if (spec.contains("zos") || spec.contains("alpine-linux")) {
 					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
 				}
 				else {
-					if ( !platform.equals("win") ) {
+					if ( !spec.contains("win") ) {
 						fileContent += "set jck.env.testPlatform.headless No" + ";\n";
 						fileContent += "set jck.env.testPlatform.xWindows Yes" + ";\n";
-						if ( !platform.equals("osx") ) { 
+						if ( !spec.contains("osx") ) { 
 							String display = System.getenv("DISPLAY");
 							if ( display == null ) {
-								System.out.println("Error: DISPLAY must be set to run tests " + tests + " on " + platform);
+								System.out.println("Error: DISPLAY must be set to run tests " + tests + " on " + spec);
 								return false; 
 							}
 							else {
@@ -559,7 +540,7 @@ public class JavatestUtil {
 				keyword += "&!robot";
 			}
 
-			if ( !platform.equals("win") && (tests.contains("api/signaturetest") || tests.contains("api/java_io")) ) {
+			if ( !spec.contains("win") && (tests.contains("api/signaturetest") || tests.contains("api/java_io")) ) {
 				fileContent += "set jck.env.testPlatform.xWindows \"No\"" + ";\n";
 			}
 
@@ -568,23 +549,24 @@ public class JavatestUtil {
 			if ( tests.equals("api/java_lang") || tests.contains("api/java_lang/instrument") ||
 					tests.contains("api/javax_management") || tests.equals("api") || tests.startsWith("vm") ) {
 				fileContent += "set jck.env.runtime.testExecute.libPathEnv " + libPath + ";\n";
-				fileContent += "set jck.env.runtime.testExecute.nativeLibPathValue \"" + jckRuntimeNativeLibValue + "\"" + ";\n";
+				fileContent += "set jck.env.runtime.testExecute.nativeLibPathValue \"" + nativesLoc + "\"" + ";\n";
 			}
-
+			
 			// tools.jar was incorporated into modules from Java 9
 			if ( jckVersion.contains("jck8") ) {
 				if ( tests.startsWith("vm/jvmti") || tests.equals("vm") || tests.equals("api") || tests.equals("api/java_lang") || tests.contains("api/java_lang/instrument") ) {
 					fileContent += "set jck.env.runtime.testExecute.additionalClasspathRemote \"" + pathToToolsJar + "\"" + ";\n";
 				}
 			}
-
+			
 			if ( tests.startsWith("vm/jvmti") || tests.equals("vm") ) {
 				fileContent += "set jck.env.runtime.testExecute.jvmtiLivePhase Yes;\n";
 			}
-
+			
 			if ( tests.contains("api/javax_management") || tests.equals("api") ) {
-				fileContent += "set jck.env.runtime.testExecute.jmxResourcePathValue \"" + jckRuntimeJmxLibValue + "\"" + ";\n";
+				fileContent += "set jck.env.runtime.testExecute.jmxResourcePathValue \"" + nativesLoc + "\"" + ";\n";
 			}
+			
 			if ( tests.contains("api/javax_sound") || tests.equals("api") ) {
 				fileContent += "set jck.env.runtime.audio.canPlaySound No" + ";\n";
 				fileContent += "set jck.env.runtime.audio.canPlayMidi No" + ";\n";
@@ -614,10 +596,12 @@ public class JavatestUtil {
 				fileContent += "set jck.env.runtime.net.testHost2Name " + testHost2Name + ";\n";
 				fileContent += "set jck.env.runtime.net.testHost2IPAddr " + testHost2Ip + ";\n";
 			}
+			
 			if ( tests.contains("api/java_net") || tests.equals("api") ) {
 				fileContent += "set jck.env.runtime.url.httpURL " + httpUrl + ";\n";
 				fileContent += "set jck.env.runtime.url.fileURL " + fileUrl + ";\n";
 			}
+			
 			if ( tests.contains("api/java_net") || tests.contains("api/org_omg") || tests.contains("api/javax_management") || tests.contains("api/javax_xml") || tests.contains("vm/jdwp") || tests.equals("api")) {
 				if ( !tests.contains("api/javax_xml/bind") &&
 						!tests.contains("api/javax_xml/soap") &&
@@ -627,6 +611,7 @@ public class JavatestUtil {
 					fileContent += "set jck.env.runtime.remoteAgent.passivePortDefault Yes" + ";\n";
 				}
 			}
+			
 			// Without the following override the following failures occur:
 			// Fatal Error: file:/jck/jck8b/JCK-runtime-8b/tests/api/javax_xml/xmlCore/w3c/ibm/valid/P85/ibm85v01.xml(6,3384): JAXP00010005: The length of entity "[xml]" is "3,381" that exceeds the "1,000" limit set by "FEATURE_SECURE_PROCESSING".
 			// Fatal Error: file:/jck/jck8b/JCK-runtime-8b/tests/api/javax_xml/xmlCore/w3c/ibm/valid/P85/ibm85v01.xml(6,3384): JAXP00010005: The length of entity "[xml]" is "3,381" that exceeds the "1,000" limit set by "default".
@@ -674,7 +659,6 @@ public class JavatestUtil {
 
 			// Get any additional jvm options for specific tests.
 			extraJvmOptions += getTestSpecificJvmOptions(jckVersion, tests);
-
 			extraJvmOptions += suppressOutOfMemoryDumpOptions;
 
 			if (getJckVersionInt(jckVersionNo) > 11) {
@@ -685,18 +669,17 @@ public class JavatestUtil {
 			fileContent += "set jck.env.runtime.testExecute.otherOpts \" " + extraJvmOptions + " \"" + ";\n";
 
 			// Tests that need Display on OSX also require AWT_FORCE_HEADFUL=true 
-			if (platform.equals("osx")) {
+			if (spec.contains("osx")) {
 				fileContent += "set jck.env.runtime.testExecute.otherEnvVars \" AWT_FORCE_HEADFUL=true \"" + ";\n";
 			}
 		}
 
 		// Compiler settings
 		if (testSuite.equals("COMPILER")) {
-
 			keyword = "keywords compiler";
 
 			// Overrides only required on zOS for compiler tests
-			if (platform.equals("zos")) {
+			if (spec.contains("zos")) {
 				pathToLib = testJdk + File.separator + "lib";
 			} 
 
@@ -704,7 +687,7 @@ public class JavatestUtil {
 			fileContent += "timeoutfactor 100" + ";\n";							// lang.CLSS,CONV,STMT,INFR requires more than 1h to complete. lang.Annot,EXPR,LMBD require more than 2h to complete tests
 			fileContent += keyword + ";\n";
 			
-			if (testExecutionType != null && testExecutionType.equals("multijvm")) { 
+			if (testExecutionType.equals("multijvm")) { 
 				fileContent += "set jck.env.testPlatform.useAgent \"Yes\";\n";
 				fileContent += "set jck.env.compiler.agent.agentType \"passive\";\n";
 				fileContent += "set jck.env.compiler.agent.passiveHost \"" + agentHost + "\"" + ";\n";
@@ -712,12 +695,12 @@ public class JavatestUtil {
 			}
 			
 			String cmdAsStringOrFile = "cmdAsString"; // Whether to reference cmd via cmdAsString or cmdAsFile
-			if (platform.equals("win")) {
+			if (spec.contains("win")) {
 				// On Windows set the testplatform.os to Windows and set systemRoot, but do not
 				// set the file and path separators (an error is thrown if they are set).
 				fileContent += "set jck.env.testPlatform.os \"Windows\";\n";
 				fileContent += "set jck.env.testPlatform.systemRoot " + System.getenv("WINDIR") + ";\n";
-			} else if (!jckVersion.contains("jck8") && (platform.equals("zos") || platform.equals("aix"))) {
+			} else if (!jckVersion.contains("jck8") && (spec.contains("zos") || spec.contains("aix"))) {
 				// On jck11+ z/OS and AIX set the testplatform.os Current system
 				// due to JCK class OsHelper bug with getFileSep() in Compiler JCK Interviewer
 				fileContent += "set jck.env.testPlatform.os \"Current system\";\n";
@@ -742,17 +725,16 @@ public class JavatestUtil {
 				fileContent += "set jck.env.compiler.testCompile.otherOpts \"-source 11 \"" + ";\n";
 			} else { // This is the case where JCK Version > 11
 				fileContent += "set jck.env.compiler.testCompile.otherOpts \"-source " + jckVersionNo + " --enable-preview\"" + ";\n";
-			} 
+			}
 
 			if (tests.contains("api/java_rmi") || tests.equals("api")) {
 				fileContent += "set jck.env.compiler.testRmic." + cmdAsStringOrFile + " \"" + pathToRmic + "\"" + ";\n";
 			}
 			
 			System.out.println("RI JDK Used: " + riJavaForMultiJVMCompTest);
-			
 			fileContent += "set jck.env.compiler.compRefExecute." + cmdAsStringOrFile + " \"" + riJavaForMultiJVMCompTest + "\"" + ";\n";
 
-			if (!jckVersion.contains("jck8") && (platform.equals("zos") || platform.equals("aix"))) {
+			if (!jckVersion.contains("jck8") && (spec.contains("zos") || spec.contains("aix"))) {
 				// On jck11+ z/OS and AIX set the compRefExecute file and path separators
 				// due to JCK class OsHelper bug with getFileSep() in Compiler JCK Interviewer
 				fileContent += "set jck.env.compiler.compRefExecute.fileSep \"/\";\n";
@@ -766,7 +748,7 @@ public class JavatestUtil {
 			}
 			
 			// Add the JVM options supplied by the user plus those added in this method to the jtb file option.
-			if (testExecutionType != null && !testExecutionType.equals("multijvm")) { 
+			if (!testExecutionType.equals("multijvm")) { 
 				fileContent += "set jck.env.compiler.compRefExecute.otherOpts \" " + extraJvmOptions + " \"" + ";\n";
 			}
 		}
@@ -776,7 +758,7 @@ public class JavatestUtil {
 			String jxcCmd = "";				// Required for "java2schema" test
 			String genCmd,impCmd  = "";		// Required for "jaxws" test
 
-			if (platform.equals("win")) {
+			if (spec.contains("win")) {
 				String winscriptdir;
 				if ( jckVersion.contains("jck6") || jckVersion.contains("jck7") || jckVersion.contains("jck8") || jckVersion.contains("jck9") ) {
 					winscriptdir="win32";
@@ -791,32 +773,32 @@ public class JavatestUtil {
 				jxcCmd = jxcCmd.replace("/", "\\");
 				genCmd = genCmd.replace("/", "\\");
 				impCmd = impCmd.replace("/", "\\");
-			} else if (platform.contains("linux") || platform.equals("aix")) {
+			} else if (spec.contains("linux") || spec.contains("aix")) {
 				xjcCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "xjc.sh";
 				jxcCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "schemagen.sh";
 				genCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "wsgen.sh";
 				impCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "wsimport.sh";
-			} else if (platform.equals("osx")) {
+			} else if (spec.contains("osx")) {
 				xjcCmd = jckBase + File.separator + "macos" + File.separator + "bin" + File.separator + "xjc.sh";
 				jxcCmd = jckBase + File.separator + "macos" + File.separator + "bin" + File.separator + "schemagen.sh";
 				genCmd = jckBase + File.separator + "macos" + File.separator + "bin" + File.separator + "wsgen.sh";
 				impCmd = jckBase + File.separator + "macos" + File.separator + "bin" + File.separator + "wsimport.sh";
-			} else if (platform.equals("zos") || platform.equals("solaris")) {
+			} else if (spec.contains("zos") || spec.contains("solaris")) {
 				pathToJavac = testJdk + File.separator + "bin" + File.separator + "javac";
 				xjcCmd = jckBase + File.separator + "solaris" + File.separator + "bin" + File.separator + "xjc.sh";
 				jxcCmd = jckBase + File.separator + "solaris" + File.separator + "bin" + File.separator + "schemagen.sh";
 				genCmd = jckBase + File.separator + "solaris" + File.separator + "bin" + File.separator + "wsgen.sh";
 				impCmd = jckBase + File.separator + "solaris" + File.separator + "bin" + File.separator + "wsimport.sh";
 			} else {
-				System.out.println("Unknown platform:: " + platform);
+				System.out.println("Unknown spec: " + spec);
 				return false; 
 			}
 			
 			// bash/ksh required to run schema scripts (cannot be standard sh)
-			if (platform.equals("linux")) {
+			if (spec.contains("linux")) {
 				xjcCmd = "bash "+xjcCmd;
 				jxcCmd = "bash "+jxcCmd;
-			} else if (platform.equals("solaris")) {
+			} else if (spec.contains("solaris")) {
 				xjcCmd = "ksh "+xjcCmd;
 				jxcCmd = "ksh "+jxcCmd;
 			}
@@ -824,7 +806,7 @@ public class JavatestUtil {
 			fileContent += "concurrency " + concurrencyString + ";\n";
 			fileContent += "timeoutfactor 40" + ";\n";							// All Devtools tests take less than 1h to finish.
 
-			if (platform.equals("win")) {
+			if (spec.contains("win")) {
 				// On Windows set the testplatform.os to Windows and set systemRoot, but do not
 				// set the file and path separators (an error is thrown if they are set).
 				fileContent += "set jck.env.testPlatform.os \"Windows\";\n";
@@ -838,7 +820,6 @@ public class JavatestUtil {
 
 			fileContent += "set jck.env.devtools.testExecute.cmdAsString \"" + pathToJava + "\"" + ";\n";
 			fileContent += "set jck.env.devtools.refExecute.cmdAsFile \"" + pathToJava + "\"" + ";\n";
-
 			fileContent += "set jck.env.devtools.scriptEnvVars \"" + "JAVA_HOME=\"" + testJdk + "\" TOOLS_HOME=\"" + testJdk + "\"" + "\"" + ";\n";
 
 			if (tests.contains("java2schema")) {
@@ -853,14 +834,20 @@ public class JavatestUtil {
 
 			// Get any additional jvm options for specific tests.
 			extraJvmOptions += getTestSpecificJvmOptions(jckVersion, tests);
-
 			extraJvmOptions += suppressOutOfMemoryDumpOptions;
 
 			// Add the JVM options supplied by the user plus those added in this method to the jtb file option.
 			fileContent += "set jck.env.devtools.refExecute.otherOpts \" " + extraJvmOptions + " \"" + ";\n";	
 		}
 
-		fileContent += "set jck.excludeList.customFiles \"" + initialJtxFullPath + " " + jtxFullPath + " " + kflFullPath + " " + fipsJtxFullPath + "\"" + ";\n";
+		// Only use default initial jtx exclude and disregard the rest of jck exclude lists 
+		// when running a test via jck_custom.
+		if (task == null || !task.equals("custom")) {  
+			fileContent += "set jck.excludeList.customFiles \"" + initialJtxFullPath + " " + defaultJtxFullPath + " " + kflFullPath + " " + customJtx + "\";\n";
+		} else {
+			fileContent += "set jck.excludeList.customFiles \"" + initialJtxFullPath + " " + defaultJtxFullPath + " " + kflFullPath + "\";\n";
+		}
+				
 		fileContent += "runTests" + ";\n";
 		fileContent += "writeReport -type xml " + reportDir + ";\n";
 
@@ -868,13 +855,12 @@ public class JavatestUtil {
 		fileContent = fileContent.replace("\\\\", "\\"); 		// Replaces \\ with \, leave \ alone.
 		fileContent = fileContent.replace("\\", "\\\\");		// Replaces \ with \\
 
-		
 		BufferedWriter bw = new BufferedWriter(new FileWriter(new File(newJtbFileRef))); 
 		bw.write(fileContent); 
 		bw.flush();
 		bw.close();
 
-		if (platform.equals("zos")) {
+		if (spec.contains("zos")) {
 			if(!doIconvFile()) {
 				System.out.println("Failed to convert jtb file encoding for z/OS");
 				return false; 
@@ -897,7 +883,7 @@ public class JavatestUtil {
 	}
 
 	private static boolean generateSummary() {
-		try { 
+		try {
 			String reportXML = reportDir + File.separator + "xml" + File.separator + "report.xml"; 
 			DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
@@ -993,7 +979,6 @@ public class JavatestUtil {
 		String kdcHostName = null;
 		BufferedReader br = new BufferedReader(new FileReader(krbConfFile.toString()));
 		String thisLine = null;
-
 		while ((thisLine = br.readLine()) != null ) {
 			if (thisLine.contains("default_realm")) {
 				String[] parts = thisLine.split("=");
@@ -1010,31 +995,26 @@ public class JavatestUtil {
 
 	private static int getFreePort() throws Exception {
 		int freePort = -1;
-
 		ServerSocket s = new ServerSocket(0);
 		freePort = s.getLocalPort();
 		s.close();
-
 		return freePort;
 	}
 
 	private static String locateFileOrFolder(String root, String pattern) throws Exception {
 		String matches = "";
-
 		StringBuffer sb = new StringBuffer();
-		File f = new File(root);
-		File[] files = f.listFiles();
+		File[] files = new File(root).listFiles();
 		for (File file : files) {
 			if (file.getName().contains(pattern)) {
 				sb.append(file.toString()).append(File.pathSeparator);
 			}
-
 			if (file.isDirectory() && !(file.getName().contains("ext")) ) {
 				String s = locateFileOrFolder(file.toString(), pattern);
 				if (!s.equals("")) {
 					sb.append(s);
 				}
-			}		
+			}
 		}
 		matches = sb.toString();
 		return matches;
@@ -1044,13 +1024,10 @@ public class JavatestUtil {
 		String jarsList = "";
 		StringBuffer sb = new StringBuffer();
 		System.out.println("Looking for .jar files in " + root + " for signaturetest.");
-
 		sb.append(locateFileOrFolder(root,".jar"));
-
 		String newRoot = new File(root).getParent() + File.separator + "bin";
 		System.out.println("Looking for vm.jar in " + newRoot + " for signaturetest.");
 		sb.append(locateFileOrFolder(newRoot,"vm.jar"));
-
 		jarsList = sb.toString();
 		System.out.println("Using " + jarsList + " for signaturetest.");
 		return jarsList;
@@ -1152,59 +1129,40 @@ public class JavatestUtil {
 	}  
 
 	private static String getOSNameShort() {
-		// get the osName and make it lowercase
-		String osName = System.getProperty("os.name").toLowerCase();
-
-		// set the shortname to the osName if the current system is Linux
-		// or AIX this is all that is needed
-		String osShortName = osName;
-
-		// We need to determine if the platform is Alpine Linux or not
-		if (osName.equals("linux")) {
+		// We need to determine if the spec is Alpine Linux or not
+		if (spec.contains("linux")) {
 			Path alpine = Paths.get("/etc/alpine-release");
 			if (Files.exists(alpine)) {
-				osShortName = "alpine-linux";
+				return "alpine-linux";
 			}
+			return "linux";
 		}
-
-		// if we are on z/OS remove the slash
-		if (osName.equals("z/os")) {
-			osShortName = "zos";
+		if (spec.contains("zos")) {
+			return "zos";
 		}
-
-		// if we are on a Windows machine use win as the shortname
-		if (osName.contains("win")) {
-			osShortName = "win";
+		if (spec.contains("win")) {
+			return "win";
 		}
-
-		// if we are on a Mac use osx as the shortname
-		if (osName.contains("mac")) {
-			osShortName = "osx";
-		}   
-
-		// if we are on BSD use bsd as the shortname
-		if (osName.contains("bsd")) {
-			osShortName = "bsd";
+		if (spec.contains("osx")) {
+			return "osx";
 		}
-
-		// if we are on sunos use solaris as the shortname
-		if (osName.contains("sunos")) {
-			osShortName = "solaris";
+		if (spec.contains("aix")) {
+			return "aix";
 		}
-
-		return osShortName;
+		if (spec.contains("sunos")) {
+			return "solaris";
+		}
+		return null;
 	}
 
 	private static boolean doIconvFile() throws Exception {
-		String tempFile = newJtbFileRef + File.separator + "jtb.tmp";
+		String tempFile = workDir + File.separator + "jtb.tmp";
 		BufferedWriter bw = new BufferedWriter(new FileWriter(tempFile)); 
 		bw.write(fileContent); 
 		bw.flush();
 		bw.close();
-		
 		new File(newJtbFileRef).delete(); 
 		new File(newJtbFileRef).createNewFile(); 
-
 		List<String> iconvCmd = new ArrayList<>();
 		iconvCmd.add("iconv");
 		iconvCmd.add("-f");
@@ -1212,7 +1170,6 @@ public class JavatestUtil {
 		iconvCmd.add("-t");
 		iconvCmd.add("ISO8859-1");
 		iconvCmd.add(tempFile);
-
 		ProcessBuilder rmidProcessBuilder = new ProcessBuilder(iconvCmd);
 		rmidProcessBuilder.redirectOutput(new File(newJtbFileRef)); 
 		Process pp = rmidProcessBuilder.start();

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -53,7 +53,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/instrument testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/instrument testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/instrument testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -67,7 +69,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/invoke testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/invoke testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/invoke testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -81,7 +85,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/reflect testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/reflect testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/reflect testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -95,7 +101,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/Package testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/Package testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/Package testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -109,7 +117,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/String testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/String testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/String testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -123,7 +133,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/StringBuilder testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/StringBuilder testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/StringBuilder testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -137,7 +149,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/StringBuffer testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/StringBuffer testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/StringBuffer testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -151,7 +165,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/ClassLoader testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/ClassLoader testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/ClassLoader testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -165,7 +181,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/ModuleLayer testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/ModuleLayer testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/ModuleLayer testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -182,7 +200,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/module testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/module testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/module testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -199,7 +219,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/StackWalker testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/StackWalker testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/StackWalker testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -216,7 +238,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/Module_class testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/Module_class testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/Module_class testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -233,7 +257,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/SecurityManager testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/SecurityManager testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/SecurityManager testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -247,7 +273,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/System testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/System testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/System testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -261,7 +289,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/constant testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/constant testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/constant testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -278,7 +308,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang/Class testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/Class testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/Class testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -292,7 +324,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/signaturetest testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/signaturetest testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/signaturetest testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -306,7 +340,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/modulegraph testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/modulegraph testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/modulegraph testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -331,7 +367,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_util/regex testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_util/regex testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_util/regex testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -345,7 +383,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_naming/spi testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_naming/spi testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming/spi testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -359,7 +399,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_util/ResourceBundle testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_util/ResourceBundle testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_util/ResourceBundle testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -386,7 +428,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_applet testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_applet testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_applet testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -410,7 +454,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_awt testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_awt testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_awt testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -432,7 +478,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_beans testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_beans testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_beans testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -447,7 +495,9 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<!-- This testcase opens many files which can exceed max open files, so limit concurrency to 1 --> 
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_io testsuite=RUNTIME concurrency=1; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_io testsuite=RUNTIME concurrency=1; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_io testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -461,7 +511,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_lang testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_lang testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -475,7 +527,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_math testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_math testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_math testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -500,7 +554,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_net testsuite=RUNTIME concurrency=1; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_net testsuite=RUNTIME concurrency=1; \
+		$(EXEC_RUNTIME_TEST_WITH_SERVICES) ; \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_net testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -514,7 +570,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_nio testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_nio testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_nio testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -536,7 +594,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_rmi testsuite=RUNTIME concurrency=1; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_rmi testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_rmi testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -558,7 +618,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_security testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_security testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_security testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -572,7 +634,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_sql testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_sql testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_sql testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -586,7 +650,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_text testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_text testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_text testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -600,7 +666,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_time testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_time testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_time testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -622,7 +690,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/java_util testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/java_util testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_util testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -643,7 +713,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_accessibility testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_accessibility testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_accessibility testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -657,7 +729,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_activation testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_activation testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_activation testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -674,7 +748,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_activity testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_activity testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_activity testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -691,7 +767,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_annotation testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_annotation testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_annotation testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -713,7 +791,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_crypto testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_crypto testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_crypto testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -727,7 +807,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_imageio testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_imageio testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_imageio testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -741,7 +823,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_lang testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_lang testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_lang testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -763,7 +847,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_management testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_management testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_management testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -777,7 +863,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_naming testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_naming testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -805,7 +893,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_net testsuite=RUNTIME concurrency=1; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_net testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -831,7 +921,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_print testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_print testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_print testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -853,7 +945,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_rmi testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_rmi testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_rmi testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -867,7 +961,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_script testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_script testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_script testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -881,7 +977,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_security testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_security testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_security testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -903,7 +1001,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_sound testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_sound testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_sound testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -917,7 +1017,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_sql testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_sql testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_sql testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -941,7 +1043,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_swing testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_swing testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_swing testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -963,7 +1067,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_tools testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_tools testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_tools testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -977,7 +1083,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_transaction testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_transaction testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_transaction testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -990,12 +1098,14 @@
 			<version>15+</version>
 		</versions>
 	</test>
-    <test>
+	<test>
 		<testCaseName>jck-runtime-api-javax_xml</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/javax_xml testsuite=RUNTIME concurrency=1; \
+		<command>$(GEN_JTB_GENERIC) tests=api/javax_xml testsuite=RUNTIME concurrency=1; \
+		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_xml testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -1019,7 +1129,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/org_ietf testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/org_ietf testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/org_ietf testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>special</level>
@@ -1045,7 +1157,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/org_omg testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/org_omg testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/org_omg testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -1062,7 +1176,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/org_w3c testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/org_w3c testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/org_w3c testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -1076,7 +1192,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/org_xml testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/org_xml testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/org_xml testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -1090,7 +1208,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/xinclude testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/xinclude testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/xinclude testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -1104,7 +1224,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/xsl testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/xsl testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/xsl testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -1118,7 +1240,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=api/serializabletypes testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=api/serializabletypes testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=api/serializabletypes testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>

--- a/jck/runtime.lang/playlist.xml
+++ b/jck/runtime.lang/playlist.xml
@@ -19,7 +19,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/BINC testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/BINC testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/BINC testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -33,7 +35,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/CLSS testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>^os.aix</platformRequirements>
 		<levels>
@@ -48,7 +52,9 @@
 		<variations>
 			<variation>-Xss2M -Xmso1M</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/CLSS testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>
 		<levels>
@@ -67,7 +73,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/CLSS testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>
 		<levels>
@@ -85,7 +93,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/CONV testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/CONV testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CONV testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -99,7 +109,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/EXPR testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/EXPR testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXPR testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -113,7 +125,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/INTF testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/INTF testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/INTF testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -127,7 +141,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/LMBD testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/LMBD testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/LMBD testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -141,7 +157,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/ARR testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/ARR testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ARR testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -155,7 +173,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/DASG testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/DASG testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/DASG testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -169,7 +189,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/EXCP testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/EXCP testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXCP testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -183,7 +205,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/EXEC testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/EXEC testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXEC testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -197,7 +221,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/FP testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/FP testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/FP testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -211,7 +237,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/ICLS testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/ICLS testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ICLS testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -225,7 +253,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/INFR testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/INFR testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/INFR testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -239,7 +269,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/MOD testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/MOD testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/MOD testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -256,7 +288,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/NAME testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/NAME testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/NAME testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -270,7 +304,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/PKGS testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/PKGS testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/PKGS testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -284,7 +320,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/THRD testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/THRD testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/THRD testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -298,7 +336,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/TYPE testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/TYPE testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/TYPE testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -312,7 +352,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/ANNOT testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/ANNOT testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ANNOT testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -326,7 +368,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/LEX testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/LEX testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/LEX testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -340,7 +384,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=lang/STMT testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/STMT testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/STMT testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -27,7 +27,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/constantpool testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/constantpool testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/constantpool testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -51,7 +53,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/jdwp testsuite=RUNTIME concurrency=1; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/jdwp testsuite=RUNTIME concurrency=1; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/jdwp testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -65,7 +69,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/jvmti testsuite=RUNTIME concurrency=1; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/jvmti testsuite=RUNTIME concurrency=1; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/jvmti testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -99,7 +105,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/overview testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/overview testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/overview testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -113,7 +121,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/classfmt testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/classfmt testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/classfmt testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -127,7 +137,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/module testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/module testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/module testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -144,7 +156,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/verifier/abstractAndNative testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/verifier/abstractAndNative testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/verifier/abstractAndNative testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -161,7 +175,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP1) testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP1) testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP1) testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -178,7 +194,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP2) testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP2) testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP2) testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -195,7 +213,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP3) testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP3) testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP3) testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -212,7 +232,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP4) testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP4) testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP4) testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -229,7 +251,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/verifier/protectedCheck testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/verifier/protectedCheck  testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/verifier/protectedCheck testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -246,7 +270,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/verifier/subclassFinal testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/verifier/subclassFinal testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/verifier/subclassFinal testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -263,7 +289,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/instr testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/instr testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/instr testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -277,7 +305,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/cldc testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/cldc testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/cldc testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -291,7 +321,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/concepts testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/concepts testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/concepts testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -305,7 +337,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/fp testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/fp testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/fp testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -319,7 +353,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/jni testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/jni testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/jni testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -333,7 +369,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=vm/typechecker testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=vm/typechecker testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=vm/typechecker testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/jck/runtime.xml_schema/playlist.xml
+++ b/jck/runtime.xml_schema/playlist.xml
@@ -19,7 +19,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/boeingData testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=xml_schema/boeingData testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/boeingData testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>
@@ -41,7 +43,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/msData testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=xml_schema/msData testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/msData testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -63,7 +67,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/nistData/atomic testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=xml_schema/nistData/atomic testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData/atomic testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -85,7 +91,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/nistData/list testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=xml_schema/nistData/list testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData/list testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -107,7 +115,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/nistData/union testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=xml_schema/nistData/union testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData/union testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
@@ -121,7 +131,9 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JCK_CMD_TEMPLATE) tests=xml_schema/sunData testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=xml_schema/sunData testsuite=RUNTIME; \
+		$(EXEC_RUNTIME_TEST); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/sunData testsuite=RUNTIME; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
This PR replaces JavaTestRunner with JavaTestUtil as the tck automation wrapper. 

**Impact:**

1. _Faster Execution:_ Absence of JavaTestRunner wrapper means we are using on less JVM instance. The JVM running the actual tests via tck harness jar is not run as a sub-process spawned by the JVM running JavaTeatRunner, but executed directly from playlist. This reduces overall time taken to run JCK builds.

2. _Easy maintenance:_ Having the ability to specify tck harness parameters directly in the playlist makes each tck playlist command line clearer, easier to maintain and update. 

3. _Enhanced debug-ability:_ Absence of JavaTestRunner wrapper means less redirection hence more debug-ability for failures.

4. _Less overhead in running additional services:_ Since additional services like rmi registry, rmid, etc, will be launched directly, as opposed to via ProcessBuilder in JavaTestRunner, it should also contribute to overall improved performance of tck builds in Jenkins.

Related to backlog/issues/1013