### PR TITLE
Switch to command line tools xcode before running tests on mac

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -380,7 +380,10 @@ def createJob( TEST_JOB_NAME, ARCH_OS ) {
 def setup() {
 	stage('Setup') {
 		setupEnv()
-
+		if (env.SPEC.startsWith('osx')) {
+			echo "Switching Xcode to command line tools"
+			sh "sudo xcode-select --switch /"
+		}
 		if (params.SDK_RESOURCE == 'nightly' && params.CUSTOMIZED_SDK_URL) {
 			// remove single quote to allow variables to be set in CUSTOMIZED_SDK_URL
 			CUSTOMIZED_SDK_URL_OPTION = "-c ${params.CUSTOMIZED_SDK_URL}"


### PR DESCRIPTION
Switches xcode path to `/Library/Developer/CommandLineTools` before running tests. This should be the default xcode path anyway. Due to https://github.com/adoptium/temurin-build/pull/3492, after a jdk8 build the machine will be stuck on `/Applications/Xcode-11.7.app/Xcode.app/Contents/Developer` which causes errors with gcc and make

```
14:06:42       [exec] gcc -D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -o /Users/jenkins/workspace/Grinder/aqa-tests/system/aqa-systemtest/openjdk.test.modularity/bin/tests/com.test.jlink/native/lib/osx/JniTest.o -arch arm64 -I. -I/Users/jenkins/workspace/Grinder/aqa-tests/system/aqa-systemtest/openjdk.test.modularity/bin/tests/com.test.jlink/native/lib -I/Users/jenkins/workspace/Grinder/openjdkbinary/j2sdk-image/Contents/Home/include/darwin -I/Users/jenkins/workspace/Grinder/openjdkbinary/j2sdk-image/Contents/Home/include -I/usr/include JniTest.c
14:06:42       [exec] make[2]: Leaving directory '/Users/jenkins/workspace/Grinder/aqa-tests/system/aqa-systemtest/openjdk.test.modularity/src/tests/com.test.jlink/native'
14:06:42       [exec] makefile:192: JAVA_EXECUTABLE set to /Users/jenkins/workspace/Grinder/openjdkbinary/j2sdk-image/Contents/Home/bin/java/
14:06:42       [exec] xcrun: error: unable to load libxcrun (dlopen(/Applications/Xcode-11.7.app/Xcode.app/Contents/Developer/usr/lib/libxcrun.dylib, 0x0005): could not use '/Applications/Xcode-11.7.app/Xcode.app/Contents/Developer/usr/lib/libxcrun.dylib' because it is not a compatible arch).
14:06:42       [exec] make[2]: *** [makefile:223: /Users/jenkins/workspace/Grinder/aqa-tests/system/aqa-systemtest/openjdk.test.modularity/bin/tests/com.test.jlink/native/lib/osx/JniTest.o] Error 1
14:06:42  
```
see https://ci.adoptium.net/job/Grinder/7745/console

I've rebuilt that failing job, https://ci.adoptium.net/job/Grinder/7749/console, with this pr's changes. Should pass 👍🏻 