### PR TITLE
Exclude overrunning SPARCV9 tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -14,6 +14,7 @@
 
 # hotspot_all
 
+compiler/7184394/TestAESMain.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 compiler/7184394/TestAESMain.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
 compiler/intrinsics/sha/TestSHA.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
 ############################################################################
@@ -220,6 +221,7 @@ java/rmi/activation/Activatable/nonExistentActivatable/NonExistentActivatable.ja
 
 # jdk_security
 
+com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
 java/security/KeyPairGenerator/SolarisShortDSA.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
 java/security/MessageDigest/TestDigestIOStream.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
@@ -252,6 +254,15 @@ sun/security/pkcs11/Secmod/TestNssDbSqlite.java	https://github.com/adoptium/aqa-
 sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
 sun/security/tools/jarsigner/diffend.sh	https://github.com/adoptium/infrastructure/issues/2623	linux-all
 sun/security/tools/jarsigner/emptymanifest.sh	https://github.com/adoptium/infrastructure/issues/2623	linux-all
+sun/security/rsa/SignatureTest.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+sun/security/tools/keytool/WeakAlg.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+sun/security/tools/keytool/standard.sh https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+sun/security/tools/keytool/PSS.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+sun/security/util/math/TestIntegerModuloP.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+javax/net/ssl/TLSCommon/TLSTest.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+sun/security/rsa/pss/SignatureTestPSS.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+sun/security/provider/DSA/SupportedDSAParamGen.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+sun/security/provider/DSA/TestAlgParameterGenerator.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 
 ############################################################################
 
@@ -295,6 +306,7 @@ demo/jvmti/minst/MinstTest.java https://github.com/adoptium/aqa-tests/issues/265
 demo/jvmti/mtrace/TraceJFrame.java https://github.com/adoptium/aqa-tests/issues/2655 generic-all
 demo/jvmti/versionCheck/FailsWhenJvmtiVersionDiffers.java https://github.com/adoptium/aqa-tests/issues/2655 generic-all
 demo/jvmti/waiters/WaitersTest.java https://github.com/adoptium/aqa-tests/issues/2655 generic-all
+demo/zipfs/ZipFSOutputStreamTest.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 sun/tools/clhsdb/Basic.sh https://github.com/adoptium/aqa-tests/issues/2665 generic-all
 sun/tools/hsdb/Basic.sh https://github.com/adoptium/aqa-tests/issues/2665 generic-all
 #Following test cases with solaris are tracked by https://github.com/adoptium/aqa-tests/issues/3618 solaris-x64
@@ -306,6 +318,7 @@ sun/tools/jstatd/TestJstatdServer.java	https://github.com/adoptium/aqa-tests/iss
 sun/tools/native2ascii/Native2AsciiTests.sh https://github.com/adoptium/aqa-tests/issues/2667 windows-all
 sun/misc/Version/Version.java https://bugs.openjdk.java.net/browse/JDK-8244548 generic-all
 com/sun/tools/attach/StartManagementAgent.java	https://github.com/adoptium/aqa-tests/issues/115	generic-all
+tools/pack200/CommandLineTests.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 tools/pack200/CommandLineTests.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
 tools/pack200/Pack200Test.java https://github.com/adoptium/aqa-tests/issues/2657 generic-all
 tools/launcher/RunpathTest.java https://bugs.openjdk.java.net/browse/JDK-8286118 linux-arm


### PR DESCRIPTION
These tests take between 10 mins and 2 hours to run, so I'm excluding them to avoid timeouts. Anyone who wants them put back in should feel free to propose faster machines, make the case for 5 extra hours of runtime per execution, or find a solution for the cause of the timeouts.