### PR TITLE
Add c99 CFLAG option for JDK21 xLinux natives

### DIFF
--- a/jck/jtrunner/makefile
+++ b/jck/jtrunner/makefile
@@ -165,6 +165,8 @@ ifeq ($(shell test $(JDK_VERSION) -ge 21; echo $$?),0)
 			CFLAGS+=-std=gnu99
 		else ifeq ($(ARCH),s390x)
 			CFLAGS+=-std=gnu99
+		else ifeq ($(ARCH),x86_64)
+			CFLAGS+=-std=gnu99
 		endif
 	endif
 endif


### PR DESCRIPTION
related: runtimes/backlog/issues/1183