### PR TITLE
Re-enable JVMTI test WaitNotifySuspendedVThreadTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -537,7 +537,6 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https:/
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
-serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16689 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
Test has been fixed by eclipse-openj9/openj9#17350

Signed-off-by: Dipak Bagadiya dipak.bagadiya@ibm.com