### PR TITLE
[JDK21] Disable failing JVMTI tests until they are fixed

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -549,6 +549,13 @@ serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://git
 serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/adoptium/aqa-tests/issues/1297 aix-all
+serviceability/jvmti/GetLocalVariable/GetSetLocalUnsuspended.java https://github.com/eclipse-openj9/openj9/issues/17711 generic-all
+serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17712 generic-all
+serviceability/jvmti/vthread/ForceEarlyReturnTest/ForceEarlyReturnTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17713 generic-all
+serviceability/jvmti/vthread/PopFrameTest/PopFrameTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17715 generic-all
+serviceability/jvmti/vthread/PopFrameTest/PopFrameTest.java#platform https://github.com/eclipse-openj9/openj9/issues/17716 generic-all
+serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17717 generic-all
+serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java#platform https://github.com/eclipse-openj9/openj9/issues/17718 generic-all
 
 # jdk_container
 jdk/internal/platform/docker/TestDockerCpuMetrics.java https://github.com/eclipse-openj9/openj9/issues/16462 generic-all


### PR DESCRIPTION
Uber issue: eclipse-openj9/openj9#17671

Issues for individual failures:
- eclipse-openj9/openj9#17711
- eclipse-openj9/openj9#17712
- eclipse-openj9/openj9#17713
- eclipse-openj9/openj9#17715
- eclipse-openj9/openj9#17716
- eclipse-openj9/openj9#17717
- eclipse-openj9/openj9#17718