### PR TITLE
exclude jdk_lang and jdk_io tests on linux-arm

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -92,6 +92,7 @@ java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjd
 # java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
 java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8313260 linux-arm
 
 ############################################################################
 
@@ -204,7 +205,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 # jdk_io
 
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all
+java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all, linux-arm
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -205,7 +205,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 # jdk_io
 
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all, linux-arm
+java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm
 
 ############################################################################
 


### PR DESCRIPTION
Same as https://github.com/adoptium/aqa-tests/pull/4785. Merging to release branch instead of master