### PR TITLE
Enable SC_Softmx_JitAot_Linux for P and Z after the fix for eclipse-openj9/openj9#17240

### DIFF
--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -99,7 +99,6 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
-	<!-- Exclude the following test on Linux ppc64le & s390x. Reason: adoptium/aqa-systemtest/issues/79 -->
 	<test>
 		<testCaseName>SC_Softmx_JitAot</testCaseName>
 		<variations>
@@ -138,7 +137,7 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<platformRequirements>os.linux,^arch.ppc,^arch.390</platformRequirements>
+		<platformRequirements>os.linux</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>SharedClasses.SCM01.SingleCL</testCaseName>


### PR DESCRIPTION
  `SC_Softmx_JitAot_Linux` was disabled for P and Z due to [adoptium/aqa-systemtest/#79](https://github.com/adoptium/aqa-systemtest/issues/79). Tested recently with the fix for eclipse-openj9/openj9#17240 on Java 8 and Java 17. [The test passes for P and Z](https://github.com/eclipse-openj9/openj9/issues/17240#issuecomment-1568724186). 