### PR TITLE
Restore UncaughtExceptionsTest for OpenJ9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -68,7 +68,6 @@ java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/
 java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/Thread/UncaughtExceptions.sh	https://github.com/eclipse-openj9/openj9/issues/6690	generic-all
-java/lang/Thread/UncaughtExceptionsTest.java	https://github.com/eclipse-openj9/openj9/issues/11930	generic-all
 java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse-openj9/openj9/issues/6691	generic-all
 java/lang/Throwable/SuppressedExceptions.java	https://github.com/eclipse-openj9/openj9/issues/6692	generic-all
 java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -112,7 +112,6 @@ java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://githu
 java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issues/17638 windows-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
-java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/11930 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -112,7 +112,6 @@ java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://githu
 java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issues/17638 windows-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
-java/lang/Thread/UncaughtExceptionsTest.java https://github.com/eclipse-openj9/openj9/issues/11930 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all


### PR DESCRIPTION
Remove the OpenJ9 exclude for
java/lang/Thread/UncaughtExceptionsTest.java now the problems have been resolved.

Issue https://github.com/eclipse-openj9/openj9/issues/11930

Tested jdk17, 21 via grinders, which passed.
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/2664/