### PR TITLE
Consolidating duplicate excluded tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -17,17 +17,19 @@
 ############################################################################
 
 # jdk_beans
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
+
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+
 ############################################################################
 
 # jdk_compiler
@@ -35,44 +37,47 @@ java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-test
 compiler/gcbarriers/UnsafeIntrinsicsTest.java#shenandoah https://github.com/adoptium/aqa-tests/issues/2640 linux-aarch64
 compiler/aot/verification/vmflags/TrackedFlagTest.java 8215224 generic-all
 compiler/aot/verification/vmflags/NotTrackedFlagTest.java 8215224 generic-all
+
 ############################################################################
 
 # jdk_lang
 
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1773 windows-x86
+java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+# java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1773 windows-x86
+java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java#id1	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
-java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessString.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-#java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/String/StringRepeat.java#id1 https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+# java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
+# java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64,linux-all
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessString.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+jdk/modules/etc/DefaultModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+
 ############################################################################
 
 # jdk_management
@@ -83,15 +88,19 @@ sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/ad
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 # alpine-linux https://github.com/adoptium/aqa-tests/issues/3238
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/aqa-tests/issues/3238 linux-all
+
 ############################################################################
 
 # jdk_security3
+
 javax/net/ssl/SSLEngine/LargePacket.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
-javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java	https://github.com/adoptium/aqa-tests/issues/2123	linux-all,macosx-all
+javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java https://github.com/adoptium/aqa-tests/issues/2123 linux-all,macosx-all
 sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aqa-tests/issues/3811 windows-x86
 
 ############################################################################
+
 # jdk_security4
+
 sun/security/krb5/auto/ReplayCacheTestProc.java https://bugs.openjdk.java.net/browse/JDK-8258855 linux-all
 sun/security/krb5/auto/rcache_usemd5.sh https://bugs.openjdk.java.net/browse/JDK-8258855 linux-all
 
@@ -106,35 +115,37 @@ sun/security/krb5/auto/rcache_usemd5.sh https://bugs.openjdk.java.net/browse/JDK
 ############################################################################
 
 # jdk_other
-#com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
+
+# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+
 ############################################################################
 
 # jdk_net
 
 java/net/DatagramSocket/SetGetSendBufferSize.java https://github.com/adoptium/aqa-tests/issues/2245 macosx-all
-java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
-java/net/Inet6Address/B6206527.java	https://github.com/adoptium/aqa-tests/issues/1524	macosx-all
-java/net/InetAddress/BadDottedIPAddress.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/InetAddress/CachedUnknownHostName.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/InetAddress/IPv4Formats.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-#Multicase failures on aix https://github.com/adoptium/aqa-tests/issues/2246
-java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x,aix-all
-java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x,aix-all
-java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x,aix-all
-java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/SocketPermission/Wildcard.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/Socks/SocksV4Test.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/URL/OpenStream.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/httpclient/ConnectExceptionTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/ipv6tests/B6521014.java	https://github.com/adoptium/aqa-tests/issues/1524	macosx-all
+java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
+java/net/Inet6Address/B6206527.java https://github.com/adoptium/aqa-tests/issues/1524 macosx-all
+java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/InetAddress/IPv4Formats.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+# Multicast failures on aix https://github.com/adoptium/aqa-tests/issues/2246
+java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/SocketPermission/SocketPermissionCollection.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/SocketPermission/Wildcard.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/Socks/SocksV4Test.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/URL/OpenStream.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/httpclient/ConnectExceptionTest.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/ipv6tests/B6521014.java https://github.com/adoptium/aqa-tests/issues/1524 macosx-all
 sun/net/www/protocol/file/DirPermissionDenied.java https://github.com/adoptium/aqa-tests/issues/760 windows-all
 sun/net/www/http/KeepAliveCache/KeepAliveProperty.java https://bugs.openjdk.org/browse/JDK-8285836 linux-ppc64le
-com/sun/net/httpserver/bugs/B6361557.java	https://github.com/adoptium/aqa-tests/issues/1272	windows-all
-java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
+com/sun/net/httpserver/bugs/B6361557.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
+
 ############################################################################
 
 # jdk_io
@@ -143,68 +154,73 @@ java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266
 
 # jdk_jdi
 
-com/sun/jdi/OnJcmdTest.java	https://github.com/adoptium/aqa-tests/issues/2837	windows-x86
+com/sun/jdi/OnJcmdTest.java https://github.com/adoptium/aqa-tests/issues/2837 windows-x86
 
 #############################################################################
 
-#jdk_jfr
+# jdk_jfr
 
 jdk/jfr/jvm/TestJFRIntrinsic.java https://bugs.openjdk.java.net/browse/JDK-8239423 linux-arm
 jdk/jfr/api/consumer/TestRecordedFrame.java https://bugs.openjdk.java.net/browse/JDK-8247203 linux-arm,linux-ppc64le
 jdk/jfr/api/recording/state/TestStateInvalid.java https://github.com/adoptium/aqa-tests/issues/3836 windows-x86
+
 ############################################################################
 
 # jdk_nio
 
-java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
+java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
-java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 # java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
 # java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
-java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/nio/file/Files/InputStreamTest.java	https://github.com/adoptium/aqa-tests/issues/2789	generic-all
-jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
-java/net/SocketPermission/SocketPermissionTest.java	https://bugs.openjdk.java.net/browse/JDK-8269919 aix-all
-java/nio/channels/DatagramChannel/BasicMulticastTests.java	https://bugs.openjdk.java.net/browse/JDK-8269919 aix-all
+# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
+java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all
+java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/nio/file/Files/InputStreamTest.java https://github.com/adoptium/aqa-tests/issues/2789 generic-all
+jdk/nio/zipfs/ZipFSTester.java https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
+java/net/SocketPermission/SocketPermissionTest.java https://bugs.openjdk.java.net/browse/JDK-8269919 aix-all
+java/nio/channels/DatagramChannel/BasicMulticastTests.java https://bugs.openjdk.java.net/browse/JDK-8269919 aix-all
 java/nio/file/DirectoryStream/SecureDS.java https://github.com/adoptium/aqa-tests/issues/3635 linux-arm
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
+
 ############################################################################ 
 
 # jdk_rmi
+
 ############################################################################
 
 # jdk_security1
 
-java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java	https://github.com/adoptium/aqa-tests/issues/2790	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/LetsEncryptCA.java	https://bugs.openjdk.java.net/browse/JDK-8270280 generic-all
+java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java https://github.com/adoptium/aqa-tests/issues/2790 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/LetsEncryptCA.java https://bugs.openjdk.java.net/browse/JDK-8270280 generic-all
 
 ############################################################################
 
 # jdk_security3
 
-jdk/security/jarsigner/JarWithOneNonDisabledDigestAlg.java	https://github.com/adoptium/aqa-tests/issues/2123	aix-all
-sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
-sun/security/pkcs11/fips/SunJSSEFIPSInit.java	https://github.com/adoptium/aqa-tests/issues/2123	linux-all
-sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
-sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
-sun/security/util/RegisteredDomain/ParseNames.java	https://github.com/adoptium/aqa-tests/issues/2123	aix-all
-sun/security/util/RegisteredDomain/Versions.java	https://github.com/adoptium/aqa-tests/issues/2123	aix-all
-sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.com/adoptium/aqa-tests/issues/2123	linux-all
+jdk/security/jarsigner/JarWithOneNonDisabledDigestAlg.java https://github.com/adoptium/aqa-tests/issues/2123 aix-all
+sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
+sun/security/pkcs11/fips/SunJSSEFIPSInit.java https://github.com/adoptium/aqa-tests/issues/2123 linux-all
+sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
+sun/security/util/RegisteredDomain/ParseNames.java https://github.com/adoptium/aqa-tests/issues/2123 aix-all
+sun/security/util/RegisteredDomain/Versions.java https://github.com/adoptium/aqa-tests/issues/2123 aix-all
+sun/security/pkcs11/Secmod/AddTrustedCert.java https://github.com/adoptium/aqa-tests/issues/2123 linux-all
+
 ############################################################################
 
 # jdk_security_infra
 
-security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/EntrustCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/EntrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+
 ############################################################################
 
 # jdk_sound
@@ -220,29 +236,34 @@ security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java 
 ############################################################################
 
 # jdk_time
+
 java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java https://github.com/adoptium/aqa-tests/issues/3051 macosx-all
 
 ############################################################################
 
 # jdk_tools
+
 sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 sun/tools/jstatd/TestJstatdExternalRegistry.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 tools/jlink/plugins/CompressorPluginTest.java https://bugs.openjdk.org/browse/JDK-8247407 generic-all
 tools/launcher/Test7029048.java#id1 https://bugs.openjdk.org/browse/JDK-8217438 aix-all
+
 ############################################################################
 
 # jdk_jdi
+
 com/sun/jdi/PrivateTransportTest.java https://bugs.openjdk.java.net/browse/JDK-8279326 macosx-all
+
 ############################################################################
 
 # jdk_util
 
-java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/util/concurrent/tck/JSR166TestCase.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/util/concurrent/tck/JSR166TestCase.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
-java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
+java/util/logging/TestLoggerWeakRefLeak.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 
 ############################################################################
 
@@ -331,17 +352,21 @@ compiler/loopopts/FillArrayWithUnsafe.java https://github.com/adoptium/aqa-tests
 compiler/loopopts/TestPredicateInputBelowLoopPredicate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/LoopRotateBadNodeBudget.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/TestRemoveEmptyLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+
 ############################################################################
 
 # jdk_imageio
-javax/imageio/plugins/shared/ImageWriterCompressionTest.java	https://github.com/adoptium/aqa-tests/issues/2814 aix-all
+
+javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/aqa-tests/issues/2814 aix-all
 
 ############################################################################
 
 # jdk_build
+
 build/AbsPathsInImage.java https://github.com/adoptium/aqa-tests/issues/3234 linux-x64
 
 ############################################################################
 
 # jdk_container/hotspot_container
+
 containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JDK-8297274 linux-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -17,67 +17,70 @@
 ############################################################################
 
 # jdk_beans
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/XMLEncoder/java_awt_CardLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/java_awt_GridBagLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/java_awt_ScrollPane.java	failure on mac is tracked by https://github.com/adoptium/aqa-tests/issues/2848
-java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
-java/beans/XMLEncoder/javax_swing_Box.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_BoxLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_Box_Filler.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_JButton.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_JLayeredPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_JSplitPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_OverlayLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_border_TitledBorder.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+# java/beans/XMLEncoder/java_awt_ScrollPane.java failure on mac is tracked by https://github.com/adoptium/aqa-tests/issues/2848
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+
 ############################################################################
 
 # jdk_lang
-java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-#java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
-java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessString.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+jdk/modules/etc/DefaultModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+# java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
+java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessString.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/String/StringRepeat.java#id1 https://bugs.openjdk.java.net/browse/JDK-8221400 windows-x86
-#java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
+# java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
 java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 generic-all
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 generic-all
 java/lang/StringBuffer/HugeCapacity.java https://bugs.openjdk.org/browse/JDK-8279954 windows-all
@@ -87,6 +90,7 @@ java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjd
 ############################################################################
 
 # jdk_management
+
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
@@ -95,6 +99,7 @@ sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/is
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+
 ############################################################################
 
 # jdk_jmx
@@ -106,36 +111,39 @@ sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-t
 ############################################################################
 
 # jdk_other
-#com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
+
+# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+
 ############################################################################
 
 # jdk_net
-java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
-java/net/InetAddress/BadDottedIPAddress.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/InetAddress/CachedUnknownHostName.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/InetAddress/IPv4Formats.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699	linux-s390x
-java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+
+java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
+java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/InetAddress/IPv4Formats.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/MulticastSocket/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/net/SocketPermission/SocketPermissionCollection.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/net/SocketPermission/SocketPermissionTest.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-java/net/SocketPermission/Wildcard.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/Socks/SocksV4Test.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/URL/OpenStream.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/httpclient/ConnectExceptionTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/httpclient/AsFileDownloadTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/StreamingBody.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/http2/ContinuationFrameTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/SpecialHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/http2/BadHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/DigestEchoClientSSL.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/ResponseBodyBeforeError.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/ResponsePublisher.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
+java/net/SocketPermission/Wildcard.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/Socks/SocksV4Test.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/URL/OpenStream.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/httpclient/ConnectExceptionTest.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/httpclient/AsFileDownloadTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/StreamingBody.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/http2/ContinuationFrameTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/SpecialHeadersTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/http2/BadHeadersTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/DigestEchoClientSSL.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/ResponseBodyBeforeError.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/ResponsePublisher.java https://github.com/adoptium/temurin-build/issues/893 linux-all
 java/net/httpclient/ShortResponseBody.java https://bugs.openjdk.java.net/browse/JDK-8261898 windows-all,sunos-all,macosx-all
 java/net/httpclient/ShortResponseBodyWithRetry.java https://bugs.openjdk.java.net/browse/JDK-8222928 windows-all,sunos-all,macosx-all
-#Multivase failures on aix https://github.com/adoptium/aqa-tests/issues/2246
+# Multicast failures on aix https://github.com/adoptium/aqa-tests/issues/2246
 java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
-java/net/MulticastSocket/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
@@ -145,55 +153,62 @@ java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adopt
 java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
+# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
+# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
+java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
 java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm,windows-x86
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
-#java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
+# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
 java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
 java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
 sun/net/www/http/KeepAliveCache/KeepAliveProperty.java https://bugs.openjdk.org/browse/JDK-8285836 linux-ppc64le
+
 ############################################################################
 
 # jdk_io
 
-java/io/File/GetXSpace.java	https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+
 ############################################################################
 
 # jdk_jdi
-com/sun/jdi/JdwpNetProps.java	https://bugs.openjdk.java.net/browse/JDK-8231915 linux-s390x
-com/sun/jdi/JdwpAttachTest.java	https://bugs.openjdk.java.net/browse/JDK-8253940 linux-s390x
+
+com/sun/jdi/JdwpNetProps.java https://bugs.openjdk.java.net/browse/JDK-8231915 linux-s390x
+com/sun/jdi/JdwpAttachTest.java https://bugs.openjdk.java.net/browse/JDK-8253940 linux-s390x
 com/sun/jdi/BreakpointTest.java https://bugs.openjdk.java.net/browse/JDK-8050470 linux-s390x
 com/sun/jdi/JdwpAllowTest.java https://bugs.openjdk.org/browse/JDK-8241624 generic-all
 com/sun/jdi/JdwpListenTest.java https://bugs.openjdk.org/browse/JDK-8241624 generic-all
+
 ############################################################################
 
 # jdk_nio
-java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
-java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+
+java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
+java/nio/charset/spi/CharsetProviderBasicTest.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/file/Files/InterruptCopy.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+java/nio/channels/DatagramChannel/ConnectExceptions.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/DatagramChannel/SendExceptions.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/file/Files/InterruptCopy.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
-java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
-jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
-java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
-java/nio/channels/FileChannel/Transfer2GPlus.java   https://bugs.openjdk.java.net/browse/JDK-8272095 linux-arm,windows-all
-#java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3690 windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+jdk/nio/zipfs/ZipFSTester.java https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
+java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/channels/FileChannel/Transfer2GPlus.java https://bugs.openjdk.java.net/browse/JDK-8272095 linux-arm,windows-all
+# java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3690 windows-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+
 ############################################################################ 
 
 # jdk_rmi
+
 ############################################################################
 
 # jdk_security
@@ -202,23 +217,25 @@ java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-test
 
 # jdk_security3
 
-javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java	https://bugs.openjdk.org/browse/JDK-8227651 generic-all
-javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java	https://bugs.openjdk.org/browse/JDK-8227651	generic-all
+javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
+javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
 javax/net/ssl/SSLEngine/LargePacket.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
-sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
-sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.com/adoptium/aqa-tests/issues/2123	linux-all
-sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java	https://github.com/adoptium/aqa-tests/issues/2123	linux-all
-sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
+sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
+sun/security/pkcs11/Secmod/AddTrustedCert.java https://github.com/adoptium/aqa-tests/issues/2123 linux-all
+sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java https://github.com/adoptium/aqa-tests/issues/2123 linux-all
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
 sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aqa-tests/issues/3811 windows-x86
+
 #############################################################################
 
-#jdk_security_infra
-security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/EntrustCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+# jdk_security_infra
+
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/EntrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
 
 ########################################################################################################################################################
 
@@ -243,52 +260,57 @@ security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java 
 sun/tools/jstatd/TestJstatdExternalRegistry.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
-sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
-sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
-sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
-sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
-tools/jpackage/share/AddLauncherTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/AppImagePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/EmptyFolderPackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/FileAssociationsTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/IconTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
-#The following 8 tests under tools/jpackage/share/ excluded on linux-aarch64 the tracked issue is https://github.com/adoptium/infrastructure/issues/2291
-tools/jpackage/share/InstallDirTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/LicenseTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/MultiLauncherTwoPhaseTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/MultiNameTwoPhaseTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/RuntimePackageTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/SimplePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/jdk/jpackage/tests/BasicTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/jdk/jpackage/tests/VendorTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/windows/WinDirChooserTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinInstallerUiTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinL10nTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinMenuGroupTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinMenuTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinPerUserInstallTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinScriptTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinShortcutPromptTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinShortcutTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinUpgradeUUIDTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinUrlTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
+sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+sun/tools/jstat/jstatLineCounts4.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AppImagePackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/EmptyFolderPackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/IconTest.java https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
+# The following 8 tests under tools/jpackage/share/ excluded on linux-aarch64 the tracked issue is https://github.com/adoptium/infrastructure/issues/2291
+tools/jpackage/share/InstallDirTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/LicenseTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/RuntimePackageTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/SimplePackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/BasicTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/VendorTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/windows/WinDirChooserTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinInstallerUiTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinL10nTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuGroupTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinScriptTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutPromptTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jlink/JLinkTest.java	https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
-tools/jlink/JLinkReproducible3Test.java	https://bugs.openjdk.java.net/browse/JDK-8253688 generic-all
-tools/jlink/JLinkReproducibleTest.java  https://bugs.openjdk.java.net/browse/JDK-8217166 aix-all 
+tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
+tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 generic-all
+tools/jlink/JLinkReproducibleTest.java https://bugs.openjdk.java.net/browse/JDK-8217166 aix-all
+
 ############################################################################
 
 # jdk_jdi
-com/sun/jdi/OnJcmdTest.java	https://github.com/adoptium/aqa-tests/issues/2837	windows-x86
+
+com/sun/jdi/OnJcmdTest.java https://github.com/adoptium/aqa-tests/issues/2837 windows-x86
+
 ############################################################################
 
 # jdk_util
-java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/util/concurrent/tck/JSR166TestCase.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/util/logging/TestLoggerWeakRefLeak.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/util/concurrent/tck/JSR166TestCase.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all
 java/util/regex/NegativeArraySize.java https://github.com/adoptium/aqa-tests/issues/3818 generic-all
 java/util/BitSet/HugeToString.java https://github.com/adoptium/aqa-tests/issues/3818 generic-all
 java/util/zip/DeInflate.java https://bugs.openjdk.org/browse/JDK-8299748 linux-s390x
+
 ############################################################################
 
 # svc_tools
@@ -296,21 +318,25 @@ java/util/zip/DeInflate.java https://bugs.openjdk.org/browse/JDK-8299748 linux-s
 ############################################################################
 
 # jdk_other
+
 ############################################################################
 
 # jdk_foreign
-java/foreign/valist/VaListTest.java https://bugs.openjdk.org/browse/JDK-8295290   windows-aarch64
-java/foreign/malloc/TestMixedMallocFree.java https://bugs.openjdk.org/browse/JDK-8295290   windows-aarch64
-java/foreign/TestNative.java https://bugs.openjdk.org/browse/JDK-8295290   windows-aarch64
-java/foreign/TestVarArgs.java https://bugs.openjdk.org/browse/JDK-8295290   windows-aarch64
-java/foreign/StdLibTest.java https://bugs.openjdk.org/browse/JDK-8295290   windows-aarch64
-java/foreign/TestArrays.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
-java/foreign/TestLayouts.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
-java/foreign/TestLayoutPaths.java	https://github.com/adoptium/aqa-tests/issues/1701	generic-all
+
+java/foreign/valist/VaListTest.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
+java/foreign/malloc/TestMixedMallocFree.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
+# java/foreign/TestNative.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
 java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+java/foreign/TestVarArgs.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
+java/foreign/StdLibTest.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
+java/foreign/TestArrays.java https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayouts.java https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayoutPaths.java https://github.com/adoptium/aqa-tests/issues/1701 generic-all
 
 ############################################################################
+
 # jvm_compiler
+
 compiler/compilercontrol/commandfile/CompileOnlyTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/compilercontrol/commands/CompileOnlyTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/calls/fromCompiled/CompiledInvokeDynamic2CompiledTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
@@ -378,45 +404,50 @@ compiler/whitebox/BlockingCompilation.java https://github.com/adoptium/aqa-tests
 compiler/whitebox/GetCodeHeapEntriesTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/MakeMethodNotCompilableTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/codecache/MHIntrinsicAllocFailureTest.java https://github.com/adoptium/aqa-tests/issues/4515#issuecomment-1512404678 windows-x86,linux-arm
+
 ############################################################################
 
 # jdk_jfr
-jdk/jfr/event/oldobject/TestAllocationTime.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestHeapDeep.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestG1.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/api/consumer/TestRecordedFrame.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java	https://github.com/adoptium/aqa-tests/issues/2870 windows-x86,linux-arm
-jdk/jfr/event/gc/collection/TestG1ParallelPhases.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestListenerLeak.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestObjectAge.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestReferenceChainLimit.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestThreadLocalLeak.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/jmx/streaming/TestClose.java	https://github.com/adoptium/aqa-tests/issues/2865 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestDelegated.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestEnableDisable.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestRemoteDump.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestRotate.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+
+jdk/jfr/event/oldobject/TestAllocationTime.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestHeapDeep.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestG1.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/api/consumer/TestRecordedFrame.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java https://github.com/adoptium/aqa-tests/issues/2870 windows-x86,linux-arm
+jdk/jfr/event/gc/collection/TestG1ParallelPhases.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestListenerLeak.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestObjectAge.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestReferenceChainLimit.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestThreadLocalLeak.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jmx/streaming/TestClose.java https://github.com/adoptium/aqa-tests/issues/2865 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestDelegated.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestEnableDisable.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRemoteDump.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRotate.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestSetSettings.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/event/gc/detailed/TestZUncommitEvent.java https://bugs.openjdk.org/browse/JDK-8248078 generic-all
 jdk/jfr/event/gc/detailed/TestGCLockerEvent.java https://github.com/adoptium/aqa-tests/issues/3817 windows-x64
 jdk/jfr/event/compiler/TestCodeCacheFull.java https://github.com/adoptium/aqa-tests/issues/3277 windows-x86
 jdk/jfr/event/compiler/TestCompilerInlining.java https://github.com/adoptium/aqa-tests/issues/3277 windows-x86
 jdk/jfr/event/compiler/TestCompilerPhase.java https://github.com/adoptium/aqa-tests/issues/3277 windows-x86
 jdk/jfr/api/consumer/log/TestVerbosity.java https://bugs.openjdk.org/browse/JDK-8269723 generic-all
+
 ###########################################################################
 
-#jdk_vector
-jdk/incubator/vector/Byte512VectorLoadStoreTests.java	https://github.com/adoptium/aqa-tests/issues/2874 windows-x86,linux-arm
-jdk/incubator/vector/Byte64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/ByteMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/Int64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/IntMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+# jdk_vector
+
+jdk/incubator/vector/Byte512VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 windows-x86,linux-arm
+jdk/incubator/vector/Byte64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ByteMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Int64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/IntMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/Byte256VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm,windows-x86
 jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/Short64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/ShortMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/Byte128VectorLoadStoreTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Short64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ShortMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte128VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+
 ############################################################################
 
 # jvm_compiler
@@ -464,13 +495,15 @@ compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adopti
 compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/TestRemoveEmptyLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestFewIterationsCountedLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+
 ############################################################################
 
-#runtime_nestmate
+# runtime_nestmate
 
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 
 ############################################################################
 
 # jdk_container/hotspot_container
+
 containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JDK-8297274 linux-all

--- a/openjdk/excludes/ProblemList_openjdk20.txt
+++ b/openjdk/excludes/ProblemList_openjdk20.txt
@@ -17,91 +17,95 @@
 ############################################################################
 
 # jdk_beans
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-#java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-#java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
-java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
-java/beans/XMLEncoder/java_awt_CardLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/java_awt_GridBagLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
-java/beans/XMLEncoder/javax_swing_Box.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_BoxLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_Box_Filler.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
-java/beans/XMLEncoder/javax_swing_JButton.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_JLayeredPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_JSplitPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
-java/beans/XMLEncoder/javax_swing_OverlayLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_border_TitledBorder.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-java/beans/XMLEncoder/Test4631471.java  https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-#java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810   aix-ppc64,linux-all
-java/beans/PropertyChangeSupport/Test4682386.java   https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
+
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+
 ############################################################################
 
 # jdk_lang
-java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-#java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
-java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestAccessString.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java		https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java	https://github.com/adoptium/infrastructure/issues/1118  linux-aarch64
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
+
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+jdk/modules/etc/DefaultModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+# java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
+java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessString.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
-#java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
-#java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
+# java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
+# java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
 java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
 
 ############################################################################
 
 # jdk_management
+
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
 sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all
 
 ############################################################################
 
@@ -114,35 +118,38 @@ sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/b
 ############################################################################
 
 # jdk_other
-#com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
+
+# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
 com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,linux-arm,aix-all
+
 ############################################################################
 
 # jdk_net
-java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
-java/net/InetAddress/BadDottedIPAddress.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/InetAddress/CachedUnknownHostName.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/InetAddress/IPv4Formats.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699	linux-s390x
-java/net/SocketPermission/SocketPermissionCollection.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
+
+java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
+java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/InetAddress/IPv4Formats.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/MulticastSocket/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/net/SocketPermission/SocketPermissionCollection.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/net/SocketPermission/SocketPermissionTest.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-java/net/SocketPermission/Wildcard.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/Socks/SocksV4Test.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/URL/OpenStream.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/httpclient/ConnectExceptionTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/net/httpclient/AsFileDownloadTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/StreamingBody.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/http2/ContinuationFrameTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/SpecialHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/http2/BadHeadersTest.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/DigestEchoClientSSL.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/ResponseBodyBeforeError.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-java/net/httpclient/ResponsePublisher.java	https://github.com/adoptium/temurin-build/issues/893	linux-all
-#Multivase failures on aix https://github.com/adoptium/aqa-tests/issues/2246
+java/net/SocketPermission/Wildcard.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/Socks/SocksV4Test.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/URL/OpenStream.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/httpclient/ConnectExceptionTest.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/httpclient/AsFileDownloadTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/StreamingBody.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/http2/ContinuationFrameTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/SpecialHeadersTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/http2/BadHeadersTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/DigestEchoClientSSL.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/ResponseBodyBeforeError.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/ResponsePublisher.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+# Multicast failures on aix https://github.com/adoptium/aqa-tests/issues/2246
 java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
-java/net/MulticastSocket/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
@@ -152,57 +159,38 @@ java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adopt
 java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-java/net/CookieHandler/CookieManagerTest.java   https://github.com/adoptium/infrastructure/issues/699   aix-ppc64,linux-ppc64le
-java/net/DatagramPacket/ReuseBuf.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/DatagramSocket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64, linux-ppc64le
-java/net/DatagramSocket/PortUnreachable.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/DatagramSocket/ReuseAddressTest.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/DatagramSocket/Send12k.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088  aix-pcc64,linux-ppc64le 
-java/net/DatagramSocket/SendSize.java.SendSize  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/CookieHandler/CookieManagerTest.java https://github.com/adoptium/infrastructure/issues/699 aix-ppc64,linux-ppc64le
+java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64, linux-ppc64le
+java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le 
+java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socket/GetLocalAddress.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socket/ProxyCons.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socket/ReadTimeout.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socket/SetSoLinger.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socket/SoTimeout.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socket/asyncClose/AsyncClose.java  https://github.com/adoptium/aqa-tests/issues/827 aix-ppc64, linux-ppc64le
-java/net/Socket/asyncClose/BrokenPipe.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socket/setReuseAddress/Basic.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socket/setReuseAddress/Restart.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/SocketInputStream/SocketTimeout.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socks/BadProxySelector.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socks/SocksProxyVersion.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/Socket/asyncClose/Race.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ProxyCons.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ReadTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SetSoLinger.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SoTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/AsyncClose.java https://github.com/adoptium/aqa-tests/issues/827 aix-ppc64, linux-ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Basic.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/BadProxySelector.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/SocksProxyVersion.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/Race.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/httpclient/ManyRequests.java   https://github.com/adoptium/aqa-tests/issues/2828 aix-ppc64
-
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
-java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
-java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
-java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
-java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 generic-all
-java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086 generic-all
-java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-java/nio/channels/DatagramChannel/AfterDisconnect.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
-#java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
-java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/net/httpclient/ManyRequests.java https://github.com/adoptium/aqa-tests/issues/2828 aix-ppc64
 com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
 com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
 java/net/InetAddress/HostsFileOrderingTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
 java/net/InetAddress/InternalNameServiceTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
 java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
 com/sun/net/httpserver/simpleserver/StressDirListings.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 java/net/vthread/HttpALot.java https://github.com/adoptium/aqa-tests/issues/4440 aix-all
 java/net/vthread/InterruptHttp.java https://github.com/adoptium/aqa-tests/issues/4440 aix-all
@@ -211,69 +199,99 @@ java/net/vthread/BlockingSocketOps.java#direct-register https://github.com/adopt
 java/net/vthread/BlockingSocketOps.java#default https://github.com/adoptium/aqa-tests/issues/4440 aix-all
 java/nio/channels/vthread/BlockingChannelOps.java#default https://github.com/adoptium/aqa-tests/issues/4440 aix-all
 java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+
 ############################################################################
 
 # jdk_io
 
-java/io/File/GetXSpace.java	https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+
 ############################################################################
 
 # jdk_jdi
-com/sun/jdi/JdwpNetProps.java	https://bugs.openjdk.java.net/browse/JDK-8231915 linux-s390x
-com/sun/jdi/JdwpAttachTest.java	https://bugs.openjdk.java.net/browse/JDK-8253940 linux-s390x
+
+com/sun/jdi/JdwpNetProps.java https://bugs.openjdk.java.net/browse/JDK-8231915 linux-s390x
+com/sun/jdi/JdwpAttachTest.java https://bugs.openjdk.java.net/browse/JDK-8253940 linux-s390x
 com/sun/jdi/BreakpointTest.java https://bugs.openjdk.java.net/browse/JDK-8050470 linux-s390x
 com/sun/jdi/JdwpAllowTest.java https://bugs.openjdk.org/browse/JDK-8241624 generic-all
 com/sun/jdi/JdwpListenTest.java https://bugs.openjdk.org/browse/JDK-8241624 generic-all
+
 ############################################################################
 
 # jdk_nio
-java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
-java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/file/Files/InterruptCopy.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
-java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
-jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
-java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
-java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x,aix-all
+# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
+# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
+java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
+java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
+java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
+java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
+java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 generic-all
+java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
+java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
+java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
+# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
+# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
+java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
+java/nio/charset/spi/CharsetProviderBasicTest.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ConnectExceptions.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/DatagramChannel/SendExceptions.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/file/Files/InterruptCopy.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+jdk/nio/zipfs/ZipFSTester.java https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
+java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+
 ############################################################################ 
 
 # jdk_rmi
+
 ############################################################################
 
 # jdk_security
 
 sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aqa-tests/issues/3811 windows-x86
-sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all
+
 ############################################################################
 
-#jdk_security3
+# jdk_security3
+
 javax/net/ssl/SSLEngine/LargePacket.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
 sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 
 ###########################################################################
 
-#jdk_security4
+# jdk_security4
+
 # Cleaners.java issue is specific to alpine-linux, but there appears to be no way to exclude on alpine-linux platform specifically
-sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
+# sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
+sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all,linux-all
 
 ###########################################################################
-#jdk_security_infra
-security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java	https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/EntrustCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
-security/infra/java/security/cert/CertPathValidator/certification/ActalisCA.java https://github.com/adoptium/aqa-tests/issues/2074	generic-all
+
+# jdk_security_infra
+
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/EntrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/ActalisCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+
 ############################################################################
+
 # jdk_sound
 
 ############################################################################
@@ -291,61 +309,65 @@ security/infra/java/security/cert/CertPathValidator/certification/ActalisCA.java
 ############################################################################
 
 # jdk_tools
-sun/tools/jstat/jstatLineCounts1.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
-sun/tools/jstat/jstatLineCounts2.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
-sun/tools/jstat/jstatLineCounts3.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
-sun/tools/jstat/jstatLineCounts4.sh	https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
-sun/tools/jstatd/TestJstatdDefaults.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-sun/tools/jstatd/TestJstatdExternalRegistry.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-sun/tools/jstatd/TestJstatdPort.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-sun/tools/jstatd/TestJstatdPortAndServer.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-sun/tools/jstatd/TestJstatdServer.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
-tools/jpackage/share/AddLauncherTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/AppImagePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/EmptyFolderPackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/FileAssociationsTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/IconTest.java	https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
-#The following 8 tests under tools/jpackage/share/ excluded on linux-aarch64 the tracked issue is https://github.com/adoptium/infrastructure/issues/2291
-tools/jpackage/share/InstallDirTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/LicenseTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/MultiLauncherTwoPhaseTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/MultiNameTwoPhaseTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/RuntimePackageTest.java#id0	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/SimplePackageTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/jdk/jpackage/tests/BasicTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/share/jdk/jpackage/tests/VendorTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
-tools/jpackage/windows/WinDirChooserTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinInstallerUiTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinL10nTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinMenuGroupTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinMenuTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinPerUserInstallTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinScriptTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinShortcutPromptTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinShortcutTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinUpgradeUUIDTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/WinUrlTest.java	https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jlink/JLinkTest.java	https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
-tools/jlink/JLinkReproducible3Test.java	https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
-tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-pcc64
-tools/jpackage/windows/WinInstallerIconTest.java    https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/AddLShortcutTest.java  https://github.com/adoptium/infrastructure/issues/2310 windows-all
+sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts4.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstatd/TestJstatdDefaults.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdExternalRegistry.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPortAndServer.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdServer.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AppImagePackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/EmptyFolderPackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/IconTest.java https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
+# The following 8 tests under tools/jpackage/share/ excluded on linux-aarch64 the tracked issue is https://github.com/adoptium/infrastructure/issues/2291
+tools/jpackage/share/InstallDirTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/LicenseTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/RuntimePackageTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/SimplePackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/BasicTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/VendorTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/windows/WinDirChooserTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinInstallerUiTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinL10nTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuGroupTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinScriptTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutPromptTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
+tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
+tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-ppc64
+tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 
 ############################################################################
 
 # jdk_jdi
-com/sun/jdi/OnJcmdTest.java	https://github.com/adoptium/aqa-tests/issues/2837	windows-x86
+
+com/sun/jdi/OnJcmdTest.java https://github.com/adoptium/aqa-tests/issues/2837 windows-x86
+
 ############################################################################
 
 # jdk_util
-java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/util/concurrent/tck/JSR166TestCase.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/util/logging/TestLoggerWeakRefLeak.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/util/concurrent/tck/JSR166TestCase.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all
 java/util/regex/NegativeArraySize.java https://github.com/adoptium/aqa-tests/issues/3818 linux-all
-java/util/zip/DeInflate.java	https://bugs.openjdk.org/browse/JDK-8299748	linux-s390x
+java/util/zip/DeInflate.java https://bugs.openjdk.org/browse/JDK-8299748 linux-s390x
+
 ############################################################################
 
 # svc_tools
@@ -353,21 +375,36 @@ java/util/zip/DeInflate.java	https://bugs.openjdk.org/browse/JDK-8299748	linux-s
 ############################################################################
 
 # jdk_foreign
-java/foreign/TestArrays.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
-java/foreign/TestLayouts.java	https://github.com/adoptium/aqa-tests/issues/1701 generic-all
-java/foreign/TestLayoutPaths.java	https://github.com/adoptium/aqa-tests/issues/1701	generic-all
+
+java/foreign/TestArrays.java https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayouts.java https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayoutPaths.java https://github.com/adoptium/aqa-tests/issues/1701 generic-all
 java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/foreign/TestLargeSegmentCopy.java https://github.com/adoptium/aqa-tests/issues/4429 aix-all
 javax/management/mxbean/ThreadStartTest.java https://github.com/adoptium/aqa-tests/issues/4429 aix-all
+
 ############################################################################
+
 # jvm_compiler
-compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux-s390x
-compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/irTests/TestPostParseCallDevirtualization.java  https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/tiered/TieredLevelsTest.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/vectorapi/TestNoInline.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+
+compiler/c2/irTests/TestPostParseCallDevirtualization.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+# compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+# compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
+compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/vectorapi/TestNoInline.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestTranslatedException.java https://github.com/adoptium/aqa-tests/issues/3658 linux-x64,windows-x64,linux-aarch64,macosx-all
 compiler/c2/TestCMoveInfiniteGVN.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/TestDeadDataLoopCmoveIdentity.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -380,102 +417,101 @@ compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java https://git
 compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestConservativeAntiDep.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/codecache/MHIntrinsicAllocFailureTest.java https://bugs.openjdk.org/browse/JDK-8298947 linux-arm
 compiler/whitebox/ForceNMethodSweepTest.java https://bugs.openjdk.org/browse/JDK-8265181 linux-arm
-
 compiler/codegen/aes/Test8292158.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
 compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
+
 ############################################################################
 
 # jdk_jfr
-jdk/jfr/event/oldobject/TestAllocationTime.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestHeapDeep.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestG1.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/api/consumer/TestRecordedFrame.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java	https://github.com/adoptium/aqa-tests/issues/2870 windows-x86,linux-arm
-jdk/jfr/event/gc/collection/TestG1ParallelPhases.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestListenerLeak.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestObjectAge.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestReferenceChainLimit.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/event/oldobject/TestThreadLocalLeak.java	https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
-jdk/jfr/jmx/streaming/TestClose.java	https://github.com/adoptium/aqa-tests/issues/2865 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestDelegated.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestEnableDisable.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestRemoteDump.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestRotate.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 
+jdk/jfr/event/oldobject/TestAllocationTime.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestHeapDeep.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestG1.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/api/consumer/TestRecordedFrame.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java https://github.com/adoptium/aqa-tests/issues/2870 windows-x86,linux-arm
+jdk/jfr/event/gc/collection/TestG1ParallelPhases.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestListenerLeak.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestObjectAge.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestReferenceChainLimit.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestThreadLocalLeak.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jmx/streaming/TestClose.java https://github.com/adoptium/aqa-tests/issues/2865 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestDelegated.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestEnableDisable.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRemoteDump.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRotate.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+# jdk/jfr/jmx/streaming/TestSetSettings.java https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
+jdk/jfr/jmx/streaming/TestSetSettings.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/3492 generic-all
-jdk/jfr/jmx/streaming/TestMetadataEvent.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
-jdk/jfr/jmx/streaming/TestSetSettings.java  https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
-jdk/jfr/jmx/streaming/TestStart.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86
-jdk/jfr/jmx/TestGetRecordings.java  https://github.com/adoptium/aqa-tests/issues/2754 linux-ppc64le
+jdk/jfr/jmx/streaming/TestMetadataEvent.java https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
+jdk/jfr/jmx/streaming/TestStart.java https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86
+jdk/jfr/jmx/TestGetRecordings.java https://github.com/adoptium/aqa-tests/issues/2754 linux-ppc64le
 jdk/jfr/event/gc/detailed/TestZUncommitEvent.java https://bugs.openjdk.org/browse/JDK-8248078 generic-all
 jdk/jfr/event/gc/detailed/TestGCLockerEvent.java https://github.com/adoptium/aqa-tests/issues/3817 windows-x64
 
 ###########################################################################
 
-#jdk_vector
-jdk/incubator/vector/Byte512VectorLoadStoreTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/Byte64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/ByteMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/Int64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/IntMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/Short64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-jdk/incubator/vector/ShortMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+# jdk_vector
 
-jdk/incubator/vector/Byte256VectorLoadStoreTests.java   https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte512VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ByteMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Int64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/IntMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Short64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ShortMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte256VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 
 ############################################################################
 
-#runtime_nestmate
+# runtime_nestmate
+
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 
 ############################################################################
-#javax_management
-javax/management/remote/mandatory/connection/RMIConnectionIdTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
-javax/management/remote/mandatory/notif/RMINotifTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+
+# javax_management
+
+javax/management/remote/mandatory/connection/RMIConnectionIdTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/notif/RMINotifTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
 javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
-javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java  https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
-javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
 javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
-javax/management/remote/mandatory/util/MapNullValuesTest.java   https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/util/MapNullValuesTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
 
 ############################################################################
-#jdk_imageio
+
+# jdk_imageio
+
 javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
 
 ############################################################################
-#sun_net
-sun/net/www/http/HttpClient/B8025710.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-sun/net/www/http/KeepAliveCache/B5045306.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+
+# sun_net
+
+sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/http/KeepAliveCache/B5045306.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-sun/net/www/protocol/http/NoCache.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-sun/net/www/protocol/http/ZoneId.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/ZoneId.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java https://bugs.openjdk.java.net/browse/JDK-8224204 generic-all
 sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
 #####################################
 
 # jdk_container/hotspot_container
+
 containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JDK-8297274 linux-all
 
 ############################################################
-#serviceability
+
+# serviceability
+
 serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfoWithEATest.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -14,30 +14,19 @@
 
 # hotspot_all
 
-compiler/7184394/TestAESMain.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
-compiler/7184394/TestAESMain.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
-compiler/intrinsics/sha/TestSHA.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
+# compiler/7184394/TestAESMain.java https://github.com/adoptium/infrastructure/issues/2893 
+compiler/7184394/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,solaris-sparcv9
+compiler/intrinsics/sha/TestSHA.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+
 ############################################################################
 
 # hotspot_jre
 
-runtime/7110720/Test7110720.sh https://github.com/adoptium/adoptium/issues/58 aix-all
 compiler/c2/Test8202414.java https://bugs.openjdk.java.net/browse/JDK-8251152 linux-arm
 compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tests/issues/2671 linux-ppc64le,aix-all,linux-arm,windows-x86
-compiler/6894807/IsInstanceTest.java https://github.com/adoptium/adoptium/issues/58 aix-all
-gc/metaspace/TestMetaspaceMemoryPool.java https://github.com/adoptium/aqa-tests/issues/2708 generic-all
-runtime/CDSCompressedKPtrs/CDSCompressedKPtrs.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/SharedArchiveFile/CdsSameObjectAlignment.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/SharedArchiveFile/LimitSharedSizes.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/SharedArchiveFile/PrintSharedArchiveAndExit.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/SharedArchiveFile/SharedArchiveFile.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/SharedArchiveFile/SpaceUtilizationCheck.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-runtime/7110720/Test7110720.sh https://github.com/adoptium/aqa-tests/issues/2818 aix-all
+# compiler/6894807/IsInstanceTest.java https://github.com/adoptium/adoptium/issues/58 aix-all
 compiler/6894807/IsInstanceTest.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/8004051/Test8004051.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
-gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/criticalnatives/argumentcorruption/Test8167409.sh https://github.com/adoptium/aqa-tests/issues/2984 linux-arm
 compiler/c2/cr6340864/TestByteVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
 compiler/c2/cr6340864/TestDoubleVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
@@ -46,27 +35,39 @@ compiler/c2/cr6340864/TestIntVect.java https://bugs.openjdk.java.net/browse/JDK-
 compiler/c2/cr6340864/TestLongVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
 compiler/codegen/TestCharVect2.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
-#compiler/EscapeAnalysis/TestGetClass.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+# compiler/EscapeAnalysis/TestGetClass.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/escapeAnalysis/TestGetClass.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
 compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
-gc/g1/Test2GbHeap.java https://bugs.openjdk.java.net/browse/JDK-8154787 linux-arm
-gc/g1/TestHumongousShrinkHeap.java https://bugs.openjdk.java.net/browse/JDK-8041506 linux-arm
-gc/whitebox/TestConcMarkCycleWB.java https://bugs.openjdk.java.net/browse/JDK-8067368 linux-arm
-runtime/StackGap/testme.sh https://bugs.openjdk.java.net/browse/JDK-8201536 linux-arm
-#https://github.com/adoptium/aqa-tests/issues/3250 linux-arm
-compiler/gcbarriers/PreserveFPRegistersTest.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
-gc/TestMemoryMXBeansAndPoolsPresence.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
-gc/g1/mixedgc/TestOldGenCollectionUsage.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
-runtime/CompressedOops/CompressedClassPointers.java https://bugs.openjdk.org/browse/JDK-8234058 linux-ppc64le,aix-all
-runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/infrastructure/issues/2565 solaris-x64,aix-all
-gc/concurrentMarkSweep/GuardShrinkWarning.java https://bugs.openjdk.java.net/browse/JDK-8023356 solaris-x64
 compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 compiler/floatingpoint/8165673/TestFloatJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 compiler/intrinsics/mathexact/LongMulOverflowTest.java https://bugs.openjdk.org/browse/JDK-8196568 solaris-x64
+compiler/gcbarriers/PreserveFPRegistersTest.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
+compiler/8209951/TestCipherBlockChainingEncrypt.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
+gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
+gc/g1/Test2GbHeap.java https://bugs.openjdk.java.net/browse/JDK-8154787 linux-arm
+gc/g1/TestHumongousShrinkHeap.java https://bugs.openjdk.java.net/browse/JDK-8041506 linux-arm
+gc/whitebox/TestConcMarkCycleWB.java https://bugs.openjdk.java.net/browse/JDK-8067368 linux-arm
+gc/metaspace/TestMetaspaceMemoryPool.java https://github.com/adoptium/aqa-tests/issues/2708 generic-all
+gc/TestMemoryMXBeansAndPoolsPresence.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
+gc/g1/mixedgc/TestOldGenCollectionUsage.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
+gc/concurrentMarkSweep/GuardShrinkWarning.java https://bugs.openjdk.java.net/browse/JDK-8023356 solaris-x64
+runtime/CDSCompressedKPtrs/CDSCompressedKPtrs.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
+runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
+runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
+runtime/SharedArchiveFile/CdsSameObjectAlignment.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
+runtime/SharedArchiveFile/LimitSharedSizes.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
+runtime/SharedArchiveFile/PrintSharedArchiveAndExit.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
+runtime/SharedArchiveFile/SharedArchiveFile.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
+runtime/SharedArchiveFile/SpaceUtilizationCheck.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
+# runtime/7110720/Test7110720.sh https://github.com/adoptium/adoptium/issues/58 aix-all
+runtime/7110720/Test7110720.sh https://github.com/adoptium/aqa-tests/issues/2818 aix-all
+runtime/StackGap/testme.sh https://bugs.openjdk.java.net/browse/JDK-8201536 linux-arm
+runtime/CompressedOops/CompressedClassPointers.java https://bugs.openjdk.org/browse/JDK-8234058 linux-ppc64le,aix-all
+runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/infrastructure/issues/2565 solaris-x64,aix-all
 runtime/NMT/NMTWithCDS.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/memory/ReserveMemory.java https://github.com/adoptium/aqa-tests/issues/4518#issuecomment-1520797671 aix-all
 runtime/SharedArchiveFile/DefaultUseWithClient.java https://github.com/adoptium/aqa-tests/issues/4270 aix-all
-compiler/8209951/TestCipherBlockChainingEncrypt.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
+
 ############################################################################
 
 # jdk_awt
@@ -75,64 +76,63 @@ compiler/8209951/TestCipherBlockChainingEncrypt.java https://github.com/adoptium
 
 # jdk_beans
 
-java/beans/Introspector/Test8027648.java	https://github.com/adoptium/aqa-tests/issues/117	linux-all
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/PropertyEditor/TestColorClass.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/PropertyEditor/TestColorClassJava.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/PropertyEditor/TestColorClassNull.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/PropertyEditor/TestColorClassValue.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/PropertyEditor/TestFontClass.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/PropertyEditor/TestFontClassJava.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/PropertyEditor/TestFontClassNull.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/PropertyEditor/TestFontClassValue.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/117	generic-all
-java/beans/EventHandler/Test6179222.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/EventHandler/Test6788531.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/PropertyChangeSupport/Test4682386.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/PropertyChangeSupport/TestSynchronization.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/Statement/Test4653179.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLDecoder/8028054/TestConstructorFinder.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLDecoder/spec/TestObject.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/Test4631471.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/Test4652928.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/Test4822050.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/Test6437265.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/Test6501431.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/Test6570354.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/java_awt_BorderLayout.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/java_awt_CardLayout.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/java_awt_GridBagLayout.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/javax_swing_BoxLayout.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/javax_swing_JButton.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/javax_swing_JLayeredPane.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/javax_swing_JSplitPane.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/javax_swing_OverlayLayout.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/javax_swing_border_TitledBorder.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
-java/beans/XMLEncoder/sun_swing_PrintColorUIResource.java	https://github.com/adoptium/aqa-tests/issues/136	macosx-all
+java/beans/Introspector/Test8027648.java https://github.com/adoptium/aqa-tests/issues/117 linux-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/117 generic-all
+java/beans/EventHandler/Test6179222.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/EventHandler/Test6788531.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/PropertyChangeSupport/TestSynchronization.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/Statement/Test4653179.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLDecoder/8028054/TestConstructorFinder.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLDecoder/spec/TestObject.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/Test4652928.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/Test4822050.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/Test6437265.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/Test6501431.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/Test6570354.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/java_awt_BorderLayout.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
+java/beans/XMLEncoder/sun_swing_PrintColorUIResource.java https://github.com/adoptium/aqa-tests/issues/136 macosx-all
 
 ############################################################################
 
 # jdk_lang
 
-java/lang/ClassLoader/Assert.java	https://github.com/adoptium/aqa-tests/issues/1012	aix-all
-java/lang/Math/HypotTests.java	https://github.com/adoptium/aqa-tests/issues/128	linux-all
-#java/lang/ProcessBuilder/Basic.java same issue with alpine linux, exclude by linux-all for now
-java/lang/ProcessBuilder/Basic.java	https://bugs.openjdk.org/browse/JDK-8282219	aix-all,solaris-x64,linux-all
-java/lang/invoke/MethodHandles/CatchExceptionTest.java  https://bugs.openjdk.java.net/browse/JDK-8146623 linux-s390x,linux-arm
+java/lang/ClassLoader/Assert.java https://github.com/adoptium/aqa-tests/issues/1012 aix-all
+java/lang/Math/HypotTests.java https://github.com/adoptium/aqa-tests/issues/128 linux-all
+# java/lang/ProcessBuilder/Basic.java same issue with alpine linux, exclude by linux-all for now
+java/lang/ProcessBuilder/Basic.java https://bugs.openjdk.org/browse/JDK-8282219 aix-all,solaris-x64,linux-all
+java/lang/invoke/MethodHandles/CatchExceptionTest.java https://bugs.openjdk.java.net/browse/JDK-8146623 linux-s390x,linux-arm
 java/lang/instrument/BootClassPath/BootClassPathTest.sh https://bugs.openjdk.java.net/browse/JDK-8256405 macosx-all
-
 
 ############################################################################
 
 # jdk_management
 
-java/lang/management/MemoryMXBean/LowMemoryTest2.sh	https://github.com/adoptium/aqa-tests/issues/157	linux-all
-com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/55	generic-all
-com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java		https://github.com/adoptium/aqa-tests/issues/134	macosx-all
+java/lang/management/MemoryMXBean/LowMemoryTest2.sh https://github.com/adoptium/aqa-tests/issues/157 linux-all
+com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/55 generic-all
+com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java https://github.com/adoptium/aqa-tests/issues/134 macosx-all
 sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
@@ -150,91 +150,93 @@ javax/management/remote/mandatory/connection/RMIConnector_NPETest.java https://b
 
 # jdk_math
 
-java/math/BigInteger/LargeValueExceptions.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/math/BigInteger/LargeValueExceptions.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 
 ############################################################################
 
 # jdk_net
 
-java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
-java/net/InetAddress/BadDottedIPAddress.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all
+java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
+java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/827 linux-all
 java/net/Inet6Address/B6206527.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
-java/net/Inet6Address/B6558853.java	https://github.com/adoptium/aqa-tests/issues/827	macosx-all
-java/net/InetAddress/CachedUnknownHostName.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all
+java/net/Inet6Address/B6558853.java https://github.com/adoptium/aqa-tests/issues/827 macosx-all
+java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/827 linux-all
 java/net/InetAddress/CheckJNI.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
-java/net/InetAddress/IPv4Formats.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all
-java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
-java/net/MulticastSocket/SetGetNetworkInterfaceTest.java	https://github.com/adoptium/aqa-tests/issues/1011	aix-all
-# java/net/MulticastSocket/SetLoopbackMode.java on aix issue	https://github.com/adoptium/aqa-tests/issues/1011
-java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x,aix-all,macosx-all
-# java/net/MulticastSocket/Test.java https://github.com/adoptium/aqa-tests/issues/1011	aix-all
-java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x,aix-all,macosx-all
+java/net/InetAddress/IPv4Formats.java https://github.com/adoptium/aqa-tests/issues/827 linux-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/net/MulticastSocket/SetGetNetworkInterfaceTest.java https://github.com/adoptium/aqa-tests/issues/1011 aix-all
+# java/net/MulticastSocket/SetLoopbackMode.java on aix issue https://github.com/adoptium/aqa-tests/issues/1011
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all,macosx-all
+# java/net/MulticastSocket/Test.java https://github.com/adoptium/aqa-tests/issues/1011 aix-all
+java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all,macosx-all
 java/net/Socket/LinkLocal.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
-java/net/SocketPermission/Wildcard.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all
-java/net/Socks/SocksV4Test.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all
+java/net/SocketPermission/Wildcard.java https://github.com/adoptium/aqa-tests/issues/827 linux-all
+java/net/Socks/SocksV4Test.java https://github.com/adoptium/aqa-tests/issues/827 linux-all
 java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
-java/net/ipv6tests/UdpTest.java	https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
-java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/1085   macosx-all
-com/sun/net/httpserver/Test1.java	https://github.com/adoptium/aqa-tests/issues/827 linux-ppc64le
-sun/net/www/http/ChunkedOutputStream/checkError.java	https://github.com/adoptium/aqa-tests/issues/1261	windows-all,linux-all
+java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
+java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
+com/sun/net/httpserver/Test1.java https://github.com/adoptium/aqa-tests/issues/827 linux-ppc64le
+sun/net/www/http/ChunkedOutputStream/checkError.java https://github.com/adoptium/aqa-tests/issues/1261 windows-all,linux-all
 sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://bugs.openjdk.java.net/browse/JDK-8155049 solaris-x64
-java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/3292 aix-all
+
 ############################################################################
 
 # jdk_io
 
-java/io/Serializable/concurrentClassDescLookup/ConcurrentClassDescLookup.java	https://github.com/adoptium/aqa-tests/issues/1261 windows-all
+java/io/Serializable/concurrentClassDescLookup/ConcurrentClassDescLookup.java https://github.com/adoptium/aqa-tests/issues/1261 windows-all
 
 ############################################################################
-
 
 # jdk_nio
 
 java/nio/MappedByteBuffer/Truncate.java https://github.com/adoptium/aqa-tests/issues/1052 linux-s390x
-java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java https://bugs.openjdk.java.net/browse/JDK-8211851 aix-all
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java    https://github.com/adoptium/infrastructure/issues/699    linux-s390x
-java/nio/channels/DatagramChannel/Promiscuous.java                  https://github.com/adoptium/infrastructure/issues/699    linux-s390x
-java/nio/channels/SocketChannel/Connect.java	https://github.com/adoptium/aqa-tests/issues/156	macosx-all
-java/nio/channels/ServerSocketChannel/AdaptServerSocket.java	https://github.com/adoptium/aqa-tests/issues/821	windows-all
-java/nio/channels/ServerSocketChannel/Basic.java	https://github.com/adoptium/aqa-tests/issues/821	windows-all
-java/nio/channels/DatagramChannel/SendToUnresolved.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all
-java/nio/channels/Selector/RacyDeregister.java	https://bugs.openjdk.java.net/browse/JDK-8161083	aix-all
-java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/593	aix-all
-sun/nio/ch/TestMaxCachedBufferSize.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-sun/nio/cs/FindDecoderBugs.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
-sun/nio/cs/OLD/TestIBMDB.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/channels/SocketChannel/Connect.java https://github.com/adoptium/aqa-tests/issues/156 macosx-all
+java/nio/channels/ServerSocketChannel/AdaptServerSocket.java https://github.com/adoptium/aqa-tests/issues/821 windows-all
+java/nio/channels/ServerSocketChannel/Basic.java https://github.com/adoptium/aqa-tests/issues/821 windows-all
+java/nio/channels/DatagramChannel/SendToUnresolved.java https://github.com/adoptium/aqa-tests/issues/827 linux-all
+java/nio/channels/Selector/RacyDeregister.java https://bugs.openjdk.java.net/browse/JDK-8161083 aix-all
+java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/593 aix-all
+sun/nio/ch/TestMaxCachedBufferSize.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+sun/nio/cs/FindDecoderBugs.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+sun/nio/cs/OLD/TestIBMDB.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/file/Files/walkFileTree/find.sh https://github.com/adoptium/aqa-tests/issues/3714 linux-all
+
 ############################################################################
 
 # jdk_rmi
 
-java/rmi/activation/Activatable/extLoadedImpl/ext.sh	https://github.com/adoptium/aqa-tests/issues/819 macosx-all
-java/rmi/transport/dgcDeadLock/DGCDeadLock.java	https://github.com/adoptium/aqa-tests/issues/1259	macosx-all
-sun/rmi/runtime/Log/6409194/NoConsoleOutput.java https://bugs.openjdk.java.net/browse/JDK-8156798	generic-all
+java/rmi/activation/Activatable/extLoadedImpl/ext.sh https://github.com/adoptium/aqa-tests/issues/819 macosx-all
+java/rmi/transport/dgcDeadLock/DGCDeadLock.java https://github.com/adoptium/aqa-tests/issues/1259 macosx-all
+sun/rmi/runtime/Log/6409194/NoConsoleOutput.java https://bugs.openjdk.java.net/browse/JDK-8156798 generic-all
 java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java https://bugs.openjdk.java.net/browse/JDK-8005619 solaris-x64
 java/rmi/activation/Activatable/shutdownGracefully/ShutdownGracefully.java https://bugs.openjdk.org/browse/JDK-8085192 linux-all
 java/rmi/activation/Activatable/nonExistentActivatable/NonExistentActivatable.java https://bugs.openjdk.org/browse/JDK-8005436 linux-all
+
 ############################################################################
 
 # jdk_security
 
 com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
-com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
-java/security/KeyPairGenerator/SolarisShortDSA.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
-java/security/MessageDigest/TestDigestIOStream.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
+com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/security/KeyPairGenerator/SolarisShortDSA.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/security/MessageDigest/TestDigestIOStream.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 javax/xml/crypto/dsig/LineFeedOnlyTest.java https://github.com/adoptium/aqa-tests/issues/2356 windows-all
-sun/security/pkcs11/KeyStore/SecretKeysBasic.sh	https://bugs.openjdk.java.net/browse/JDK-8189603	linux-all,macosx-all,windows-all
-sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.com/adoptium/aqa-tests/issues/125	linux-all
-sun/security/pkcs11/Signature/TestDSAKeyLength.java	https://github.com/adoptium/aqa-tests/issues/70 linux-all
-sun/security/pkcs11/ec/TestECDH.java	https://github.com/adoptium/aqa-tests/issues/70	linux-all
-sun/security/pkcs11/ec/TestECDSA.java	https://github.com/adoptium/aqa-tests/issues/70	linux-all
-sun/security/pkcs11/ec/TestECGenSpec.java	https://github.com/adoptium/aqa-tests/issues/70	linux-all
-sun/security/pkcs11/rsa/TestCACerts.java	https://github.com/adoptium/aqa-tests/issues/68	linux-all
-sun/security/pkcs11/tls/TestKeyMaterial.java	https://github.com/adoptium/aqa-tests/issues/71	linux-all
-sun/security/rsa/TestCACerts.java	https://github.com/adoptium/aqa-tests/issues/68	generic-all
+sun/security/pkcs11/KeyStore/SecretKeysBasic.sh https://bugs.openjdk.java.net/browse/JDK-8189603 linux-all,macosx-all,windows-all
+sun/security/pkcs11/Secmod/AddTrustedCert.java https://github.com/adoptium/aqa-tests/issues/125 linux-all
+sun/security/pkcs11/Signature/TestDSAKeyLength.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
+sun/security/pkcs11/ec/TestECDH.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
+sun/security/pkcs11/ec/TestECDSA.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
+sun/security/pkcs11/ec/TestECGenSpec.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
+sun/security/pkcs11/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/issues/68 linux-all
+sun/security/pkcs11/tls/TestKeyMaterial.java https://github.com/adoptium/aqa-tests/issues/71 linux-all
+sun/security/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/issues/68 generic-all
 com/sun/crypto/provider/Mac/MacClone.java https://bugs.openjdk.java.net/browse/JDK-7087021 solaris-all
 javax/net/ssl/ServerName/BestEffortOnLazyConnected.java https://bugs.openjdk.org/browse/JDK-8155049 solaris-x64
 javax/net/ssl/Stapling/HttpsUrlConnClient.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
@@ -244,17 +246,16 @@ javax/net/ssl/TLSCommon/TestSessionLocalPrincipal.java https://github.com/adopti
 sun/security/pkcs11/KeyStore/ClientAuth.sh https://bugs.openjdk.org/browse/JDK-7132249 solaris-all
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java https://bugs.openjdk.org/browse/JDK-8042583 solaris-x64
 sun/security/pkcs11/fips/ClientJSSEServerJSSE.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
-sun/security/pkcs11/fips/TestTLS12.java https://bugs.openjdk.org/browse/JDK-8029661 linux-ppc64le
 
 ############################################################################
 
 # jdk_security3
 
-sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
-sun/security/pkcs11/Secmod/TestNssDbSqlite.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
-sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
-sun/security/tools/jarsigner/diffend.sh	https://github.com/adoptium/infrastructure/issues/2623	linux-all
-sun/security/tools/jarsigner/emptymanifest.sh	https://github.com/adoptium/infrastructure/issues/2623	linux-all
+sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
+sun/security/pkcs11/Secmod/TestNssDbSqlite.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
+sun/security/tools/jarsigner/diffend.sh https://github.com/adoptium/infrastructure/issues/2623 linux-all
+sun/security/tools/jarsigner/emptymanifest.sh https://github.com/adoptium/infrastructure/issues/2623 linux-all
 sun/security/rsa/SignatureTest.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 sun/security/tools/keytool/WeakAlg.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 sun/security/tools/keytool/standard.sh https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
@@ -275,7 +276,8 @@ sun/security/krb5/auto/Unreachable.java https://github.com/adoptium/aqa-tests/is
 ############################################################################
 
 # jdk_sound
-javax/sound/midi/Devices/InitializationHang.java	https://github.com/adoptium/aqa-tests/issues/136	generic-all
+
+javax/sound/midi/Devices/InitializationHang.java https://github.com/adoptium/aqa-tests/issues/136 generic-all
 
 ############################################################################
 
@@ -300,6 +302,7 @@ sun/text/IntHashtable/Bug4170614Test.sh https://bugs.openjdk.java.net/browse/JDK
 ############################################################################
 
 # jdk_tools
+
 demo/jvmti/gctest/Gctest.java https://github.com/adoptium/aqa-tests/issues/2655 generic-all
 demo/jvmti/heapTracker/HeapTrackerTest.java https://github.com/adoptium/aqa-tests/issues/2655 generic-all
 demo/jvmti/heapViewer/HeapViewerTest.java https://github.com/adoptium/aqa-tests/issues/2655 generic-all
@@ -310,70 +313,72 @@ demo/jvmti/waiters/WaitersTest.java https://github.com/adoptium/aqa-tests/issues
 demo/zipfs/ZipFSOutputStreamTest.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 sun/tools/clhsdb/Basic.sh https://github.com/adoptium/aqa-tests/issues/2665 generic-all
 sun/tools/hsdb/Basic.sh https://github.com/adoptium/aqa-tests/issues/2665 generic-all
-#Following test cases with solaris are tracked by https://github.com/adoptium/aqa-tests/issues/3618 solaris-x64
-sun/tools/jstatd/TestJstatdDefaults.java	https://github.com/adoptium/aqa-tests/issues/115	linux-all,solaris-x64
-sun/tools/jstatd/TestJstatdExternalRegistry.java	https://bugs.openjdk.java.net/browse/JDK-8081569	linux-all,solaris-x64
-sun/tools/jstatd/TestJstatdPort.java	https://bugs.openjdk.java.net/browse/JDK-8081569	linux-all,solaris-x64
-sun/tools/jstatd/TestJstatdPortAndServer.java	https://bugs.openjdk.java.net/browse/JDK-8081569	linux-all,solaris-x64
-sun/tools/jstatd/TestJstatdServer.java	https://github.com/adoptium/aqa-tests/issues/115	linux-all,solaris-x64
+# Following test cases with solaris are tracked by https://github.com/adoptium/aqa-tests/issues/3618 solaris-x64
+sun/tools/jstatd/TestJstatdDefaults.java https://github.com/adoptium/aqa-tests/issues/115 linux-all,solaris-x64
+sun/tools/jstatd/TestJstatdExternalRegistry.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all,solaris-x64
+sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all,solaris-x64
+sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all,solaris-x64
+sun/tools/jstatd/TestJstatdServer.java https://github.com/adoptium/aqa-tests/issues/115 linux-all,solaris-x64
 sun/tools/native2ascii/Native2AsciiTests.sh https://github.com/adoptium/aqa-tests/issues/2667 windows-all
 sun/misc/Version/Version.java https://bugs.openjdk.java.net/browse/JDK-8244548 generic-all
-com/sun/tools/attach/StartManagementAgent.java	https://github.com/adoptium/aqa-tests/issues/115	generic-all
-tools/pack200/CommandLineTests.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
-tools/pack200/CommandLineTests.java	https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x
+com/sun/tools/attach/StartManagementAgent.java https://github.com/adoptium/aqa-tests/issues/115 generic-all
+# tools/pack200/CommandLineTests.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+tools/pack200/CommandLineTests.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,solaris-sparcv9
 tools/pack200/Pack200Test.java https://github.com/adoptium/aqa-tests/issues/2657 generic-all
 tools/launcher/RunpathTest.java https://bugs.openjdk.java.net/browse/JDK-8286118 linux-arm
 sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java https://github.com/adoptium/infrastructure/issues/2565 solaris-x64
 sun/jvmstat/monitor/MonitoredVm/CR6672135.java https://github.com/adoptium/aqa-tests/issues/3691 windows-x64
 
 ###############################################################################
+
 # jdk_jdi
 
-com/sun/jdi/JdbMethodExitTest.sh                https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/Redefine-g.sh                       https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/AllLineLocations.java               https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/EarlyReturnTest.java                https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/MethodExitReturnValuesTest.java     https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/NativeInstanceFilter.java           https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/PopAndStepTest.java                 https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/PopAsynchronousTest.java            https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/PopSynchronousTest.java             https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/RedefineCrossStart.java             https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/redefineMethod/RedefineTest.java    https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
-com/sun/jdi/PrivateTransportTest.sh             https://github.com/adoptium/aqa-tests/issues/2154 windows-all
+com/sun/jdi/JdbMethodExitTest.sh https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/Redefine-g.sh https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/AllLineLocations.java https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/EarlyReturnTest.java https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/MethodExitReturnValuesTest.java https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/NativeInstanceFilter.java https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/PopAndStepTest.java https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/PopAsynchronousTest.java https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/PopSynchronousTest.java https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/RedefineCrossStart.java https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/redefineMethod/RedefineTest.java https://github.com/adoptium/aqa-tests/issues/2408 linux-s390x
+com/sun/jdi/PrivateTransportTest.sh https://github.com/adoptium/aqa-tests/issues/2154 windows-all
+
 ############################################################################
 
 # jdk_util
 
-java/util/Arrays/TimSortStackSize2.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/util/Arrays/TimSortStackSize2.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/util/Calendar/CalendarRegression.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
 java/util/Calendar/JapanEraNameCompatTest.java https://bugs.openjdk.java.net/browse/JDK-8218781 generic-all
-java/util/Locale/LocaleProviders.sh	https://github.com/adoptium/aqa-tests/issues/1261	windows-all
-java/util/Random/RandomTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/ResourceBundle/Control/Bug6530694.java	https://github.com/adoptium/aqa-tests/issues/137	macosx-all
-java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/util/Locale/LocaleProviders.sh https://github.com/adoptium/aqa-tests/issues/1261 windows-all
+java/util/Random/RandomTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/util/ResourceBundle/Control/Bug6530694.java https://github.com/adoptium/aqa-tests/issues/137 macosx-all
+java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/util/TimeZone/HongKong.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/adoptium/aqa-tests/issues/1259	macosx-all
-java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1259	macosx-all
-java/util/stream/boottest/java/util/stream/SpinedBufferTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/ExplodeOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/FlatMapOpTest.java https://bugs.openjdk.java.net/browse/JDK-8173112    linux-s390x,linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/InfiniteStreamWithLimitOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/SequentialOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/SliceOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/StreamSpliteratorTest.java	https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/StreamBuilderTest.java https://bugs.openjdk.java.net/browse/JDK-8173112    linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/TabulatorsTest.java    https://bugs.openjdk.java.net/browse/JDK-8173112    linux-s390x,linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/TeeOpTest.java         https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/ForEachOpTest.java     https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/ConcatOpTest.java      https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/DistinctOpTest.java    https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/SortedOpTest.java      https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/StreamLinkTest.java    https://github.com/adoptium/aqa-tests/issues/2263   linux-arm
-sun/util/calendar/zi/TestZoneInfo310.java		https://github.com/eclipse-openj9/openj9/issues/1131	generic-all
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/adoptium/aqa-tests/issues/1259 macosx-all
+java/util/logging/TestLoggerWeakRefLeak.java https://github.com/adoptium/aqa-tests/issues/1259 macosx-all
+java/util/stream/boottest/java/util/stream/SpinedBufferTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/ExplodeOpTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/FlatMapOpTest.java https://bugs.openjdk.java.net/browse/JDK-8173112 linux-s390x,linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/InfiniteStreamWithLimitOpTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/SequentialOpTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/SliceOpTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/StreamSpliteratorTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/StreamBuilderTest.java https://bugs.openjdk.java.net/browse/JDK-8173112 linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/TabulatorsTest.java https://bugs.openjdk.java.net/browse/JDK-8173112 linux-s390x,linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/TeeOpTest.java https://github.com/adoptium/aqa-tests/issues/2263 linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/ForEachOpTest.java https://github.com/adoptium/aqa-tests/issues/2263 linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/ConcatOpTest.java https://github.com/adoptium/aqa-tests/issues/2263 linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/DistinctOpTest.java https://github.com/adoptium/aqa-tests/issues/2263 linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/SortedOpTest.java https://github.com/adoptium/aqa-tests/issues/2263 linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/StreamLinkTest.java https://github.com/adoptium/aqa-tests/issues/2263 linux-arm
+sun/util/calendar/zi/TestZoneInfo310.java https://github.com/eclipse-openj9/openj9/issues/1131 generic-all
 java/util/Locale/Bug8040211.java https://github.com/adoptium/aqa-tests/issues/2420 linux-aarch64
-java/util/stream/test/org/openjdk/tests/java/util/stream/MapOpTest.java https://github.com/adoptium/aqa-tests/issues/2754#issuecomment-883704362   linux-arm
+java/util/stream/test/org/openjdk/tests/java/util/stream/MapOpTest.java https://github.com/adoptium/aqa-tests/issues/2754#issuecomment-883704362 linux-arm
 
 ############################################################################
 
@@ -385,13 +390,14 @@ java/util/stream/test/org/openjdk/tests/java/util/stream/MapOpTest.java https://
 
 com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/2351 generic-all
 com/sun/jndi/ldap/LdapDnsProviderTest.java https://github.com/adoptium/aqa-tests/issues/2355 generic-all
-jdk/lambda/vm/InterfaceAccessFlagsTest.java	https://github.com/adoptium/aqa-tests/issues/126	linux-all
+jdk/lambda/vm/InterfaceAccessFlagsTest.java https://github.com/adoptium/aqa-tests/issues/126 linux-all
 com/sun/jndi/ldap/RemoveNamingListenerTest.java https://bugs.openjdk.java.net/browse/JDK-8202117 aix-all
 
 ############################################################################
 
 # jdk_imageio
-#javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
+
+# javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github.com/adoptium/aqa-tests/issues/2321 aix-all,solaris-all
 
 ############################################################################
@@ -401,7 +407,7 @@ javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github
 jdk/jfr/api/flightrecorder/TestGetEventTypes.java https://bugs.openjdk.org/browse/JDK-8309729 solaris-sparcv9
 jdk/jfr/event/sampling/TestNative.java https://github.com/adoptium/aqa-tests/issues/2754#issuecomment-882618581 generic-all
 jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java https://github.com/adoptium/aqa-tests/issues/2766 generic-all
-#linux-arm https://github.com/adoptium/aqa-tests/issues/3301
+# jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/2985 generic-all
 jdk/jfr/event/io/TestInstrumentation.java https://bugs.openjdk.java.net/browse/JDK-8202142 generic-all
 jdk/jfr/event/compiler/TestCompilerPhase.java https://github.com/adoptium/aqa-tests/issues/3046 generic-all
@@ -413,7 +419,7 @@ jdk/jfr/event/gc/detailed/TestEvacuationInfoEvent.java https://github.com/adopti
 jdk/jfr/event/gc/detailed/TestG1HeapRegionTypeChangeEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/detailed/TestG1MMUEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/detailed/TestPromotionEventWithG1.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
-#jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventG1.java https://github.com/adoptium/aqa-tests/issues/3254 solaris-sparcv9
+# jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventG1.java https://github.com/adoptium/aqa-tests/issues/3254 solaris-sparcv9
 jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventG1.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm,solaris-sparcv9
 jdk/jfr/event/gc/objectcount/TestObjectCountAfterGCEventWithG1ConcurrentMark.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/stacktrace/TestG1HumongousAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
@@ -443,4 +449,3 @@ jdk/jfr/jcmd/TestJcmdStopReadOnlyFile.java https://github.com/adoptium/aqa-tests
 jfr/api/consumer/TestRecordedFrame.java https://bugs.openjdk.org/browse/JDK-8247203 linux-aarch64,linux-ppc64le
 jdk/jfr/api/consumer/TestRecordedFrame.java https://bugs.openjdk.java.net/browse/JDK-8247203 linux-arm,linux-ppc64le
 jdk/jfr/event/compiler/TestCompilerInlining.java https://github.com/adoptium/aqa-tests/issues/3277 windows-all
-


### PR DESCRIPTION
Commenting out duplicate tests from the exclude files, ensuring the platforms are appended to their unexcluded duplicates, and tidying the targets to help avoid this problem in the future.

See here for details:

https://github.com/adoptium/aqa-tests/issues/4650