### PR TITLE
[Jtreg/FFI] Enable the test suites in JDK20

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -129,6 +129,8 @@ jdk/internal/vm/Continuation/Scoped.java https://github.com/eclipse-openj9/openj
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/17399 generic-all
+
 ############################################################################
 
 # jdk_internal
@@ -534,6 +536,7 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https:/
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
+serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16689 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1518,8 +1518,8 @@
 		<testCaseName>jdk_foreign</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/16565</comment>
-				<version>20+</version>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/17399</comment>
+				<version>21+</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>


### PR DESCRIPTION
The changes enable the FFI test suites in JDK20
and exclude them in JDK21 as the FFI specific
code for JEP442 has not yet been completed.

Fixes: #eclipse-openj9/openj9/issues/16565

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
