### PR TITLE
Excluding some of the JDK17 tests on z/OS

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -161,6 +161,7 @@ com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java htt
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+com/sun/management/OperatingSystemMXBean/GetFreePhysicalMemorySize.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 
 ############################################################################
 
@@ -234,9 +235,15 @@ java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
 #java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all,z/OS-s390x
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.ibm.com/runtimes/backlog/issues/684 aix-all
+java/nio/channels/FileChannel/directio/ReadDirect.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/nio/channels/FileChannel/directio/PreadDirect.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/nio/channels/FileChannel/directio/PwriteDirect.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/nio/channels/FileChannel/TempDirectBuffersReclamation.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/nio/channels/FileChannel/directio/WriteDirect.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/nio/channels/Selector/OutOfBand.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse-openj9/openj9/issues/4317 macosx-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
 java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/openj9/issues/6831 generic-all
@@ -277,6 +284,7 @@ javax/net/ssl/SSLEngine/LargePacket.java	https://github.ibm.com/runtimes/backlog
 javax/net/ssl/SSLSocket/Tls13PacketSize.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 javax/net/ssl/TLSv11/TLSEnginesClosureTest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
 sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ec/ed/TestEdDSA.java https://github.com/adoptium/aqa-tests/issues/4566 z/OS-s390x
 sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
 sun/security/mscapi/CastError.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/CngCipher.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
@@ -300,13 +308,21 @@ sun/security/provider/SecureRandom/StrongSecureRandom.java	https://github.ibm.co
 sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
-sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+#sun/security/ssl/CipherSuite/DisabledCurve.java is excluded as Invalid scenario after removing unsupported binary curves from SSLSocketTemplate.java
+sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all,z/OS-s390x
 sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
 sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
 
 ########################################################################################################################################################
+
+# jdk_security_4
+
+sun/security/krb5/auto/NoAddresses.java https://github.com/adoptium/aqa-tests/issues/4566 z/OS-s390x
+ 
+######################################################################################################
+
 
 # jdk_sound
 
@@ -325,6 +341,8 @@ sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://gith
 ############################################################################
 
 # jdk_tools
+
+tools/launcher/MainClassCantBeLoadedTest.java https://github.com/adoptium/aqa-tests/issues/1297	z/OS-s390x
 
 ############################################################################
 
@@ -386,16 +404,41 @@ vm/verifier/VerifyProtectedConstructor.java	https://github.com/eclipse-openj9/op
 
 # jdk_foreign
 
+# Disabling foreign tests as they are unsupported on z/OS
+java/foreign/enablenativeaccess/TestDriver.java#panama_all_unnamed_module_native_access https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/enablenativeaccess/TestDriver.java#panama_comma_separated_enable https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/enablenativeaccess/TestDriver.java#panama_comma_separated_enable_invoke https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/enablenativeaccess/TestDriver.java#panama_comma_separated_enable_reflection https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/enablenativeaccess/TestDriver.java#panama_enable_native_access https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/enablenativeaccess/TestDriver.java#panama_enable_native_access_invoke https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/enablenativeaccess/TestDriver.java#panama_enable_native_access_reflection https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/handles/Driver.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/malloc/TestMixedMallocFree.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
+java/foreign/StdLibTest.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestCircularInit1.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestCircularInit2.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestCondy.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestDowncall.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestFunctionDescriptor.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
+java/foreign/TestIntrinsics.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestNULLAddress.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestNulls.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+java/foreign/TestUpcall.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestUpcallException.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestUpcallHighArity.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestUpcallStructScope.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestResourceScope.java https://github.com/eclipse-openj9/openj9/issues/16551 generic-all
+java/foreign/TestScopedOperations.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestStringEncoding.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 
 ############################################################################
 


### PR DESCRIPTION
Excluding some of the JDK17 tests on z/OS which includes both temporary and permanent exclusions.

For more details refer :- https://github.com/adoptium/aqa-tests/issues/1297#issuecomment-1538456904

Temporary exclusions refer :- https://github.com/adoptium/aqa-tests/issues/4566