### PR TITLE
[JDK21/JDK22] Enable virtual/stress/Skynet

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -114,7 +114,6 @@ java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issue
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
-java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/16728 generic-all
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -114,7 +114,6 @@ java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issue
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
-java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/16728 generic-all
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all


### PR DESCRIPTION
- Depends on https://github.com/eclipse-openj9/openj9/pull/18251
- Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/53
- Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/675
- Related: https://github.com/eclipse-openj9/openj9/issues/16728