### PR TITLE
Reenable PingPerf on zlinux, alinux and plinux

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -234,12 +234,8 @@ timestamps{
             def target = "testList TESTLIST=disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry,disabled.criu-portable-checkpoint_test,disabled.criu-ubi-portable-checkpoint_test"
 
             // exclude criu-portable-checkpoint_test on plinux due to github_ibm/runtimes/backlog/issues/1099
-            // exclude criu_pingPerf_testCreateRestoreImageAndPushToRegistry on plinux, zlinux and alinux due to https://github.com/adoptium/aqa-tests/issues/4632
             if (params.PLATFORM == "ppc64le_linux") {
                 target = target.minus("disabled.criu-portable-checkpoint_test,")
-                target = target.minus("disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry,")
-            } else if (params.PLATFORM == "s390x_linux" || params.PLATFORM == "aarch64_linux") {
-                target = target.minus("disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry,")
             }
 
             echo "Trigger ${imageUploadJobName} job ..."

--- a/external/criu/pingPerf.sh
+++ b/external/criu/pingPerf.sh
@@ -83,8 +83,6 @@ prepare() {
     git clone https://github.com/OpenLiberty/ci.docker.git
     (
         cd ci.docker || exit
-        openLibertyBranch="instanton"
-        git checkout $openLibertyBranch
         if [ "$OPENLIBERTY_SHA" != "" ]
         then
             git checkout $OPENLIBERTY_SHA

--- a/external/criu/playlist.xml
+++ b/external/criu/playlist.xml
@@ -20,13 +20,6 @@
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/4632</comment>
-				<platform>(?:s390x_linux.*|aarch64_linux.*|ppc64le_linux.*)</platform>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<features>
 			<feature>CRIU:required</feature>
 		</features>
@@ -43,13 +36,6 @@
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/4632</comment>
-				<platform>(?:s390x_linux.*|aarch64_linux.*|ppc64le_linux.*)</platform>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<features>
 			<feature>CRIU:required</feature>
 		</features>
@@ -87,13 +73,6 @@
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/4632</comment>
-				<platform>(?:s390x_linux.*|aarch64_linux.*|ppc64le_linux.*)</platform>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<features>
 			<feature>CRIU:required</feature>
 		</features>
@@ -110,13 +89,6 @@
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/4632</comment>
-				<platform>(?:s390x_linux.*|aarch64_linux.*|ppc64le_linux.*)</platform>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<features>
 			<feature>CRIU:required</feature>
 		</features>


### PR DESCRIPTION
- switch PingPerf to use `main` branch (from `instanton` branch)

related: https://github.com/adoptium/aqa-tests/issues/4632 and https://github.com/OpenLiberty/ci.docker/pull/412