### PR TITLE
Don't refer to JENKINS_KEY on z/OS

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -899,7 +899,7 @@ def testExecution() {
 		} else {
 			buildTest()
 		}
-		if( env.BUILD_LIST.startsWith('jck')) {
+		if(env.BUILD_LIST.startsWith('jck') && !env.SPEC.startsWith('zos')) {
 			sshagent(credentials:["${params.JENKINS_KEY}"], ignoreMissing: true) {
 				runTest()
 			}


### PR DESCRIPTION
- Temporarily refrain from using JENKINS_KEY on z/OS, until the key gets fixed via infrastructure/issues/7949.
- Needed to unblock JCK automated builds on z/OS JDK 11. 
- Related to backlog/issues/1101

