### PR TITLE
Disable MauveMultiThrdLoad_5m and TestJlmRemoteMemoryAuth for FIPS mode

### DIFF
--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -112,6 +112,9 @@
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteMemoryAuth; \
 	$(TEST_STATUS)</command>
+		<features>
+			<feature>FIPS:nonapplicable</feature>
+		</features>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -106,6 +106,9 @@
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MauveMultiThrdLoad -test-args=$(Q)timeLimit=5m$(Q); \
 	$(TEST_STATUS)</command>
+		<features>
+			<feature>FIPS:nonapplicable</feature>
+		</features>
 		<levels>
 			<level>sanity</level>
 		</levels>


### PR DESCRIPTION
This PR excludes MauveMultiThrdLoad_5m  and TestJlmRemoteMemoryAuth  for FIPS mode. 

WIs with detailed information about failing tests in FIPS mode.

- https://github.com/eclipse-openj9/openj9/issues/16904
- https://github.com/eclipse-openj9/openj9/issues/16903

Grinder sanity.system with changes. 
- https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/32853/tapResults/

Grinder sanity.system without changes. 
- https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/32874/tapResults/

From the grindr builds, I can see that the testcases are disabled in FIPS mode. 

Signed-off-by: Paritosh Kumar paritkum@in.ibm.com
