### PR TITLE
Crypto/build.xml: Fixed problem with un-evaluated variable in dependencyList

### DIFF
--- a/functional/security/Crypto/build.xml
+++ b/functional/security/Crypto/build.xml
@@ -79,6 +79,18 @@
 			</if>
 		</else>
 	</if>
+	<if>
+		<or>
+			<equals arg1="${JDK_IMPL}" arg2="ibm"  />
+			<equals arg1="${JDK_IMPL}" arg2="openj9" />
+		</or>
+		<then>
+			<property name="openj9jtregtimeouthandler" value=",tohandler_simple"/>
+		</then>
+		<else>
+			<property name="openj9jtregtimeouthandler" value=""/>
+		</else>
+	</if>
 	<property name="LIB" value="${jtregTar}${openj9jtregtimeouthandler}"/>
 	
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>


### PR DESCRIPTION
See issue: https://github.com/adoptium/aqa-tests/issues/4537
Fix based on discussion in above issue.

Testing:
- fixed problem, when ran by our scripts
- [Passed in grinder](https://ci.adoptium.net/view/Test_grinder/job/Grinder/7267/)