### PR TITLE
JDK21 add jdk_tools_openj9_DynamicLoadWarningTest

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1439,6 +1439,34 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>jdk_tools_openj9_DynamicLoadWarningTest</testCaseName>
+		<variations>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	$(Q)$(JTREG_JDK_TEST_DIR)$(D)com/sun/tools/attach/warnings/DynamicLoadWarningTest.java$(Q); \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>21+</version>
+		</versions>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_jdi_jdk8</testCaseName>
 		<disables>
 			<disable>


### PR DESCRIPTION
`JDK21` add `jdk_tools_openj9_DynamicLoadWarningTest`

This is to run `com/sun/tools/attach/warnings/DynamicLoadWarningTest.java` test for `OpenJ9/IBM` `JDK21+`.

Instead of enabling`jdk_tools` and disabling other tests except `com/sun/tools/attach/warnings/DynamicLoadWarningTest.java`, this PR adds `jdk_tools_openj9_DynamicLoadWarningTest` to run this test only.

[An internal grinder](https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/34558/console)


Related to
* https://github.com/eclipse-openj9/openj9/issues/17500

Signed-off-by: Jason Feng <fengj@ca.ibm.com>