### PR TITLE
Disable plinux criu ubuntu-container based tests

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -221,6 +221,11 @@ timestamps{
             def imageUploadJobs = [:]
             def target = "testList TESTLIST=disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry,disabled.criu-portable-checkpoint_test,disabled.criu-ubi-portable-checkpoint_test"
 
+            // exclude criu-portable-checkpoint_test on plinux due to github_ibm/runtimes/backlog/issues/1099
+            if (params.PLATFORM == "ppc64le_linux") {
+                target = target.minus(",disabled.criu-portable-checkpoint_test")
+            }
+
             echo "Trigger ${imageUploadJobName} job ..."
             for (int i = 0; i < imageUploadMap[params.PLATFORM].size(); i++) {
                 def labelAddition = imageUploadMap[params.PLATFORM][i].LABEL_ADDITION

--- a/external/criu-portable-restore/playlist.xml
+++ b/external/criu-portable-restore/playlist.xml
@@ -20,6 +20,12 @@
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir criu-portable-restore --platform "${PLATFORM}" --node_labels "${NODE_LABELS}" --docker_registry_url $(DOCKER_REGISTRY_URL) --docker_registry_dir "$(DOCKER_REGISTRY_DIR)" --criu_default_image_job_name "$(CRIU_DEFAULT_IMAGE_JOB_NAME)"
 		</command>
+		<disables>
+			<disable>
+				<comment>semeru docker image has no support for plinux ubuntu22 Github_ibm/runtimes/backlog/issues/1099</comment>
+				<platform>ppc64le_linux</platform>
+			</disable>
+		</disables>
 		<features>
 			<feature>CRIU:required</feature>
 		</features>


### PR DESCRIPTION
- Semeru dockerhub plinux image doesn't support ubuntu, disable these tests
- Related Issue: ibm_git/runtimes/backlog/issues/1099