### PR TITLE
Exclude all multijvm dev level targets against hotspot

### DIFF
--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -707,6 +707,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-BINC_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -724,6 +730,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group1_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -741,6 +753,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group2_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -762,6 +780,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -786,6 +808,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -808,6 +834,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -832,6 +862,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -854,6 +888,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -878,6 +916,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -900,6 +942,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -924,6 +970,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -942,6 +992,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-CONV-group1_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -959,6 +1015,12 @@
 	</test>
 		<test>
 		<testCaseName>jck-compiler-lang-CONV-group2_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -980,6 +1042,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1004,6 +1070,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1026,6 +1096,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1062,6 +1136,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group2_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1083,6 +1163,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1107,6 +1191,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1129,6 +1217,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1153,6 +1245,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1175,6 +1271,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1199,6 +1299,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1221,6 +1325,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1245,6 +1353,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1268,6 +1380,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1286,6 +1402,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-INTF-group1_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1303,6 +1425,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-INTF-group2_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1324,6 +1452,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1348,6 +1480,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1371,6 +1507,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1389,6 +1529,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-LMBD-group1_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1406,6 +1552,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-LMBD-group2_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1427,6 +1579,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1451,6 +1607,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1473,6 +1633,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1546,6 +1710,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-ARR_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1563,6 +1733,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-DASG-group1_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1580,6 +1756,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-DASG-group2_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1601,6 +1783,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1625,6 +1811,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1648,6 +1838,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1665,7 +1859,13 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>jck-compiler-lang-EXCP_multijvm</testCaseName>
+		<testCaseName>jck-compiler-lang-EXCP_multijvm</testCaseName>		
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1682,7 +1882,13 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>jck-compiler-lang-EXEC_multijvm</testCaseName>
+		<testCaseName>jck-compiler-lang-EXEC_multijvm</testCaseName>		
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1699,7 +1905,13 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>jck-compiler-lang-FP_multijvm</testCaseName>
+		<testCaseName>jck-compiler-lang-FP_multijvm</testCaseName>		
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1721,6 +1933,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1745,6 +1961,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1768,6 +1988,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1789,6 +2013,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-NAME-group1_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1806,6 +2036,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-NAME-group2_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1827,6 +2063,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1851,6 +2091,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1874,6 +2118,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -1892,6 +2140,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-PKGS_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1909,6 +2163,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-THRD_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1926,6 +2186,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-TYPE-group1_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1943,6 +2209,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-TYPE-group2_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1964,6 +2236,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -1988,6 +2264,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -2010,6 +2290,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -2034,6 +2318,10 @@
 				<comment>Fails in multijvm mode with Agent connectivity issues. Disabled temporarily</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -2056,6 +2344,10 @@
 			<disable>
 				<comment>Fails in multijvm mode with Agent connectivity issues. Disabled temporarily</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -2080,6 +2372,10 @@
 				<comment>Fails in multijvm mode with Agent connectivity issues. Disabled temporarily</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -2102,6 +2398,10 @@
 			<disable>
 				<comment>Fails in multijvm mode with Agent connectivity issues. Disabled temporarily</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -2126,6 +2426,10 @@
 				<comment>Fails in multijvm mode with Agent connectivity issues. Disabled temporarily</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -2143,7 +2447,13 @@
 		</groups>
 	</test>	
 	<test>
-		<testCaseName>jck-compiler-lang-LEX_multijvm</testCaseName>
+		<testCaseName>jck-compiler-lang-LEX_multijvm</testCaseName>		
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -2160,7 +2470,13 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>jck-compiler-lang-STMT-group1_multijvm</testCaseName>
+		<testCaseName>jck-compiler-lang-STMT-group1_multijvm</testCaseName>		
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -2177,7 +2493,13 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>jck-compiler-lang-STMT-group2_multijvm</testCaseName>
+		<testCaseName>jck-compiler-lang-STMT-group2_multijvm</testCaseName>		
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -2199,6 +2521,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>
@@ -2223,6 +2549,10 @@
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -2245,6 +2575,10 @@
 			<disable>
 				<comment>Disabled temporarily in multijvm mode</comment>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>


### PR DESCRIPTION
Missed this playlist when doing https://github.com/adoptium/aqa-tests/pull/4611