### PR TITLE
Clean workspace before copyArtifacts

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -126,6 +126,7 @@ JDK_VERSIONS.each { JDK_VERSION ->
                     if (downstreamJob.getResult() == 'SUCCESS' || downstreamJob.getResult() == 'UNSTABLE') {
                         echo "[NODE SHIFT] MOVING INTO CONTROLLER NODE..."
                         node("worker || (ci.role.test&&hw.arch.x86&&sw.os.linux)") {
+                            cleanWs disableDeferredWipeout: true, deleteDirs: true
                             try {
                                 timeout(time: 2, unit: 'HOURS') {
                                     copyArtifacts(


### PR DESCRIPTION
Clean workspace before copyArtifacts

Remove former artifacts.

Fix #4542 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>