### PR TITLE
Exclude OpenSSL test on z/OS

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -295,6 +295,8 @@ sun/security/mscapi/SmallPrimeExponentP.java	https://github.ibm.com/runtimes/bac
 sun/security/mscapi/VeryLongAlias.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/pkcs11/Provider/MultipleLogins.sh	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
 sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
+#sun/security/pkcs12/KeytoolOpensslInteropTest.java is not supported on z/OS
+sun/security/pkcs12/KeytoolOpensslInteropTest.java	https://github.com/adoptium/aqa-tests/issues/1297	z/OS-s390x    
 sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java	https://github.ibm.com/runtimes/backlog/issues/809	linux-aarch64
 sun/security/provider/SecureRandom/StrongSecureRandom.java	https://github.ibm.com/runtimes/backlog/issues/809	linux-aarch64
 sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all


### PR DESCRIPTION
sun/security/pkcs12/KeytoolOpensslInteropTest.java uses OpenSSL which doesn't support on z/OS. Hence, excluding the test on z/OS.

For more details refer : https://github.com/adoptium/aqa-tests/issues/4535