### PR TITLE
Exclude failing tests using vm.continuations flag

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -112,6 +112,8 @@ java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://githu
 java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issues/17638 windows-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
+java/lang/Thread/virtual/CarrierThreadWaits.java#id0 https://github.com/eclipse-openj9/openj9/issues/18051 generic-all
+java/lang/Thread/virtual/GetStackTrace.java https://github.com/eclipse-openj9/openj9/issues/18052 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
@@ -546,8 +548,9 @@ serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://gith
 serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+serviceability/jvmti/vthread/ThreadStateTest/ThreadStateTest.java https://github.com/eclipse-openj9/openj9/issues/18054 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/adoptium/aqa-tests/issues/1297 aix-all
-serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17712 generic-all
+serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java https://github.com/eclipse-openj9/openj9/issues/17712 generic-all
 serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 # jdk_container

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -112,6 +112,8 @@ java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://githu
 java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issues/17638 windows-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
+java/lang/Thread/virtual/CarrierThreadWaits.java#id0 https://github.com/eclipse-openj9/openj9/issues/18051 generic-all
+java/lang/Thread/virtual/GetStackTrace.java https://github.com/eclipse-openj9/openj9/issues/18052 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
@@ -540,6 +542,7 @@ serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java https://githu
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/eclipse-openj9/openj9/issues/17490 generic-all
+serviceability/jvmti/vthread/ThreadStateTest/ThreadStateTest.java https://github.com/eclipse-openj9/openj9/issues/18054 generic-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16689 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -547,7 +550,7 @@ serviceability/jvmti/thread/GetFrameCount/framecnt01/framecnt01.java https://git
 serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/adoptium/aqa-tests/issues/1297 aix-all
-serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17712 generic-all
+serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java https://github.com/eclipse-openj9/openj9/issues/17712 generic-all
 serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 # jdk_container


### PR DESCRIPTION
java/lang/Thread/virtual/CarrierThreadWaits.java#id0 eclipse-openj9/openj9#18051 java/lang/Thread/virtual/GetStackTrace.java eclipse-openj9/openj9#18052 serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#default eclipse-openj9/openj9#18053 serviceability/jvmti/vthread/ThreadStateTest/ThreadStateTest.java eclipse-openj9/openj9#18054