### PR TITLE
[JDK21] Enable JVMTI tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -547,13 +547,8 @@ serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://git
 serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/adoptium/aqa-tests/issues/1297 aix-all
-serviceability/jvmti/GetLocalVariable/GetSetLocalUnsuspended.java https://github.com/eclipse-openj9/openj9/issues/17711 generic-all
 serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17712 generic-all
 serviceability/jvmti/vthread/ForceEarlyReturnTest/ForceEarlyReturnTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17713 generic-all
-serviceability/jvmti/vthread/PopFrameTest/PopFrameTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17715 generic-all
-serviceability/jvmti/vthread/PopFrameTest/PopFrameTest.java#platform https://github.com/eclipse-openj9/openj9/issues/17716 generic-all
-serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17717 generic-all
-serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java#platform https://github.com/eclipse-openj9/openj9/issues/17718 generic-all
 
 # jdk_container
 jdk/internal/platform/docker/TestDockerCpuMetrics.java https://github.com/eclipse-openj9/openj9/issues/16462 generic-all


### PR DESCRIPTION
- StopThreadTest is fixed by eclipse-openj9/openj9#17806.
- PopFrameTest is fixed by eclipse-openj9/openj9#17809.
- GetSetLocalUnsuspended is fixed by eclipse-openj9/openj9#17829.

Closes eclipse-openj9/openj9#17711
Closes eclipse-openj9/openj9#17715
Closes eclipse-openj9/openj9#17716
Closes eclipse-openj9/openj9#17717
Closes eclipse-openj9/openj9#17718