### PR TITLE
Move jdk_security1, 2 and 4 to sanity

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1065,7 +1065,7 @@
 	$(Q)$(JTREG_JDK_TEST_DIR):jdk_security1$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>
@@ -1091,7 +1091,7 @@
 	$(Q)$(JTREG_JDK_TEST_DIR):jdk_security2$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>
@@ -1150,7 +1150,7 @@
 	$(Q)$(JTREG_JDK_TEST_DIR):jdk_security4$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>extended</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>


### PR DESCRIPTION
Since we have people make changes to security code, we would like to run security tests more often.

resolves: https://github.com/adoptium/aqa-tests/issues/3858