### PR TITLE
[JDK22] Permanently disbale RedefinePreviousVersions

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -548,6 +548,7 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https:/
 serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/adoptium/aqa-tests/issues/1297 aix-all
 serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/17712 generic-all
+serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 # jdk_container
 jdk/internal/platform/docker/TestDockerCpuMetrics.java https://github.com/eclipse-openj9/openj9/issues/16462 generic-all


### PR DESCRIPTION
RedefinePreviousVersions tests Hotspot specific cmd line options which
are not supported in OpenJ9:

```
-Xlog:redefine+class+iklass+add=trace,redefine+class+iklass+purge=trace
```

RedefinePreviousVersions is permanently disabled for OpenJ9 since the
above options are not supported by OpenJ9.

Related:
- https://github.com/eclipse-openj9/openj9/issues/18046
- https://github.com/eclipse-openj9/openj9/issues/18038
- https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/34
- https://github.com/adoptium/aqa-tests/pull/4736

Signed-off-by: Babneet Singh [sbabneet@ca.ibm.com](mailto:sbabneet@ca.ibm.com)