### PR TITLE
Support CRIU portable testing on plinux

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -193,7 +193,15 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z15"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z15"]
-                    ]
+                    ],
+            'ppc64le_linux' : [
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p8"],
+                        // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p9"],
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p10"],
+                        // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p8"],
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p9"],
+                        // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.98&&hw.arch.ppc64le.p10"],
+            ]
         ]
         def imagePullMap = [
             'x86-64_linux' : [
@@ -210,6 +218,10 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z13"],
                         ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z14"],
                         ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z15"]
+                    ],
+            'ppc64le_linux' : [
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8"],
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
                     ]
         ]
         if (params.PLATFORM && imageUploadMap[params.PLATFORM] != null && imagePullMap[params.PLATFORM] != null) {
@@ -222,10 +234,11 @@ timestamps{
             def target = "testList TESTLIST=disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry,disabled.criu-portable-checkpoint_test,disabled.criu-ubi-portable-checkpoint_test"
 
             // exclude criu-portable-checkpoint_test on plinux due to github_ibm/runtimes/backlog/issues/1099
+            // exclude criu_pingPerf_testCreateRestoreImageAndPushToRegistry on plinux, zlinux and alinux due to https://github.com/adoptium/aqa-tests/issues/4632
             if (params.PLATFORM == "ppc64le_linux") {
                 target = target.minus("disabled.criu-portable-checkpoint_test,")
+                target = target.minus("disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry,")
             } else if (params.PLATFORM == "s390x_linux" || params.PLATFORM == "aarch64_linux") {
-                // exclude criu_pingPerf_testCreateRestoreImageAndPushToRegistry on zlinux and alinux due to https://github.com/adoptium/aqa-tests/issues/4632
                 target = target.minus("disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry,")
             }
 

--- a/external/criu/playlist.xml
+++ b/external/criu/playlist.xml
@@ -23,7 +23,7 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4632</comment>
-				<platform>(?:s390x_linux.*|aarch64_linux.*)</platform>
+				<platform>(?:s390x_linux.*|aarch64_linux.*|ppc64le_linux.*)</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -46,7 +46,7 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4632</comment>
-				<platform>(?:s390x_linux.*|aarch64_linux.*)</platform>
+				<platform>(?:s390x_linux.*|aarch64_linux.*|ppc64le_linux.*)</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -90,7 +90,7 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4632</comment>
-				<platform>(?:s390x_linux.*|aarch64_linux.*)</platform>
+				<platform>(?:s390x_linux.*|aarch64_linux.*|ppc64le_linux.*)</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -113,7 +113,7 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4632</comment>
-				<platform>(?:s390x_linux.*|aarch64_linux.*)</platform>
+				<platform>(?:s390x_linux.*|aarch64_linux.*|ppc64le_linux.*)</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>

--- a/external/criuSettings.mk
+++ b/external/criuSettings.mk
@@ -24,5 +24,5 @@ export CRIU_COMBO_LIST_linux_390_64_z15=sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.
 export CRIU_COMBO_LIST_aarch64_linux=sw.os.ubuntu.22-hw.arch.aarch64.armv8 sw.os.rhel.9-hw.arch.aarch64.armv8
 # not available: sw.os.rhel.8-hw.arch.aarch64.armv8 sw.os.ubuntu.20-hw.arch.aarch64.armv8
 
-# placeholder 
-export CRIU_COMBO_LIST_ppc64le_linux=
+export CRIU_COMBO_LIST_ppc64le_linux=sw.os.rhel.8-hw.arch.ppc64le.p8 sw.os.rhel.8-hw.arch.ppc64le.p10 sw.os.rhel.9-hw.arch.ppc64le.p9
+# not available: sw.os.rhel.8-hw.arch.ppc64le.p9 sw.os.rhel.9-hw.arch.ppc64le.p8 sw.os.rhel.9-hw.arch.ppc64le.p10


### PR DESCRIPTION
PingPerf failed with `exec /bin/sh: exec format error` on plinux (see https://github.com/adoptium/aqa-tests/issues/4632#issuecomment-1608146897). Exclude PingPerf on plinux.