### PR TITLE
Exclude more multijvm dev level targets against hotspot

### DIFF
--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -729,6 +729,29 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>jck-compiler-lang-EXPR-group1_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(GEN_JTB) tests=lang/EXPR testsuite=COMPILER$(USEQ); \
+		$(START_MULTI_JVM_COMP_TEST); \
+		$(TEST_STATUS); \
+		$(GEN_SUMMARY) tests=lang/EXPR testsuite=COMPILER
+		</command>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>jck</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group1_multijvm</testCaseName>
 		<disables>
 			<disable>

--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -729,29 +729,6 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>jck-compiler-lang-EXPR-group1_multijvm</testCaseName>
-		<disables>
-			<disable>
-				<comment>Disabled temporarily in multijvm mode</comment>
-				<impl>hotspot</impl>
-			</disable>
-		</disables>
-		<variations>
-			<variation>NoOptions</variation>
-		</variations>
-		<command>$(GEN_JTB) tests=lang/EXPR testsuite=COMPILER$(USEQ); \
-		$(START_MULTI_JVM_COMP_TEST); \
-		$(TEST_STATUS); \
-		$(GEN_SUMMARY) tests=lang/EXPR testsuite=COMPILER
-		</command>
-		<levels>
-			<level>dev</level>
-		</levels>
-		<groups>
-			<group>jck</group>
-		</groups>
-	</test>
-	<test>
 		<testCaseName>jck-compiler-lang-CLSS-Group1_multijvm</testCaseName>
 		<disables>
 			<disable>
@@ -1142,6 +1119,12 @@
 	</test>
 	<test>
 		<testCaseName>jck-compiler-lang-EXPR-group1_multijvm</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled temporarily in multijvm mode</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
Follow up to https://github.com/adoptium/aqa-tests/pull/4633 and https://github.com/adoptium/aqa-tests/pull/4611

@smlambert I assume this one is ok to exclude as well - it failed in Grinder 3518

Testing in 3519