### PR TITLE
Make AIX use non-group multiJVM

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -565,8 +565,8 @@ public class JavaTestRunner {
 			extraJvmOptions += " -Dfile.encoding=US-ASCII";
 		}
 
-                // testExecutionType of multiJVM_group on Windows causes memory exhaustion, so limit to plain multiJVM
-                if (getJckVersionInt(jckVersionNo) >= 17 && platform.contains("win")) {
+                // testExecutionType of multiJVM_group on Windows and AIX causes memory exhaustion, so limit to non-group multiJVM
+                if (getJckVersionInt(jckVersionNo) >= 17 && (platform.contains("win") || platform.contains("aix"))) {
 			fileContent += "set jck.env.testPlatform.multiJVM \"Yes\";\n";
                 }
 


### PR DESCRIPTION
Using multiJVM_group mode causes an excessive number of javatest agents, which easily exhausts machine memory or max-process limits.
Add AIX to Windows in using non-group multiJVM mode.
