### PR TITLE
Limit rmi services to only rmi test + Add agent startup to jdwp + fix false negative 

### DIFF
--- a/jck/agent-drive.sh
+++ b/jck/agent-drive.sh
@@ -1,9 +1,10 @@
-#!/bin/bash -ue
+#!/bin/bash
 
 jckAgentPID=0
 rmiRegistryPID=0
 rmidPID=0
 tnameservPID=0
+harnessExitCode=0
 
 startJCKAgent() {
 	echo "Starting JCK agent.."
@@ -19,7 +20,7 @@ stopJCKAgent() {
 
 startJCKHarness() {
 	echo "Starting JCK harness.."
-	eval $1
+	eval $1; return $?
 }
 
 startRMIRegistry() {
@@ -61,24 +62,35 @@ stopTNameServ() {
 if [ $# -eq 2 ]; then
 	startJCKAgent "$1"
 	startJCKHarness "$2"
+	harnessExitCode=$?
 	stopJCKAgent
-elif [ $# -eq 4 ]; then
-	startRMIRegistry "$1"
-	startRMID "$2"
-	startJCKAgent "$3"
-	startJCKHarness "$4"
-	stopRMIRegistry
-	stopRMID
-	stopJCKAgent
-elif [ $# -eq 5 ]; then
-	startRMIRegistry "$1"
-	startRMID "$2"
-	startTNameServ "$3"
-	startJCKAgent "$4"
-	startJCKHarness "$5"
-	stopRMIRegistry
-	stopRMID
+elif [ $# -eq 3 ]; then
+	startJCKAgent "$1"
+	startTNameServ "$2"
+	startJCKHarness "$3"
+	harnessExitCode=$?
 	stopJCKAgent
 	stopTNameServ
+elif [ $# -eq 4 ]; then
+	startJCKAgent "$1"
+	startRMIRegistry "$2"
+	startRMID "$3"
+	startJCKHarness "$4"
+	harnessExitCode=$?
 	stopJCKAgent
+	stopRMIRegistry
+	stopRMID
+elif [ $# -eq 5 ]; then
+	startJCKAgent "$1"
+	startRMIRegistry "$2"
+	startRMID "$3"
+	startTNameServ "$4"
+	startJCKHarness "$5"
+	harnessExitCode=$?
+	stopJCKAgent
+	stopRMIRegistry
+	stopRMID
+	stopTNameServ
 fi
+
+exit $harnessExitCode

--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -31,8 +31,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_rmi testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_rmi testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_rmi testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -51,8 +52,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_annotation testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_annotation testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_annotation testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -67,8 +69,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_lang testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_lang testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_lang testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -91,8 +94,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_tools testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_tools testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_tools testsuite=COMPILER
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -115,8 +119,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/signaturetest testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/signaturetest testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/signaturetest testsuite=COMPILER
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -140,9 +145,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB) tests=api/java_rmi testsuite=COMPILER$(USEQ); \
-			$(START_MULTI_JVM_COMP_TEST); \
-			$(GEN_SUMMARY) tests=api/java_rmi testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(START_MULTI_JVM_COMP_TEST); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=api/java_rmi testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -160,9 +166,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB) tests=api/javax_annotation testsuite=COMPILER$(USEQ); \
-			$(START_MULTI_JVM_COMP_TEST); \
-			$(GEN_SUMMARY) tests=api/javax_annotation testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(START_MULTI_JVM_COMP_TEST); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=api/javax_annotation testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -177,8 +184,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=api/javax_lang testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=api/javax_lang testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=api/javax_lang testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -201,8 +209,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=api/javax_tools testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=api/javax_tools testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=api/javax_tools testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -225,8 +234,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=api/signaturetest testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=api/signaturetest testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=api/signaturetest testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>

--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -21,8 +21,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/BINC testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/BINC testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/BINC testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -37,8 +38,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -53,8 +55,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -69,8 +72,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -85,8 +89,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -101,8 +106,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -117,8 +123,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -133,8 +140,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -149,8 +157,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -165,8 +174,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -181,8 +191,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -197,8 +208,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/CONV testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/CONV testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CONV testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -213,8 +225,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -229,8 +242,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -245,8 +259,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -261,8 +276,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -277,8 +293,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -293,8 +310,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -309,8 +327,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -325,8 +344,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -341,8 +361,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -357,8 +378,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -373,8 +395,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -389,8 +412,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/INTF testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/INTF testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/INTF testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -405,8 +429,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/LMBD testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/LMBD testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/LMBD testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -421,8 +446,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/ARR testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/ARR testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ARR testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -437,8 +463,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/DASG testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/DASG testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/DASG testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -453,8 +480,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/EXCP testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/EXCP testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXCP testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -469,8 +497,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/EXEC testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/EXEC testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXEC testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -485,8 +514,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/FP  testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/FP  testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/FP  testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -501,8 +531,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/ICLS testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/ICLS testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ICLS testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -517,8 +548,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/INFR testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/INFR testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/INFR testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -533,8 +565,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/MOD testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/MOD testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/MOD testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -552,8 +585,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/NAME testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/NAME testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/NAME testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -568,8 +602,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/PKGS testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/PKGS testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/PKGS testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -584,8 +619,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/THRD testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/THRD testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/THRD testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -600,8 +636,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/TYPE testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/TYPE testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/TYPE testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -624,8 +661,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/ANNOT testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/ANNOT testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ANNOT testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -640,8 +678,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/LEX testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/LEX testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/LEX testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -656,8 +695,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/STMT testsuite=COMPILER; \
 		$(EXEC_COMPILER_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/STMT testsuite=COMPILER; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=lang/STMT testsuite=COMPILER
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -672,8 +712,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/BINC testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/BINC testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/BINC testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -688,8 +729,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -704,8 +746,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -726,8 +769,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -748,8 +792,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -770,8 +815,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -792,8 +838,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP6) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -814,8 +861,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP7) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -836,8 +884,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP8) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -858,8 +907,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP9) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -880,8 +930,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CLASS_TESTS_GROUP10) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -896,8 +947,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -912,8 +964,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -934,8 +987,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -956,8 +1010,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -978,8 +1033,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_CONV_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -994,8 +1050,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1010,8 +1067,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1032,8 +1090,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1054,8 +1113,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1076,8 +1136,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1098,8 +1159,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP6) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1120,8 +1182,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP7) testsuite=COMPILER
+		)</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1142,8 +1205,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP8) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1164,8 +1228,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP9) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1186,8 +1251,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP10) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1208,8 +1274,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_EXPR_TESTS_GROUP11) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1224,8 +1291,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1240,8 +1308,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP2) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1262,8 +1331,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP3) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1284,8 +1354,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP4) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1306,8 +1377,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_INTF_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP5) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_INTF_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1322,8 +1394,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1338,8 +1411,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP2) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1360,8 +1434,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP3) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1382,8 +1457,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP4) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1404,8 +1480,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP5) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1430,8 +1507,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP6) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP6) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP6) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1456,8 +1534,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP7) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP7) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_LMBD_TESTS_GROUP7) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1472,8 +1551,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/ARR testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/ARR testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/ARR testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1488,8 +1568,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1504,8 +1585,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP2) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1526,8 +1608,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP3) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1548,8 +1631,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP4) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1570,8 +1654,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_DASG_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP5) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_DASG_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1586,8 +1671,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/EXCP testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/EXCP testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/EXCP testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1602,8 +1688,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/EXEC testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/EXEC testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/EXEC testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1618,8 +1705,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/FP testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/FP testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/FP testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1640,8 +1728,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/ICLS testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/ICLS testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/ICLS testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1662,8 +1751,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/INFR testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/INFR testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/INFR testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1684,8 +1774,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/MOD testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/MOD testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/MOD testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1703,8 +1794,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1719,8 +1811,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP2) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1741,8 +1834,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP3) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1763,8 +1857,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP4) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1785,8 +1880,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_NAME_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP5) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_NAME_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1801,8 +1897,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/PKGS testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/PKGS testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/PKGS testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1817,8 +1914,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/THRD testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/THRD testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/THRD testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1833,8 +1931,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1849,8 +1948,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP2) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1871,8 +1971,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP3) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1893,8 +1994,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP4) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1915,8 +2017,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP5) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_TYPE_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1937,8 +2040,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1959,8 +2063,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP2) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -1981,8 +2086,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP3) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -2003,8 +2109,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP4) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -2025,8 +2132,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP5) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_ANNOT_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -2041,8 +2149,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=lang/LEX testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=lang/LEX testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/LEX testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -2057,8 +2166,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP1) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP1) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP1) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -2073,8 +2183,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP2) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP2) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP2) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -2095,8 +2206,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP3) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP3) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP3) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -2117,8 +2229,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP4) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP4) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP4) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>
@@ -2139,8 +2252,9 @@
 		</variations>
 		<command>$(GEN_JTB) tests=$(COMPILER_LANG_STMT_TESTS_GROUP5) testsuite=COMPILER$(USEQ); \
 		$(START_MULTI_JVM_COMP_TEST); \
-		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP5) testsuite=COMPILER; \
-		$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=$(COMPILER_LANG_STMT_TESTS_GROUP5) testsuite=COMPILER
+		</command>
 		<levels>
 			<level>dev</level>
 		</levels>

--- a/jck/devtools.java2schema/playlist.xml
+++ b/jck/devtools.java2schema/playlist.xml
@@ -20,8 +20,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=java2schema/CustomizedMapping testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=java2schema/CustomizedMapping testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=java2schema/CustomizedMapping testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -39,8 +40,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=java2schema/DefaultMapping testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=java2schema/DefaultMapping testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=java2schema/DefaultMapping testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/jck/devtools.jaxws/playlist.xml
+++ b/jck/devtools.jaxws/playlist.xml
@@ -21,8 +21,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=jaxws/mapping testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=jaxws/mapping testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=jaxws/mapping testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/jck/devtools.schema2java/playlist.xml
+++ b/jck/devtools.schema2java/playlist.xml
@@ -21,8 +21,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema2java/nisttest testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema2java/nisttest testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema2java/nisttest testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -40,8 +41,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema2java/structures testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema2java/structures testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema2java/structures testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/jck/devtools.schema_bind/playlist.xml
+++ b/jck/devtools.schema_bind/playlist.xml
@@ -21,8 +21,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_class testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_class testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_class testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -40,8 +41,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_dom testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_dom testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_dom testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -59,8 +61,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_factoryMethod testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_factoryMethod testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_factoryMethod testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -78,8 +81,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_globalBindings testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_globalBindings testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_globalBindings testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -97,8 +101,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_inlineBinaryData testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_inlineBinaryData testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_inlineBinaryData testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -116,8 +121,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_javaType testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_javaType testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_javaType testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -135,8 +141,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_property testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_property testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_property testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -154,8 +161,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=schema_bind/bind_schemaBindings testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_schemaBindings testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=schema_bind/bind_schemaBindings testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/jck/devtools.xml_schema/playlist.xml
+++ b/jck/devtools.xml_schema/playlist.xml
@@ -21,8 +21,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=xml_schema/boeingData testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=xml_schema/boeingData testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/boeingData testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -40,8 +41,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP1) testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP1) testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP1) testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -59,8 +61,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP2) testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP2) testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP2) testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -78,8 +81,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP3) testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP3) testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP3) testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -97,8 +101,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP4) testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP4) testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=$(RUNTIME_DEVTOOLS_XML_SCHEMA_MSDATA_GROUP4) testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -116,8 +121,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=xml_schema/nistData testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -135,8 +141,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=xml_schema/sunData testsuite=DEVTOOLS; \
 		$(EXEC_DEVTOOLS_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=xml_schema/sunData testsuite=DEVTOOLS; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/sunData testsuite=DEVTOOLS
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -150,20 +150,21 @@ GEN_JTB_GENERIC = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.o
 GEN_SUMMARY_GENERIC = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavatestUtil testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) configAltPath=$(CONFIG_ALT_PATH) workdir=$(REPORTDIR) spec=$(SPEC) task=summarygen
 START_AGENT_GENERIC = $(JAVA_TO_TEST) -Djavatest.security.allowPropertiesAccess=true -Djava.security.policy=$(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/lib/jck.policy -classpath $(Q)$(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/lib/javatest.jar$(P)$(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/classes$(Q) com.sun.javatest.agent.AgentMain -passive -trace &> $(REPORTDIR)/agent.log &
 START_RMIREG = $(TEST_JDK_HOME)/bin/rmiregistry > $(REPORTDIR)$(D)rmiregistry.log &
-START_RMID = $(TEST_JDK_HOME)/bin/rmid -J-Dsun.rmi.activation.execPolicy=none -J-Djava.security.policy=$(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/lib/jck.policym > $(REPORTDIR)$(D)rmid.log &
+START_RMID = $(TEST_JDK_HOME)/bin/rmid -J-Dsun.rmi.activation.execPolicy=none -J-Djava.security.policy=$(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/lib/jck.policy > $(REPORTDIR)$(D)rmid.log &
 START_TNAMESRV = $(TEST_JDK_HOME)/bin/tnameserv -ORBInitialPort 9876 > $(REPORTDIR)$(D)tnameserv.log &
 EXEC_RUNTIME_TEST = $(JAVA_TO_TEST) -jar $(JCK_ROOT)/JCK-runtime-$(JCK_VERSION_NUMBER)/lib/javatest.jar -config $(CONFIG_ALT_PATH)/$(JCK_VERSION)/runtime.jti @$(REPORTDIR)/generated.jtb
 EXEC_COMPILER_TEST = $(JAVA_TO_TEST) -jar $(JCK_ROOT)/JCK-compiler-$(JCK_VERSION_NUMBER)/lib/javatest.jar -config $(CONFIG_ALT_PATH)/$(JCK_VERSION)/compiler.jti @$(REPORTDIR)/generated.jtb
 EXEC_DEVTOOLS_TEST = $(JAVA_TO_TEST) -jar $(JCK_ROOT)/JCK-devtools-$(JCK_VERSION_NUMBER)/lib/javatest.jar -config $(CONFIG_ALT_PATH)/$(JCK_VERSION)/devtools.jti @$(REPORTDIR)/generated.jtb
 EXEC_RUNTIME_TEST_WITH_AGENT = $(TEST_ROOT)/jck/agent-drive.sh '$(START_AGENT_GENERIC)' '$(EXEC_RUNTIME_TEST)'
-EXEC_RUNTIME_TEST_WITH_SERVICES = $(EXEC_RUNTIME_TEST)
+EXEC_RUNTIME_TEST_WITH_RMI_SERVICES = $(EXEC_RUNTIME_TEST_WITH_AGENT)
 
 ifeq ($(JDK_VERSION), 8)
-	EXEC_RUNTIME_TEST_WITH_SERVICES = $(TEST_ROOT)/jck/agent-drive.sh '$(START_AGENT_GENERIC)' '$(START_RMIREG)' '$(START_RMID)' '$(START_TNAMESRV)' '$(EXEC_RUNTIME_TEST)'
+	EXEC_RUNTIME_TEST_WITH_RMI_SERVICES = $(TEST_ROOT)/jck/agent-drive.sh '$(START_AGENT_GENERIC)' '$(START_RMIREG)' '$(START_RMID)' '$(START_TNAMESRV)' '$(EXEC_RUNTIME_TEST)'
+	EXEC_RUNTIME_TEST_WITH_AGENT = $(TEST_ROOT)/jck/agent-drive.sh '$(START_AGENT_GENERIC)' '$(START_TNAMESRV)' '$(EXEC_RUNTIME_TEST)'
 endif
 
 ifeq ($(JDK_VERSION), 11)
-	EXEC_RUNTIME_TEST_WITH_SERVICES = $(TEST_ROOT)/jck/agent-drive.sh '$(START_RMIREG)' '$(START_RMID)' '$(START_AGENT_GENERIC)' '$(EXEC_RUNTIME_TEST)'
+	EXEC_RUNTIME_TEST_WITH_RMI_SERVICES = $(TEST_ROOT)/jck/agent-drive.sh '$(START_AGENT_GENERIC)' '$(START_RMIREG)' '$(START_RMID)' '$(EXEC_RUNTIME_TEST)'
 endif
 
 ifeq (8, $(JDK_VERSION))

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -55,8 +55,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/instrument testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/instrument testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/instrument testsuite=RUNTIME
+</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -71,8 +72,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/invoke testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/invoke testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/invoke testsuite=RUNTIME
+	</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -87,8 +89,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/reflect testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/reflect testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/reflect testsuite=RUNTIME
+	</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -103,8 +106,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/Package testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/Package testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/Package testsuite=RUNTIME
+	</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -119,8 +123,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/String testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/String testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/String testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -135,8 +140,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/StringBuilder testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/StringBuilder testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/StringBuilder testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -151,8 +157,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/StringBuffer testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/StringBuffer testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/StringBuffer testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -167,8 +174,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/ClassLoader testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/ClassLoader testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/ClassLoader testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -183,8 +191,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/ModuleLayer testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/ModuleLayer testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/ModuleLayer testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -202,8 +211,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/module testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/module testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/module testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -221,8 +231,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/StackWalker testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/StackWalker testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/StackWalker testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -240,8 +251,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/Module_class testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/Module_class testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/Module_class testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -259,8 +271,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/SecurityManager testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/SecurityManager testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/SecurityManager testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -275,8 +288,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/System testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/System testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/System testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -291,8 +305,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/constant testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/constant testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/constant testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -310,8 +325,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang/Class testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/Class testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang/Class testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -326,8 +342,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/signaturetest testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/signaturetest testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/signaturetest testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -342,8 +359,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/modulegraph testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/modulegraph testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/modulegraph testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -368,9 +386,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_util/regex testsuite=RUNTIME; \
-		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_util/regex testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(EXEC_RUNTIME_TEST_WITH_AGENT); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_util/regex testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -385,8 +404,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_naming/spi testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming/spi testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming/spi testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -400,9 +420,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_util/ResourceBundle testsuite=RUNTIME; \
-		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_util/ResourceBundle testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(EXEC_RUNTIME_TEST_WITH_AGENT); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_util/ResourceBundle testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -430,8 +451,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_applet testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_applet testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_applet testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -456,8 +478,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_awt testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_awt testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_awt testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -480,8 +503,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_beans testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_beans testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_beans testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -497,8 +521,9 @@
 		<!-- This testcase opens many files which can exceed max open files, so limit concurrency to 1 --> 
 		<command>$(GEN_JTB_GENERIC) tests=api/java_io testsuite=RUNTIME concurrency=1; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_io testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_io testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -513,8 +538,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_lang testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_lang testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_lang testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -529,8 +555,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_math testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_math testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_math testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -555,9 +582,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_net testsuite=RUNTIME concurrency=1; \
-		$(EXEC_RUNTIME_TEST_WITH_SERVICES) ; \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_net testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(EXEC_RUNTIME_TEST_WITH_AGENT); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_net testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>special</level>
 		</levels>
@@ -572,8 +600,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_nio testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_nio testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_nio testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>special</level>
 		</levels>
@@ -595,9 +624,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_rmi testsuite=RUNTIME; \
-		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_rmi testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(EXEC_RUNTIME_TEST_WITH_RMI_SERVICES); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_rmi testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -620,8 +650,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_security testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_security testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_security testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -636,8 +667,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_sql testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_sql testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_sql testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -652,8 +684,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_text testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_text testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_text testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -668,8 +701,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_time testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_time testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_time testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -691,9 +725,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/java_util testsuite=RUNTIME; \
-		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
-		$(GEN_SUMMARY_GENERIC) tests=api/java_util testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(EXEC_RUNTIME_TEST_WITH_AGENT); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/java_util testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -715,8 +750,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_accessibility testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_accessibility testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_accessibility testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -731,8 +767,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_activation testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_activation testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_activation testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -750,8 +787,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_activity testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_activity testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_activity testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -769,8 +807,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_annotation testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_annotation testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_annotation testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -793,8 +832,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_crypto testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_crypto testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_crypto testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -809,8 +849,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_imageio testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_imageio testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_imageio testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -825,8 +866,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_lang testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_lang testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_lang testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -848,9 +890,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_management testsuite=RUNTIME; \
-		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_management testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(EXEC_RUNTIME_TEST_WITH_AGENT); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_management testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -865,8 +908,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_naming testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -895,8 +939,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_net testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -923,8 +968,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_print testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_print testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_print testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -947,8 +993,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_rmi testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_rmi testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_rmi testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -963,8 +1010,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_script testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_script testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_script testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -979,8 +1027,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_security testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_security testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_security testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>special</level>
 		</levels>
@@ -1003,8 +1052,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_sound testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_sound testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_sound testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1019,8 +1069,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_sql testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_sql testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_sql testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1045,8 +1096,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_swing testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_swing testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_swing testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1069,8 +1121,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_tools testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_tools testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_tools testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -1085,8 +1138,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_transaction testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_transaction testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_transaction testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1104,9 +1158,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_xml testsuite=RUNTIME concurrency=1; \
-		$(EXEC_RUNTIME_TEST_WITH_SERVICES); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_xml testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(EXEC_RUNTIME_TEST_WITH_AGENT); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_xml testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1131,8 +1186,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/org_ietf testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/org_ietf testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/org_ietf testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>special</level>
 		</levels>
@@ -1158,9 +1214,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/org_omg testsuite=RUNTIME; \
-		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/org_omg testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(EXEC_RUNTIME_TEST_WITH_AGENT); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/org_omg testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1178,8 +1235,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/org_w3c testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/org_w3c testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/org_w3c testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1194,8 +1252,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/org_xml testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/org_xml testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/org_xml testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1210,8 +1269,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/xinclude testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/xinclude testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/xinclude testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1226,8 +1286,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/xsl testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/xsl testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/xsl testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1242,8 +1303,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=api/serializabletypes testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=api/serializabletypes testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=api/serializabletypes testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>

--- a/jck/runtime.lang/playlist.xml
+++ b/jck/runtime.lang/playlist.xml
@@ -21,8 +21,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/BINC testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/BINC testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/BINC testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -37,8 +38,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CLSS testsuite=RUNTIME
+		</command>
 		<platformRequirements>^os.aix</platformRequirements>
 		<levels>
 			<level>sanity</level>
@@ -54,8 +56,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CLSS testsuite=RUNTIME
+		</command>
 		<platformRequirements>os.aix</platformRequirements>
 		<levels>
 			<level>sanity</level>
@@ -75,8 +78,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/CLSS testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CLSS testsuite=RUNTIME
+		</command>
 		<platformRequirements>os.aix</platformRequirements>
 		<levels>
 			<level>sanity</level>
@@ -95,8 +99,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/CONV testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/CONV testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/CONV testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -111,8 +116,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/EXPR testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/EXPR testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXPR testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -127,8 +133,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/INTF testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/INTF testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/INTF testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -143,8 +150,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/LMBD testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/LMBD testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/LMBD testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -159,8 +167,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/ARR testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/ARR testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ARR testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -175,8 +184,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/DASG testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/DASG testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/DASG testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -191,8 +201,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/EXCP testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/EXCP testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXCP testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -207,8 +218,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/EXEC testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/EXEC testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/EXEC testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -223,8 +235,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/FP testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/FP testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/FP testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -239,8 +252,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/ICLS testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/ICLS testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ICLS testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -255,8 +269,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/INFR testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/INFR testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/INFR testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -271,8 +286,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/MOD testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/MOD testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/MOD testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -290,8 +306,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/NAME testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/NAME testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/NAME testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -306,8 +323,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/PKGS testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/PKGS testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/PKGS testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -322,8 +340,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/THRD testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/THRD testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/THRD testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -338,8 +357,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/TYPE testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/TYPE testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/TYPE testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -354,8 +374,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/ANNOT testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/ANNOT testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/ANNOT testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -370,8 +391,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/LEX testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/LEX testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/LEX testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -386,8 +408,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=lang/STMT testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=lang/STMT testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=lang/STMT testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -29,8 +29,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/constantpool testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/constantpool testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/constantpool testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -54,9 +55,10 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/jdwp testsuite=RUNTIME concurrency=1; \
-		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/jdwp testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(EXEC_RUNTIME_TEST_WITH_AGENT); \
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/jdwp testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -71,8 +73,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/jvmti testsuite=RUNTIME concurrency=1; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/jvmti testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/jvmti testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -107,8 +110,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/overview testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/overview testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/overview testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -123,8 +127,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/classfmt testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/classfmt testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/classfmt testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -139,8 +144,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/module testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/module testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/module testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -158,8 +164,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/verifier/abstractAndNative testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/verifier/abstractAndNative testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/verifier/abstractAndNative testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -177,8 +184,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP1) testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP1) testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP1) testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -196,8 +204,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP2) testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP2) testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP2) testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -215,8 +224,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP3) testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP3) testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP3) testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -234,8 +244,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP4) testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP4) testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=$(VERIFIER_INSTRUCTIONS_TESTS_GROUP4) testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -253,8 +264,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/verifier/protectedCheck  testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/verifier/protectedCheck testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/verifier/protectedCheck testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -272,8 +284,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/verifier/subclassFinal testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/verifier/subclassFinal testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/verifier/subclassFinal testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -291,8 +304,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/instr testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/instr testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/instr testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -307,8 +321,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/cldc testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/cldc testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/cldc testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -323,8 +338,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/concepts testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/concepts testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/concepts testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -339,8 +355,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/fp testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/fp testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/fp testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -355,8 +372,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/jni testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/jni testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/jni testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -371,8 +389,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=vm/typechecker testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=vm/typechecker testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS) ; \
+		$(GEN_SUMMARY_GENERIC) tests=vm/typechecker testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/jck/runtime.xml_schema/playlist.xml
+++ b/jck/runtime.xml_schema/playlist.xml
@@ -21,8 +21,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=xml_schema/boeingData testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=xml_schema/boeingData testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/boeingData testsuite=RUNTIME
+	</command>
 		<levels>
 			<level>sanity</level>
 		</levels>
@@ -45,8 +46,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=xml_schema/msData testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=xml_schema/msData testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/msData testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -69,8 +71,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=xml_schema/nistData/atomic testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData/atomic testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData/atomic testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -93,8 +96,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=xml_schema/nistData/list testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData/list testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData/list testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -117,8 +121,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=xml_schema/nistData/union testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData/union testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/nistData/union testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -133,8 +138,9 @@
 		</variations>
 		<command>$(GEN_JTB_GENERIC) tests=xml_schema/sunData testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
-		$(GEN_SUMMARY_GENERIC) tests=xml_schema/sunData testsuite=RUNTIME; \
-	$(TEST_STATUS)</command>
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY_GENERIC) tests=xml_schema/sunData testsuite=RUNTIME
+		</command>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
- Limit rmi services startup to only rmi test. 
- Add agent startup to jdwp.
- Remove `-ue` from agent-drive.sh to not exit script when harness fails (allows agent-drive.sh to stop all services started-- fixing the hang issue on java_net and java_util). 
- Capture and return exit value of harness from agent-drive.sh. Additionally, in the playlists, move `$(TEST_STATUS);` immediately below the javatest command, ahead of result summary generation. This ensures TKG can mark the test as 'failed' when it fails-- fixing the false negative issue. 
