### PR TITLE
[Jtreg/FFI] Enable the test suites in JDK21

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -129,8 +129,6 @@ jdk/internal/vm/Continuation/Scoped.java https://github.com/eclipse-openj9/openj
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/17399 generic-all
-
 ############################################################################
 
 # jdk_internal
@@ -485,9 +483,11 @@ java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
+java/foreign/TestByteBuffer.java https://github.com/eclipse-openj9/openj9/issues/17870 aix-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
+java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/17953 linux-ppc64le
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 ############################################################################

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1518,8 +1518,8 @@
 		<testCaseName>jdk_foreign</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/17399</comment>
-				<version>21+</version>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/17872</comment>
+				<version>22+</version>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -1548,45 +1548,6 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-	</test>
-	<test>
-		<testCaseName>jdk_foreign_native</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/11760</comment>
-				<version>16+</version>
-				<impl>openj9</impl>
-			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
-				<impl>ibm</impl>
-			</disable>
-		</disables>
-		<variations>
-			<variation>Mode150</variation>
-			<variation>Mode650</variation>
-			<variation>Mode1000</variation>
-		</variations>
-		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
-	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(ADD_MODULES) $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
-	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
-	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
-	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
-	$(Q)$(OPENJDK_DIR)$(D)test$(D)jdk$(D)java$(D)foreign$(D)TestNative.java$(Q); \
-	$(TEST_STATUS)</command>
-		<versions>
-			<version>14+</version>
-		</versions>
-		<levels>
-			<level>sanity</level>
-		</levels>
-		<types>
-			<type>native</type>
-		</types>
-		<groups>
-			<group>openjdk</group>
-		</groups>
-		<platformRequirements>bits.64,^arch.ppc,^arch.390,^arch.riscv,^arch.loongarch,^os.zos,^os.sunos</platformRequirements>
 	</test>
 	<test>
 		<testCaseName>jdk_instrument</testCaseName>


### PR DESCRIPTION
The changes enable all FFI test suites except
a few excluded tests in JDK21 given everything
specific to JEP442 (except the union support)
has been implemented, as specified at
https://github.com/eclipse-openj9/openj9/issues/16951.

Fixes: #eclipse-openj9/openj9/issues/17399

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>