### PR TITLE
Update hotspot_* targets to run for all JDK versions

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -255,10 +255,6 @@
 	${VENDOR_PROBLEM_LIST_FILE} \
 	$(Q)$(JTREG_HOTSPOT_TEST_DIR):hotspot_compiler$(Q); \
 	$(TEST_STATUS)</command>
-		<versions>
-			<version>8</version>
-			<version>9</version>
-		</versions>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -286,10 +282,6 @@
 	${VENDOR_PROBLEM_LIST_FILE} \
 	$(Q)$(JTREG_HOTSPOT_TEST_DIR):hotspot_gc$(Q); \
 	$(TEST_STATUS)</command>
-		<versions>
-			<version>8</version>
-			<version>9</version>
-		</versions>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -346,10 +338,6 @@
 	${VENDOR_PROBLEM_LIST_FILE} \
 	$(Q)$(JTREG_HOTSPOT_TEST_DIR):hotspot_serviceability$(Q); \
 	$(TEST_STATUS)</command>
-		<versions>
-			<version>8</version>
-			<version>9</version>
-		</versions>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -318,10 +318,6 @@
 	${VENDOR_PROBLEM_LIST_FILE} \
 	$(Q)$(JTREG_HOTSPOT_TEST_DIR):hotspot_runtime$(Q); \
 	$(TEST_STATUS)</command>
-		<versions>
-			<version>8</version>
-			<version>9</version>
-		</versions>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Enable hotspot_gc, hotspot_serviceability, hotspot_runtime and hotspot_compiler targets for all JDK versions (previously only enabled for JDK8 and JDK9)