### PR TITLE
Exclude jdk_lang and jdk_io tests on linux-arm

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -92,6 +92,7 @@ java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjd
 # java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
 java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8313260 linux-arm
 
 ############################################################################
 
@@ -204,7 +205,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 # jdk_io
 
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all, linux-arm
 
 ############################################################################
 


### PR DESCRIPTION
ref https://github.com/adoptium/aqa-tests/issues/4773#issuecomment-1727814787

java/lang/ScopedValue/StressStackOverflow.java
```
Execution failed: `main' threw exception: java.lang.RuntimeException: java.lang.RuntimeException: java.lang.IllegalStateException: Subtask not completed or did not complete successfully
```
https://bugs.openjdk.org/browse/JDK-8313260 shows it fails in the same way on linux-x86 in the same way. Passes on jdk22

java/io/File/GetXSpace.java
```
FAILED: '/ usable space': 97777729536 > 1139773440
Warning: us > s.free()
FAILED: '/ usable vs. free space': 97777729536 > 3305226240
6 tests: 6 failure(s); first: java.lang.RuntimeException: '/ total space': 125693825024 != 1139773440
java.lang.RuntimeException: 2 test(s) failed
	at GetXSpace.main(GetXSpace.java:485)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```
Upstream bug for its failure on linux https://bugs.openjdk.org/browse/JDK-8251017

Both tests have failed consistently in this (september 2023) release on linux arm. Should be excluded on this platform