### PR TITLE
JDK11 excludes java/lang/Thread/UncaughtExceptionsTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -66,6 +66,7 @@ java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/
 java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/Thread/UncaughtExceptions.sh	https://github.com/eclipse-openj9/openj9/issues/6690	generic-all
+java/lang/Thread/UncaughtExceptionsTest.java	https://github.com/eclipse-openj9/openj9/issues/11930	generic-all
 java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse-openj9/openj9/issues/6691	generic-all
 java/lang/Throwable/SuppressedExceptions.java	https://github.com/eclipse-openj9/openj9/issues/6692	generic-all
 java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all


### PR DESCRIPTION
JDK11 excludes `java/lang/Thread/UncaughtExceptionsTest.java`

related https://github.com/eclipse-openj9/openj9/issues/11930

Signed-off-by: Jason Feng <fengj@ca.ibm.com>