### PR TITLE
Excluding some of foreign tests on z/OS

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -416,6 +416,7 @@ java/foreign/enablenativeaccess/TestDriver.java#panama_enable_native_access_invo
 java/foreign/enablenativeaccess/TestDriver.java#panama_enable_native_access_reflection https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/handles/Driver.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/malloc/TestMixedMallocFree.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/SafeFunctionAccessTest.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
@@ -431,6 +432,7 @@ java/foreign/TestFunctionDescriptor.java https://github.com/adoptium/aqa-tests/i
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestIntrinsics.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestNULLAddress.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestNulls.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
@@ -441,6 +443,7 @@ java/foreign/TestUpcallStructScope.java https://github.com/adoptium/aqa-tests/is
 java/foreign/TestResourceScope.java https://github.com/eclipse-openj9/openj9/issues/16551 generic-all
 java/foreign/TestScopedOperations.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestStringEncoding.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestSymbolLookup.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 
 ############################################################################
 


### PR DESCRIPTION
Excluding below tests on z/OS as they are not supported. For more details refer /openj9-openjdk-jdk17-zos/issues/534
java/foreign/SafeFunctionAccessTest.java
java/foreign/TestNative.java
java/foreign/TestSymbolLookup.java