### PR TITLE
Update OpenLiberty tag

### DIFF
--- a/external/openliberty-mp-tck/test.properties
+++ b/external/openliberty-mp-tck/test.properties
@@ -1,6 +1,6 @@
 github_url="https://github.com/OpenLiberty/open-liberty.git"
 test_results="testResults"
-tag_version="gm-22.0.0.2"
+tag_version="gm-23.0.0.5"
 ant_version="1.10.6"
 ubuntu_packages="git wget tar"
 maven_version="3.8.5"


### PR DESCRIPTION
Before excluding OpenLiberty external test, try updating tags to see if it resolves failures.