### PR TITLE
Enable test specified docker image in grinder

### DIFF
--- a/external/external.sh
+++ b/external/external.sh
@@ -27,7 +27,7 @@ test=derby
 testtarget=""
 platform="linux_x86-64"
 portable="false"
-job_name=$JOB_NAME
+docker_image_source_job_name=""
 build_number=$BUILD_NUMBER
 node_name=""
 node_labels=""
@@ -172,7 +172,7 @@ parseCommandLineArgs() {
 				docker_registry_dir="$1"; shift;
 				docker_registry_dir=$(echo "$docker_registry_dir" | tr '[:upper:]' '[:lower:]')  # docker registry link must be lowercase
 				IFS=':' read -r -a dir_array <<< "$docker_registry_dir"
-				job_name=${dir_array[0]}
+				docker_image_source_job_name=${dir_array[0]}
 				build_number=${dir_array[1]};;
 
 			"--criu_default_image_job_name" )
@@ -291,7 +291,7 @@ if [ $command_type == "run" ]; then
 				echo "Private Docker Registry login starts:"
 				echo $DOCKER_REGISTRY_CREDENTIALS_PSW | $container_login --username=$DOCKER_REGISTRY_CREDENTIALS_USR --password-stdin $docker_registry_url
 
-				restore_ready_checkpoint_image_folder="${docker_registry_url}/${job_name}/${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${platform}-${node_label_current_os}-${node_label_micro_architecture}"
+				restore_ready_checkpoint_image_folder="${docker_registry_url}/${docker_image_source_job_name}/${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${platform}-${node_label_current_os}-${node_label_micro_architecture}"
 				tagged_restore_ready_checkpoint_image_num="${restore_ready_checkpoint_image_folder}:${build_number}"
 
 				# Push a docker image with build_num for records
@@ -329,12 +329,17 @@ if [ $command_type == "load" ]; then
 
 			restore_docker_image_name_list=()
 
-			echo "Testing images from nightly builds"
-			image_os_micro_architecture_list=($criu_combo_os_microarch_list)
-			for image_os_micro_architecture in ${image_os_micro_architecture_list[@]}
-			do
-				restore_docker_image_name_list+=("${docker_registry_url}/$job_name/${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${platform}-${image_os_micro_architecture}:${build_number}")
-			done
+			if [[ $JOB_NAME == "Grinder" ]]; then
+			    echo "Testing image from docker_registry_dir"
+				restore_docker_image_name_list+=("${docker_registry_url}/$docker_image_source_job_name:${build_number}")
+			else
+				echo "Testing images from nightly builds"
+				image_os_micro_architecture_list=($criu_combo_os_microarch_list)
+				for image_os_micro_architecture in ${image_os_micro_architecture_list[@]}
+				do
+					restore_docker_image_name_list+=("${docker_registry_url}/$docker_image_source_job_name/${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${platform}-${image_os_micro_architecture}:${build_number}")
+				done
+			fi
 
 			echo "The host machine OS is ${node_label_current_os}, and micro-architecture is ${node_label_micro_architecture}"
 			for restore_docker_image_name in ${restore_docker_image_name_list[@]}
@@ -376,5 +381,6 @@ if [ $command_type == "clean" ]; then
 	fi
 	$container_rm -f $test-test; $container_rmi -f adoptopenjdk-$test-test:${JDK_VERSION}-$package-$docker_os-${JDK_IMPL}-$build_type
 	$container_rm -f restore-test
-	$container_rmi -f ${docker_registry_url}/${job_name}/${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${platform}-${node_label_current_os}-${node_label_micro_architecture}:${build_number}
+	$container_rmi -f ${docker_registry_url}/${docker_image_source_job_name}/${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${platform}-${node_label_current_os}-${node_label_micro_architecture}:${build_number}
+	$container_rmi -f ${docker_registry_url}/${docker_image_source_job_name}:${build_number}
 fi


### PR DESCRIPTION
- for grinder portable restore test, only pull the specified docker image
- for non-grinder pipeline, including `Grinder_imagePull`, pull all available platfrom checkpoint images
Closes #4561 