### PR TITLE
Support aarch64 for CRIU portable testing

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -178,10 +178,11 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.amd"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.skylake"]
                     ],
-            'linux_aarch64' : [
-                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22"],
+            'aarch64_linux' : [
+                        // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.20"],
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.aarch64.armv8"],
                         // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8"],
-                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.aarch64.armv8"]
                     ],
             's390x_linux' : [
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z13"],
@@ -200,7 +201,7 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
                     ],
-            'linux_aarch64' : [
+            'aarch64_linux' : [
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22"],
                         // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]

--- a/external/criuSettings.mk
+++ b/external/criuSettings.mk
@@ -21,6 +21,8 @@ export CRIU_COMBO_LIST_linux_390_64_z13=sw.os.ubuntu.22-hw.arch.s390x.z13
 export CRIU_COMBO_LIST_linux_390_64_z14=sw.os.ubuntu.22-hw.arch.s390x.z14 sw.os.rhel.8-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z14
 export CRIU_COMBO_LIST_linux_390_64_z15=sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
 
+export CRIU_COMBO_LIST_aarch64_linux=sw.os.ubuntu.22-hw.arch.aarch64.armv8 sw.os.rhel.9-hw.arch.aarch64.armv8
+# not available: sw.os.rhel.8-hw.arch.aarch64.armv8 sw.os.ubuntu.20-hw.arch.aarch64.armv8
+
 # placeholder 
-export CRIU_COMBO_LIST_aarch64_linux=
 export CRIU_COMBO_LIST_ppc64le_linux=


### PR DESCRIPTION
depends on https://github.com/ibmruntimes/semeru-containers/pull/55 and https://github.com/ibmruntimes/semeru-containers/pull/56

related: backlog/issues/1133