### PR TITLE
jck.mk and 'tests' value of compiler.lang/playlist.xml do not match

### DIFF
--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -1340,6 +1340,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1361,6 +1365,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>


### PR DESCRIPTION
running jck-compiler-lang-LMBD-group6_multijvm, jck-compiler-lang-LMBD-group7_multijvm and jck-compiler-lang-ANNOT-group5_multijvm results in the following error, so jck.mk and 'tests' value of compiler.lang/playlist.xml  were modified.

`
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 1
    at JavatestUtil.main(JavatestUtil.java:155)
Starting JCK agent..
Agent started with PID 19175
Starting JCK harness..
cannot find file "/jck/aqa-tests/TKG/../TKG/output_16842250754665/jck-compiler-lang-ANNOT-group5_multijvm_0/generated.jtb" 
Test complete. Stopping JCK Agent..
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 1 
at JavatestUtil.main(JavatestUtil.java:155)
`