### PR TITLE
[JDK21/22] Update the exlcudes for StressStackOverflow

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -80,7 +80,10 @@ java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/e
 java/lang/reflect/Nestmates/TestReflectionAPI.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java https://github.com/eclipse-openj9/openj9/issues/7775 generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java https://github.com/eclipse-openj9/openj9/issues/7897 generic-all
-java/lang/ScopedValue/StressStackOverflow.java https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#default https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#no-TieredCompilation https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
 java/lang/StackTraceElement/PublicConstructor.java https://github.com/eclipse-openj9/openj9/issues/6659 generic-all
 java/lang/StackTraceElement/SerialTest.java https://github.com/eclipse-openj9/openj9/issues/6659 generic-all
 java/lang/StackWalker/Basic.java https://github.com/eclipse-openj9/openj9/issues/6698 generic-all

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -80,7 +80,10 @@ java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/e
 java/lang/reflect/Nestmates/TestReflectionAPI.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/reflect/Proxy/ProxyLayerTest.java https://github.com/eclipse-openj9/openj9/issues/7775 generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java https://github.com/eclipse-openj9/openj9/issues/7897 generic-all
-java/lang/ScopedValue/StressStackOverflow.java https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#default https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#no-TieredCompilation https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
+java/lang/ScopedValue/StressStackOverflow.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/16965 generic-all
 java/lang/StackTraceElement/PublicConstructor.java https://github.com/eclipse-openj9/openj9/issues/6659 generic-all
 java/lang/StackTraceElement/SerialTest.java https://github.com/eclipse-openj9/openj9/issues/6659 generic-all
 java/lang/StackWalker/Basic.java https://github.com/eclipse-openj9/openj9/issues/6698 generic-all


### PR DESCRIPTION
Now, the test has four sub-variants, which need to be individually excluded.

Related: eclipse-openj9/openj9#18065
Related: eclipse-openj9/openj9#16965

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>