### PR TITLE
Enable CRIU plinux portable testing on p9 and p10

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -195,7 +195,6 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z15"]
                     ],
             'ppc64le_linux' : [
-                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p8"],
                         // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p9"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p10"],
                         // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p8"],
@@ -220,8 +219,8 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z15"]
                     ],
             'ppc64le_linux' : [
-                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8"],
-                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
+                        ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.ppc64le.p10"],
+                        ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.ppc64le.p9"]
                     ]
         ]
         if (params.PLATFORM && imageUploadMap[params.PLATFORM] != null && imagePullMap[params.PLATFORM] != null) {
@@ -233,9 +232,11 @@ timestamps{
             def imageUploadJobs = [:]
             def target = "testList TESTLIST=disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi8,disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi9,disabled.criu-portable-checkpoint_test,disabled.criu-ubi-portable-checkpoint_test"
 
-            // exclude criu-portable-checkpoint_test on plinux due to github_ibm/runtimes/backlog/issues/1099
             if (params.PLATFORM == "ppc64le_linux") {
+                // exclude criu-portable-checkpoint_test on plinux due to github_ibm/runtimes/backlog/issues/1099
                 target = target.minus("disabled.criu-portable-checkpoint_test,")
+                // exclude criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi8 on plinux due to github_ibm/runtimes/backlog/issues/1207
+                target = target.minus("disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi8,")
             }
 
             echo "Trigger ${imageUploadJobName} job ..."

--- a/external/criu/pingPerf.sh
+++ b/external/criu/pingPerf.sh
@@ -243,15 +243,25 @@ getImageNameList() {
         comboList=CRIU_COMBO_LIST_$platValue
         if [[ "$PLATFORM" =~ "linux_390-64" ]]; then
             micro_architecture=$(echo $node_label_micro_architecture | sed "s/hw.arch.s390x.//")
-            comboList=$comboList_$micro_architecture
+            comboList="${comboList}_${micro_architecture}"
+        elif [[ "$PLATFORM" =~ "linux_ppc-64" ]]; then
+            micro_architecture=$(echo $node_label_micro_architecture | sed "s/hw.arch.ppc64le.//")
+            comboList="${comboList}_${micro_architecture}"
         fi
 
         image_os_combo_list="${!comboList}"
-        echo "${comboList}: ${image_os_combo_list}"
+        echo "comboList: ${comboList}"
+        echo "image_os_combo_list: ${image_os_combo_list}"
         for image_os_combo in ${image_os_combo_list[@]}
         do
             restore_docker_image_name_list+=("${DOCKER_REGISTRY_URL}/${docker_image_source_job_name}/pingperf_${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${docker_os_version}-${PLATFORM}-${image_os_combo}:${build_number}")
         done
+        if [[ -z "$restore_docker_image_name_list" ]]; then
+            echo "Error: restore_docker_image_name_list is empty."
+            exit 1
+        else
+            echo "restore_docker_image_name_list: $restore_docker_image_name_list"
+        fi
     fi
 }
 

--- a/external/criu/playlist.xml
+++ b/external/criu/playlist.xml
@@ -16,6 +16,12 @@
 	<include>../criuSettings.mk</include>
 	<test>
 		<testCaseName>criu_pingPerf_testCreateImageAndUnprivilegedRestore_ubi8</testCaseName>
+		<disables>
+			<disable>
+				<comment>runtimes_backlog_issues_1207</comment>
+				<platform>ppc64le_linux</platform>
+			</disable>
+		</disables>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndUnprivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_JDK_HOME) ${JDK_VERSION} "ubi" "8"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
@@ -48,6 +54,12 @@
 	</test>
 	<test>
 		<testCaseName>criu_pingPerf_testCreateImageAndPrivilegedRestore_ubi8</testCaseName>
+		<disables>
+			<disable>
+				<comment>runtimes_backlog_issues_1207</comment>
+				<platform>ppc64le_linux</platform>
+			</disable>
+		</disables>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndPrivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_JDK_HOME) ${JDK_VERSION} "ubi" "8"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
@@ -122,6 +134,12 @@
 	</test>
 	<test>
 		<testCaseName>criu_pingPerf_pullImageUnprivilegedRestore_ubi8</testCaseName>
+		<disables>
+			<disable>
+				<comment>runtimes_backlog_issues_1207</comment>
+				<platform>ppc64le_linux</platform>
+			</disable>
+		</disables>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh pullImageUnprivilegedRestore "ubi" "8" "$(DOCKER_REGISTRY_DIR)"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
@@ -154,6 +172,12 @@
 	</test>
 	<test>
 		<testCaseName>criu_pingPerf_pullImagePrivilegedRestore_ubi8</testCaseName>
+		<disables>
+			<disable>
+				<comment>runtimes_backlog_issues_1207</comment>
+				<platform>ppc64le_linux</platform>
+			</disable>
+		</disables>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh pullImagePrivilegedRestore "ubi" "8" "$(DOCKER_REGISTRY_DIR)"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean

--- a/external/criuSettings.mk
+++ b/external/criuSettings.mk
@@ -13,7 +13,7 @@
 ##############################################################################
 
 # - is shell metacharacter. In PLATFORM value, replace - with _
-export CRIU_COMBO_LIST_x86_64_linux=sw.os.ubuntu.22-hw.arch.x86.broadwell sw.os.ubuntu.22-hw.arch.x86.amd sw.os.rhel.8-hw.arch.x86.broadwell sw.os.rhel.8-hw.arch.x86.amd sw.os.rhel.8-hw.arch.x86.skylake sw.os.rhel.9-hw.arch.x86.amd sw.os.rhel.9-hw.arch.x86.skylake
+export CRIU_COMBO_LIST_linux_x86_64=sw.os.ubuntu.22-hw.arch.x86.broadwell sw.os.ubuntu.22-hw.arch.x86.amd sw.os.rhel.8-hw.arch.x86.broadwell sw.os.rhel.8-hw.arch.x86.amd sw.os.rhel.8-hw.arch.x86.skylake sw.os.rhel.9-hw.arch.x86.amd sw.os.rhel.9-hw.arch.x86.skylake
 # not available: sw.os.ubuntu.22-hw.arch.x86.skylake sw.os.rhel.9-hw.arch.x86.broadwell
 
 export CRIU_COMBO_LIST_linux_390_64_z13=sw.os.ubuntu.22-hw.arch.s390x.z13
@@ -21,8 +21,9 @@ export CRIU_COMBO_LIST_linux_390_64_z13=sw.os.ubuntu.22-hw.arch.s390x.z13
 export CRIU_COMBO_LIST_linux_390_64_z14=sw.os.ubuntu.22-hw.arch.s390x.z14 sw.os.rhel.8-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z14
 export CRIU_COMBO_LIST_linux_390_64_z15=sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
 
-export CRIU_COMBO_LIST_aarch64_linux=sw.os.ubuntu.22-hw.arch.aarch64.armv8 sw.os.rhel.9-hw.arch.aarch64.armv8
+export CRIU_COMBO_LIST_linux_aarch64=sw.os.ubuntu.22-hw.arch.aarch64.armv8 sw.os.rhel.9-hw.arch.aarch64.armv8
 # not available: sw.os.rhel.8-hw.arch.aarch64.armv8 sw.os.ubuntu.20-hw.arch.aarch64.armv8
 
-export CRIU_COMBO_LIST_ppc64le_linux=sw.os.rhel.8-hw.arch.ppc64le.p8 sw.os.rhel.8-hw.arch.ppc64le.p10 sw.os.rhel.9-hw.arch.ppc64le.p9
+export CRIU_COMBO_LIST_linux_ppc_64_p9=sw.os.rhel.9-hw.arch.ppc64le.p9
+export CRIU_COMBO_LIST_linux_ppc_64_p10=sw.os.rhel.8-hw.arch.ppc64le.p10
 # not available: sw.os.rhel.8-hw.arch.ppc64le.p9 sw.os.rhel.9-hw.arch.ppc64le.p8 sw.os.rhel.9-hw.arch.ppc64le.p10


### PR DESCRIPTION
- temporarily excluded ubi8 on plinux due to runtimes/backlog/issues/1210
- added check for empty restore_docker_image_name_list
- fixed empty restore_docker_image_name_list issue on x/a/zlinux

resolves: runtimes/backlog/issues/1210
related: runtimes/backlog/issues/1207