### PR TITLE
Disable multijvm targets on hotspot

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -135,6 +135,10 @@
 				<comment>Disabled on all platforms and Java levels due to backlog/issues/559. To be run manually by CR team</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -156,6 +160,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-api-javax_annotation_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -172,6 +182,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-api-javax_lang_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -194,6 +210,10 @@
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>11</version>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -218,6 +238,10 @@
 				<platform>ppc64_aix</platform>
 				<version>8</version>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>


### PR DESCRIPTION
These targets are experimental dev level and duplicate of targets already being run.  Disable for now so as not to attempt to run them without required extra machine/network configuration.