### PR TITLE
Exclude java/util/zip/CloseInflaterDeflaterTest on OpenJ9 zlinux

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -354,6 +354,7 @@ java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://githu
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java 	https://github.com/eclipse-openj9/openj9/issues/4613 	generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse-openj9/openj9/issues/3447	generic-all
 java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/util/zip/CloseInflaterDeflaterTest.java	https://github.com/eclipse-openj9/openj9/issues/14948	linux-s390x
 java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -376,6 +376,7 @@ java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://githu
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java	https://github.com/eclipse-openj9/openj9/issues/3447	generic-all
 java/util/WeakHashMap/GCDuringIteration.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
+java/util/zip/CloseInflaterDeflaterTest.java	https://github.com/eclipse-openj9/openj9/issues/14948	linux-s390x
 java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/issues/8872 	generic-all
 java/util/Random/RandomTestChiSquared.java	https://github.com/eclipse-openj9/openj9/issues/13202	generic-all
 java/util/Random/RandomTestBsi1999.java		https://github.com/eclipse-openj9/openj9/issues/13202	generic-all

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -441,6 +441,7 @@ java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://githu
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java https://github.com/eclipse-openj9/openj9/issues/3447 generic-all
 java/util/WeakHashMap/GCDuringIteration.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/util/zip/CloseInflaterDeflaterTest.java	https://github.com/eclipse-openj9/openj9/issues/14948	linux-s390x
 java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/8872  generic-all
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -443,6 +443,7 @@ java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://githu
 java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java https://github.com/eclipse-openj9/openj9/issues/4613 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java https://github.com/eclipse-openj9/openj9/issues/3447 generic-all
 java/util/WeakHashMap/GCDuringIteration.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/util/zip/CloseInflaterDeflaterTest.java	https://github.com/eclipse-openj9/openj9/issues/14948	linux-s390x
 java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/8872  generic-all
 
 ############################################################################


### PR DESCRIPTION
It doesn't pass when the system zlib is optimized to use hardware, such as with rhel8 on z15.

Issue https://github.com/eclipse-openj9/openj9/issues/14948