### PR TITLE
Revert "Make AIX use non-group multiJVM (#4513)"

### DIFF
--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -520,7 +520,7 @@ public class JavaTestRunner {
 			extraJvmOptions += " -Dfile.encoding=US-ASCII";
 		}
 
-		// testExecutionType of multiJVM_group on Windows and AIX causes memory exhaustion, so limit to plain multiJVM
+		// testExecutionType of multiJVM_group on Windows causes memory exhaustion, so limit to plain multiJVM
 		if (jckVersionInt >= 17 && spec.contains("win")) {
 			fileContent += "set jck.env.testPlatform.multiJVM \"Yes\";\n";
 		}

--- a/jck/jtrunner/JavaTestRunner.java
+++ b/jck/jtrunner/JavaTestRunner.java
@@ -521,7 +521,7 @@ public class JavaTestRunner {
 		}
 
 		// testExecutionType of multiJVM_group on Windows and AIX causes memory exhaustion, so limit to plain multiJVM
-		if (jckVersionInt >= 17 && (spec.contains("win") || spec.contains("aix"))) {
+		if (jckVersionInt >= 17 && spec.contains("win")) {
 			fileContent += "set jck.env.testPlatform.multiJVM \"Yes\";\n";
 		}
 


### PR DESCRIPTION
@andrew-m-leonard TC Grinder 3514 seems to have worked ok so I think all the [previous issues with this were resolved](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2968). If you have any outstanding concerns let me know.

This reverts commit b5ded17506ba5c2b84bde238b70e77ef689ea386

Related earlier PRs - this is a revert of the last one:
- https://github.com/adoptium/aqa-tests/pull/4499
- https://github.com/adoptium/aqa-tests/pull/4506
- https://github.com/adoptium/aqa-tests/pull/4513