### PR TITLE
Update JDK20 Test Exclude List

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -317,12 +317,12 @@ java/nio/channels/SocketChannel/VectorIO.java https://github.ibm.com/runtimes/ba
 java/nio/channels/SocketChannel/VectorParams.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/SocketChannel/Write.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
-java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
 java/nio/file/Files/probeContentType/Basic.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4679 linux-x64,macosx-all
+java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/adoptium/aqa-tests/issues/1297 aix-all
+java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/adoptium/aqa-tests/issues/1297 aix-all
 
 ############################################################################
 
@@ -533,18 +533,16 @@ serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java https://github.com/ecl
 serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
-serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/17307 generic-all
-serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://github.com/eclipse-openj9/openj9/issues/16185 generic-all
-serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/eclipse-openj9/openj9/issues/16185 generic-all
-serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/eclipse-openj9/openj9/issues/16185 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
-serviceability/jvmti/thread/SuspendThread/suspendthrd03/suspendthrd03.java https://github.com/eclipse-openj9/openj9/issues/16242 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
-serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/eclipse-openj9/openj9/issues/16279 aix-all
-serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16168 generic-all
+serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16689 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/adoptium/aqa-tests/issues/1297 aix-all
 
 # jdk_container
 jdk/internal/platform/docker/TestDockerCpuMetrics.java https://github.com/eclipse-openj9/openj9/issues/16462 generic-all


### PR DESCRIPTION
- `NotSuspended/GetStackTraceNotSuspendedStressTest` has been fixed.
- `SuspendThread/suspendthrd03` has been removed in JDK20.
- Now, `VThreadTest` fails because of [eclipse-openj9/openj9#15920](https://github.com/eclipse-openj9/openj9/issues/15920).
- [eclipse-openj9/openj9#16185](https://github.com/eclipse-openj9/openj9/issues/16185) and [eclipse-openj9/openj9#16279](https://github.com/eclipse-openj9/openj9/issues/16279) are
permanently excluded. Changed their reason to [#1297](https://github.com/adoptium/aqa-tests/issues/1297) to support
the test tool, which automatically enables tests after the related
issues are closed.

Related:
- [eclipse-openj9/openj9#16688](https://github.com/eclipse-openj9/openj9/issues/16688)
- [eclipse-openj9/openj9#16242](https://github.com/eclipse-openj9/openj9/issues/16242)
- [eclipse-openj9/openj9#17307](https://github.com/eclipse-openj9/openj9/issues/17307)

Depends on eclipse-openj9/openj9#17318