### PR TITLE
Exclude some of the jdk_security2 and jdk_foreign tests on z/OS

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -225,7 +225,8 @@ java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse-openj9/ope
 java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse-openj9/openj9/issues/8063	generic-all
 java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse-openj9/openj9/issues/8065	generic-all
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all,linux-s390x,macosx-all
-java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/infrastructure/issues/1173	linux-all,aix-all
+#java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/infrastructure/issues/1173	linux-all,aix-all,z/OS-s390x
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
@@ -273,6 +274,12 @@ security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.jav
 java/security/KeyPairGenerator/FinalizeHalf.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/Signature/ResetAfterException.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
+
+############################################################################
+
+# jdk_security2
+
+javax/xml/crypto/dsig/SecureValidation.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 
 ############################################################################
 
@@ -444,6 +451,9 @@ java/foreign/TestResourceScope.java https://github.com/eclipse-openj9/openj9/iss
 java/foreign/TestScopedOperations.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestStringEncoding.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestSymbolLookup.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestVarArgs.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/virtual/TestVirtualCalls.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 
 ############################################################################
 


### PR DESCRIPTION
Below tests needs to be excluded on z/OS for JDK17.
jdk_security2 
javax/xml/crypto/dsig/SecureValidation.java

jdk_foreign
java/foreign/TestVarArgs.java
java/foreign/valist/VaListTest.java
java/foreign/virtual/TestVirtualCalls.java