### PR TITLE
unset LD_LIBRARY_PATH for alpine-linux jdk8 test

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -6,6 +6,10 @@ import org.tap4j.model.TestSet;
 def makeTest(testParam) {
 	String tearDownCmd = "$RESOLVED_MAKE; \$MAKE -f ./aqa-tests/TKG/testEnv.mk testEnvTeardown"
 	String makeTestCmd = "$RESOLVED_MAKE; cd ./aqa-tests/TKG; \$MAKE $testParam"
+	//unset LD_LIBRARY_PATH workaround for issue https://github.com/adoptium/infrastructure/issues/2934
+	if (JDK_IMPL == 'hotspot' && JDK_VERSION == '8' && PLATFORM.contains('alpine-linux')) {
+		makeTestCmd = "unset LD_LIBRARY_PATH; $makeTestCmd"
+	}
 	try {
 		sh "$tearDownCmd"
 		if (env.DOCKER_REGISTRY_URL && env.DOCKER_REGISTRY_URL_CREDENTIAL_ID) {
@@ -538,6 +542,10 @@ def get_sources() {
 }
 def makeCompileTest(){
 	String makeTestCmd = "bash ./compile.sh ${USE_TESTENV_PROPERTIES}"
+	//unset LD_LIBRARY_PATH workaround for issue https://github.com/adoptium/infrastructure/issues/2934
+	if (JDK_IMPL == 'hotspot' && JDK_VERSION == '8' && PLATFORM.contains('alpine-linux')) {
+		makeTestCmd = "unset LD_LIBRARY_PATH; $makeTestCmd"
+	}
 	dir('aqa-tests') {
 		if (!env.SPEC.startsWith('zos')) {
 			sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"], ignoreMissing: true) {
@@ -548,7 +556,6 @@ def makeCompileTest(){
 		}
 	}
 }
-
 
 def buildTest() {
 	stage('Build') {

--- a/get.sh
+++ b/get.sh
@@ -756,6 +756,12 @@ if [ "$USE_TESTENV_PROPERTIES" = true ]; then
 else
 	> ./testenv/testenv.properties
 fi
+
+# unset LD_LIBRARY_PATH workaround for issue https://github.com/adoptium/infrastructure/issues/2934
+if [[ $JDK_IMPL == 'hotspot' && $JDK_VERSION == '8' && $PLATFORM =~ 'alpine-linux' ]]; then
+	unset LD_LIBRARY_PATH
+fi
+
 if [ "$SDKDIR" != "" ]; then
 	getBinaryOpenjdk
 	testJavaVersion


### PR DESCRIPTION
LD_LIBRARY_PATH env variable makes installed java will fail to run

Related https://github.com/adoptium/infrastructure/issues/2934

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>