### PR TITLE
Set failIfNotNew to false

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -816,7 +816,7 @@ def post(output_name) {
 			xunit (
 					tools: [Custom(customXSL: "$WORKSPACE/aqa-tests/jck/xUnit.xsl",
 							deleteOutputFiles: true,
-							failIfNotNew: true,
+							failIfNotNew: false,
 							pattern: "**/TKG/output_*/**/report.xml",
 							skipNoTestFiles: true,
 							stopProcessingIfError: true)]


### PR DESCRIPTION
If the test run and the plugin run are more than 3 seconds apart, the plugin will throw NoNewTestReportException. Therefore, set failIfNotNew to false

resolves: backlog/issues/1187