### PR TITLE
[JDK21] Enable JVMTI framepop02.java#id1

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -535,10 +535,9 @@ serviceability/jvmti/SuspendWithObjectMonitorEnter/SuspendWithObjectMonitorEnter
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java https://github.com/eclipse-openj9/openj9/issues/15994 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
-serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
-serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/16346 generic-all
+serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/17490 generic-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16689 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
eclipse-openj9/openj9#17125 fixes framepop02.java#id1, and it was
embedded in eclipse-openj9/openj9#17514 and merged.

Now, the MethodExitTest failure is being tracked through
eclipse-openj9/openj9#17490.

Closes eclipse-openj9/openj9#16346