### PR TITLE
Fix another incorrect detection of Solaris in JavatestUtil.java

### DIFF
--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -802,7 +802,7 @@ public class JavatestUtil {
 			if (spec.contains("linux")) {
 				xjcCmd = "bash "+xjcCmd;
 				jxcCmd = "bash "+jxcCmd;
-			} else if (spec.contains("solaris")) {
+			} else if (spec.contains("sunos")) {
 				xjcCmd = "ksh "+xjcCmd;
 				jxcCmd = "ksh "+jxcCmd;
 			}


### PR DESCRIPTION
This fixes a symptom where the execution of `xjc.sh` gives a syntax error as it snot compatible with the bourne shell.