### PR TITLE
Update versions for jck-compiler-api-java_rmi

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -40,10 +40,6 @@
 		<groups>
 			<group>jck</group>
 		</groups>
-		<versions>
-			<version>8</version>
-			<version>11</version>
-		</versions>
 	</test>
 	<test>
 		<testCaseName>jck-compiler-api-javax_annotation</testCaseName>


### PR DESCRIPTION
- remove the versions tag as it should run against all versions