### PR TITLE
Exclude security/infra certification/ActalisCA on OpenJ9 jdk20

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -347,6 +347,7 @@ java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj
 security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/ActalisCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
 
 ############################################################################
 


### PR DESCRIPTION
It's already excluded for other platforms via
https://github.com/adoptium/aqa-tests/issues/2074

See also https://github.com/eclipse-openj9/openj9/issues/16966