### PR TITLE
[JDK21] Re-enable TestByteBuffer on AIX

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -486,7 +486,6 @@ java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
-java/foreign/TestByteBuffer.java https://github.com/eclipse-openj9/openj9/issues/17870 aix-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all


### PR DESCRIPTION
Fix: https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/44

Grinder: https://openj9-jenkins.osuosl.org/job/Grinder/2929

The above grinder confirms that TestByteBuffer is fixed on AIX.

Closes: https://github.com/eclipse-openj9/openj9/issues/17870