### PR TITLE
(v0.9.8-release) - Back port problemlist-openjdk21.txt and exclude GoogleCA.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -199,6 +199,7 @@ sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.com/adoptium/aqa-t
 
 # jdk_security_infra
 
+security/infra/java/security/cert/CertPathValidator/certification/GoogleCA.java https://bugs.openjdk.org/browse/JDK-8309088 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/AmazonCA.java https://bugs.openjdk.org/browse/JDK-8309088 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -214,6 +214,7 @@ sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aq
 
 # jdk_security_infra
 
+security/infra/java/security/cert/CertPathValidator/certification/GoogleCA.java https://bugs.openjdk.org/browse/JDK-8309088 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/AmazonCA.java https://bugs.openjdk.org/browse/JDK-8309088 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -1,0 +1,519 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans
+
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
+java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
+java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+
+############################################################################
+
+# jdk_lang
+
+java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/LoggerInImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+jdk/modules/etc/DefaultModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+# java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
+java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessInt.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessLong.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessShort.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestAccessString.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestByteArrayAsFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
+jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
+java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
+# java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
+# java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
+java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
+java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+
+############################################################################
+
+# jdk_management
+
+com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
+sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
+sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+############################################################################
+
+# jdk_other
+
+# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
+com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
+jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,linux-arm,aix-all
+
+############################################################################
+
+# jdk_net
+
+java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
+java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/InetAddress/IPv4Formats.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/MulticastSocket/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/net/SocketPermission/SocketPermissionCollection.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/SocketPermission/SocketPermissionTest.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/net/SocketPermission/Wildcard.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/Socks/SocksV4Test.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/URL/OpenStream.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/httpclient/ConnectExceptionTest.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/net/httpclient/AsFileDownloadTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/StreamingBody.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/http2/ContinuationFrameTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/SpecialHeadersTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/http2/BadHeadersTest.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/DigestEchoClientSSL.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/ResponseBodyBeforeError.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+java/net/httpclient/ResponsePublisher.java https://github.com/adoptium/temurin-build/issues/893 linux-all
+# Multicast failures on aix https://github.com/adoptium/aqa-tests/issues/2246
+java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all,linux-ppc64le
+java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
+java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
+java/net/CookieHandler/CookieManagerTest.java https://github.com/adoptium/infrastructure/issues/699 aix-ppc64,linux-ppc64le
+java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64, linux-ppc64le
+java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
+java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le 
+java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ProxyCons.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/ReadTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SetSoLinger.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/SoTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/AsyncClose.java https://github.com/adoptium/aqa-tests/issues/827 aix-ppc64, linux-ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Basic.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/BadProxySelector.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socks/SocksProxyVersion.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/Socket/asyncClose/Race.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+java/net/httpclient/ManyRequests.java https://github.com/adoptium/aqa-tests/issues/2828 aix-ppc64
+com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+java/net/InetAddress/HostsFileOrderingTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+java/net/InetAddress/InternalNameServiceTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
+com/sun/net/httpserver/simpleserver/StressDirListings.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+java/net/vthread/HttpALot.java https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+java/net/vthread/InterruptHttp.java https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+jdk/net/ExtendedSocketOption/DontFragmentTest.java https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+java/net/vthread/BlockingSocketOps.java#direct-register https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+java/net/vthread/BlockingSocketOps.java#default https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+java/nio/channels/vthread/BlockingChannelOps.java#default https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+
+############################################################################
+
+# jdk_io
+
+java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+
+############################################################################
+
+# jdk_jdi
+
+com/sun/jdi/JdwpNetProps.java https://bugs.openjdk.java.net/browse/JDK-8231915 linux-s390x
+com/sun/jdi/JdwpAttachTest.java https://bugs.openjdk.java.net/browse/JDK-8253940 linux-s390x
+com/sun/jdi/BreakpointTest.java https://bugs.openjdk.java.net/browse/JDK-8050470 linux-s390x
+com/sun/jdi/JdwpAllowTest.java https://bugs.openjdk.org/browse/JDK-8241624 generic-all
+com/sun/jdi/JdwpListenTest.java https://bugs.openjdk.org/browse/JDK-8241624 generic-all
+
+############################################################################
+
+# jdk_nio
+
+# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
+# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
+java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
+java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
+java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
+java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
+java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 generic-all
+java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
+java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
+java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
+# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
+# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
+java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
+java/nio/charset/spi/CharsetProviderBasicTest.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/ConnectExceptions.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/DatagramChannel/SendExceptions.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/file/Files/InterruptCopy.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
+java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
+jdk/nio/zipfs/ZipFSTester.java https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
+java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+
+############################################################################ 
+
+# jdk_rmi
+
+############################################################################
+
+# jdk_security
+
+sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aqa-tests/issues/3811 windows-x86
+
+############################################################################
+
+# jdk_security3
+
+javax/net/ssl/SSLEngine/LargePacket.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
+sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
+sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
+
+###########################################################################
+
+# jdk_security4
+
+# Cleaners.java issue is specific to alpine-linux, but there appears to be no way to exclude on alpine-linux platform specifically
+# sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
+sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all,linux-all
+
+###########################################################################
+
+# jdk_security_infra
+
+security/infra/java/security/cert/CertPathValidator/certification/GoogleCA.java https://bugs.openjdk.org/browse/JDK-8309088 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/AmazonCA.java https://bugs.openjdk.org/browse/JDK-8309088 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/EntrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/ActalisCA.java https://github.com/adoptium/aqa-tests/issues/2074 generic-all
+
+############################################################################
+
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+
+sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstat/jstatLineCounts4.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
+sun/tools/jstatd/TestJstatdDefaults.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdExternalRegistry.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdPortAndServer.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/tools/jstatd/TestJstatdServer.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AppImagePackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/EmptyFolderPackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/IconTest.java https://github.com/adoptium/infrastructure/issues/2291 linux-aarch64
+# The following 8 tests under tools/jpackage/share/ excluded on linux-aarch64 the tracked issue is https://github.com/adoptium/infrastructure/issues/2291
+tools/jpackage/share/InstallDirTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/LicenseTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/RuntimePackageTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/SimplePackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/BasicTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/jdk/jpackage/tests/VendorTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/windows/WinDirChooserTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinInstallerUiTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinL10nTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuGroupTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinMenuTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinScriptTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutPromptTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
+tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
+tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-ppc64
+tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+
+############################################################################
+
+# jdk_jdi
+
+com/sun/jdi/OnJcmdTest.java https://github.com/adoptium/aqa-tests/issues/2837 windows-x86
+
+############################################################################
+
+# jdk_util
+
+java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/util/logging/TestLoggerWeakRefLeak.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
+java/util/concurrent/tck/JSR166TestCase.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/util/regex/NegativeArraySize.java https://github.com/adoptium/aqa-tests/issues/3818 linux-all
+java/util/zip/DeInflate.java https://bugs.openjdk.org/browse/JDK-8299748 linux-s390x
+
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_foreign
+
+java/foreign/TestArrays.java https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayouts.java https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestLayoutPaths.java https://github.com/adoptium/aqa-tests/issues/1701 generic-all
+java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+java/foreign/TestLargeSegmentCopy.java https://github.com/adoptium/aqa-tests/issues/4429 aix-all
+javax/management/mxbean/ThreadStartTest.java https://github.com/adoptium/aqa-tests/issues/4429 aix-all
+
+############################################################################
+
+# jvm_compiler
+
+compiler/c2/irTests/TestPostParseCallDevirtualization.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+# compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+# compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
+compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/vectorapi/TestNoInline.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestTranslatedException.java https://github.com/adoptium/aqa-tests/issues/3658 linux-x64,windows-x64,linux-aarch64,macosx-all
+compiler/c2/TestCMoveInfiniteGVN.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/TestDeadDataLoopCmoveIdentity.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/TestModDivTopInput.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopopts/FillArrayWithUnsafe.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopopts/TestPredicateInputBelowLoopPredicate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/print/PrintInlining.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopstripmining/TestConservativeAntiDep.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/codecache/MHIntrinsicAllocFailureTest.java https://bugs.openjdk.org/browse/JDK-8298947 linux-arm
+compiler/whitebox/ForceNMethodSweepTest.java https://bugs.openjdk.org/browse/JDK-8265181 linux-arm
+compiler/codegen/aes/Test8292158.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
+compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
+
+############################################################################
+
+# jdk_jfr
+
+jdk/jfr/event/oldobject/TestAllocationTime.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestHeapDeep.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestG1.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/api/consumer/TestRecordedFrame.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java https://github.com/adoptium/aqa-tests/issues/2870 windows-x86,linux-arm
+jdk/jfr/event/gc/collection/TestG1ParallelPhases.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestListenerLeak.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestObjectAge.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestReferenceChainLimit.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/event/oldobject/TestThreadLocalLeak.java https://github.com/adoptium/aqa-tests/issues/2855 windows-x86
+jdk/jfr/jmx/streaming/TestClose.java https://github.com/adoptium/aqa-tests/issues/2865 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestDelegated.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestEnableDisable.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRemoteDump.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestRotate.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+# jdk/jfr/jmx/streaming/TestSetSettings.java https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
+jdk/jfr/jmx/streaming/TestSetSettings.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/3492 generic-all
+jdk/jfr/jmx/streaming/TestMetadataEvent.java https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
+jdk/jfr/jmx/streaming/TestStart.java https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86
+jdk/jfr/jmx/TestGetRecordings.java https://github.com/adoptium/aqa-tests/issues/2754 linux-ppc64le
+jdk/jfr/event/gc/detailed/TestZUncommitEvent.java https://bugs.openjdk.org/browse/JDK-8248078 generic-all
+jdk/jfr/event/gc/detailed/TestGCLockerEvent.java https://github.com/adoptium/aqa-tests/issues/3817 windows-x64
+
+###########################################################################
+
+# jdk_vector
+
+jdk/incubator/vector/Byte512VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ByteMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Int64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/IntMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Short64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/ShortMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Byte256VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+
+############################################################################
+
+# runtime_nestmate
+
+runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
+
+############################################################################
+
+# javax_management
+
+javax/management/remote/mandatory/connection/RMIConnectionIdTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/notif/RMINotifTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/socketFactories/RMISocketFactoriesTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+javax/management/remote/mandatory/util/MapNullValuesTest.java https://github.com/adoptium/aqa-tests/issues/3087 linux-ppc64le
+
+############################################################################
+
+# jdk_imageio
+
+javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+
+############################################################################
+
+# sun_net
+
+sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/http/KeepAliveCache/B5045306.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/http/ZoneId.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java https://bugs.openjdk.java.net/browse/JDK-8224204 generic-all
+sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
+
+#####################################
+
+# jdk_container/hotspot_container
+
+containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JDK-8297274 linux-all
+
+############################################################
+
+# serviceability
+
+serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfoWithEATest.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
+serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all


### PR DESCRIPTION
Back port problemlist-openjdk21.txt

cherry-pick #4765 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>