### PR TITLE
Remove the variations from jdk_custom

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -16,11 +16,6 @@
 	<include>openjdk.mk</include>
 	<test>
 		<testCaseName>jdk_custom</testCaseName>
-		<variations>
-			<variation>Mode150</variation>
-			<variation>Mode650</variation>
-			<variation>Mode1000</variation>
-		</variations>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(CUSTOM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
 	$(TIMEOUT_HANDLER) \


### PR DESCRIPTION
Related to
https://github.com/adoptium/aqa-tests/issues/4495#issuecomment-1498290854

The jdk_custom variations are not necessarily the desired variations to run. Since jdk_lang_j9 was added for Mode501 (-Xgcpolicy:balanced), this variation is arguably missing from jdk_custom. If you replace command line options, the variations may end up doing nothing except extra runs.