### PR TITLE
Fix concurrency on non-cgroups linux

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -46,7 +46,7 @@ endif
 # Upstream OpenJDK, roughly, sets concurrency based on the
 # following: min(NPROCS/2, MEM_IN_GB/2).
 MEM := $(shell expr $(MEMORY_SIZE) / 2048)
-CORE := $(shell expr $(NPROCS) / 2)
+CORE := $(shell expr $(NPROCS))
 CONC := $(CORE)
 ifeq ($(shell expr $(CORE) \> $(MEM)), 1)
 	CONC := $(MEM)

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -19,7 +19,7 @@ OS:=$(shell uname -s)
 
 ifeq ($(OS),Linux)
 	NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
-	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`; else CGMEM=`expr $${KMEMMB} \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1048576`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
+	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`; else CGMEM=`expr $${KMEMMB} \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1024`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
 endif
 ifeq ($(OS),Darwin)
 	NPROCS:=$(shell sysctl -n hw.ncpu)
@@ -58,9 +58,9 @@ endif
 JTREG_CONC ?= 0
 # Allow JTREG_CONC be set via parameter
 ifeq ($(JTREG_CONC), 0)
-	JTREG_CONC := $(MEM)
+	JTREG_CONC := $(CONC)
 	ifeq ($(JTREG_CONC), 0)
-                JTREG_CONC := 5
+                JTREG_CONC := 1
 	endif
 endif
 EXTRA_JTREG_OPTIONS += -concurrency:$(JTREG_CONC)

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -11,9 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##############################################################################
-NPROCS:=2
+NPROCS:=1
 # Memory size in MB
-MEMORY_SIZE:=4096
+MEMORY_SIZE:=1024
 
 OS:=$(shell uname -s)
 
@@ -46,7 +46,7 @@ endif
 # Upstream OpenJDK, roughly, sets concurrency based on the
 # following: min(NPROCS/2, MEM_IN_GB/2).
 MEM := $(shell expr $(MEMORY_SIZE) / 2048)
-CORE := $(shell expr $(NPROCS))
+CORE := $(shell expr $(NPROCS) / 2)
 CONC := $(CORE)
 ifeq ($(shell expr $(CORE) \> $(MEM)), 1)
 	CONC := $(MEM)
@@ -60,7 +60,7 @@ JTREG_CONC ?= 0
 ifeq ($(JTREG_CONC), 0)
 	JTREG_CONC := $(CONC)
 	ifeq ($(JTREG_CONC), 0)
-                JTREG_CONC := 1
+		JTREG_CONC := 1
 	endif
 endif
 EXTRA_JTREG_OPTIONS += -concurrency:$(JTREG_CONC)

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -58,7 +58,7 @@ endif
 JTREG_CONC ?= 0
 # Allow JTREG_CONC be set via parameter
 ifeq ($(JTREG_CONC), 0)
-	JTREG_CONC := $(CONC)
+	JTREG_CONC := $(CORE)
 	ifeq ($(JTREG_CONC), 0)
                 JTREG_CONC := 5
 	endif

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -58,7 +58,7 @@ endif
 JTREG_CONC ?= 0
 # Allow JTREG_CONC be set via parameter
 ifeq ($(JTREG_CONC), 0)
-	JTREG_CONC := $(CORE)
+	JTREG_CONC := $(MEM)
 	ifeq ($(JTREG_CONC), 0)
                 JTREG_CONC := 5
 	endif

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -11,9 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##############################################################################
-NPROCS:=1
+NPROCS:=2
 # Memory size in MB
-MEMORY_SIZE:=1024
+MEMORY_SIZE:=4096
 
 OS:=$(shell uname -s)
 
@@ -60,7 +60,7 @@ JTREG_CONC ?= 0
 ifeq ($(JTREG_CONC), 0)
 	JTREG_CONC := $(CONC)
 	ifeq ($(JTREG_CONC), 0)
-		JTREG_CONC := 1
+                JTREG_CONC := 5
 	endif
 endif
 EXTRA_JTREG_OPTIONS += -concurrency:$(JTREG_CONC)


### PR DESCRIPTION
There appears to be a bug in the logic when detecting the amount of RAM available on a Linux machine which does not have cgroups enabled.

In this case, the amount of RAM is coming back in GB instead of MB so ends up looking very small when the concurrency calculation is performed. This should resolve it, however it needs to be checked on more machines since I found that `/sys/fs/cgroup/memory/memory.limit_in_bytes` on one of out Linux/ppc64le machines (`test-osuosl-ubuntu1604-ppc64le-2`) was `9223372036854710272` which doesn't seem right.

Fixing this has the potential to dramatically decrease the openjdk test job times on some Linux machines (Spotted on RISC-V)