### PR TITLE
Temporary exclude quarkus_quickstarts_test due to openj9 docker setting

### DIFF
--- a/external/quarkus_quickstarts/playlist.xml
+++ b/external/quarkus_quickstarts/playlist.xml
@@ -26,8 +26,7 @@
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
-				<comment>github_ibm/runtimes/backlog/issues/776</comment>
-				<platform>.*(aarch64_linux|s390).*</platform>
+				<comment>github_ibm/runtimes/backlog/issues/776 1169</comment>
 				<impl>openj9</impl>
 			</disable>
 		</disables>		


### PR DESCRIPTION
- Temporary exclude quarkus_quickstarts_test due to openj9 docker setting
- Related Issue: runtimes/backlog 1169