### PR TITLE
Add ssl-tests

### DIFF
--- a/functional/security/ssl-tests/build.xml
+++ b/functional/security/ssl-tests/build.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0"?>
+
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<project name="ssl-tests Security Functional tests" default="build" basedir=".">
+    <taskdef resource="net/sf/antcontrib/antlib.xml" />
+    <description>
+        ssl-tests Security Functional tests
+    </description>
+
+    <!-- set global properties for this build -->
+    <property name="DEST" value="${BUILD_ROOT}/functional/security/ssl-tests" />
+
+    <!--Properties for this particular build-->
+    <property name="src" location="./ssl-tests" />
+
+    <target name="ssltests.check">
+        <condition property="ssltestsTestdir.exists">
+            <available file="ssl-tests" type="dir"/>
+        </condition>
+    </target>
+
+    <if>
+        <contains string="${SPEC}" substring="zos"/>
+        <then>
+            <property name="GIT_REPO" value="git@github.com:" />
+        </then>
+        <else>
+            <property name="GIT_REPO" value="https://github.com/" />
+        </else>
+    </if>
+    <target name="getSsltestsTest" depends="ssltests.check" unless="ssltestsTestdir.exists">
+        <exec executable="git" failonerror="true">
+            <arg value="clone" />
+            <arg value="${GIT_REPO}rh-openjdk/ssl-tests.git" />
+        </exec>
+    </target>
+
+    <target name="init">
+        <mkdir dir="${DEST}" />
+    </target>
+    <if>
+        <or>
+            <matches pattern="^[89]{1}$" string="${JDK_VERSION}"/>
+            <matches pattern="^[1][023456]" string="${JDK_VERSION}"/>
+        </or>
+        <then>
+            <property name="jtregTar" value="jtreg_5_1_b01"/>
+        </then>
+        <else>
+            <if>
+                <matches pattern="^[1][17]" string="${JDK_VERSION}"/>
+                <then>
+                    <property name="jtregTar" value="jtreg_6_1"/>
+                </then>
+                <else>
+                    <if>
+                        <matches pattern="^[1][89]" string="${JDK_VERSION}"/>
+                        <then>
+                            <property name="jtregTar" value="jtreg_6_1_1"/>
+                        </then>
+                        <else>
+                            <property name="jtregTar" value="jtreg_7_1_1_1"/>
+                        </else>
+                    </if>
+                </else>
+            </if>
+        </else>
+    </if>
+    <if>
+        <or>
+            <equals arg1="${JDK_IMPL}" arg2="ibm"  />
+            <equals arg1="${JDK_IMPL}" arg2="openj9" />
+        </or>
+        <then>
+            <property name="openj9jtregtimeouthandler" value=",tohandler_simple"/>
+        </then>
+        <else>
+            <property name="openj9jtregtimeouthandler" value=""/>
+        </else>
+    </if>
+    <property name="LIB" value="${jtregTar}${openj9jtregtimeouthandler}"/>
+
+    <import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
+    <target name="getJtreg">
+        <mkdir dir="${DEST}"/>
+        <if>
+            <not>
+                <available file="${LIB_DIR}/${jtregTar}.tar.gz" />
+            </not>
+            <then>
+                <if>
+                    <available file="custom_jtreg.tar.gz"/>
+                    <then>
+                        <echo message="Using custom_jtreg.tar.gz"/>
+                        <copy file="custom_jtreg.tar.gz" tofile="${jtregTar}.tar.gz"/>
+                    </then>
+                </if>
+            </then>
+            <else>
+                <copy file="${LIB_DIR}/${jtregTar}.tar.gz" tofile="${jtregTar}.tar.gz"/>
+            </else>
+        </if>
+        <exec executable="gzip" failonerror="true">
+            <arg line="-df ${jtregTar}.tar.gz" />
+        </exec>
+        <if>
+            <contains string="${SPEC}" substring="zos" />
+            <then>
+                <exec executable="tar" failonerror="true">
+                    <arg line="xfo ${jtregTar}.tar -C ${DEST}" />
+                </exec>
+            </then>
+            <else>
+                <exec executable="sh" failonerror="true">
+                    <arg line="-c 'cat ${jtregTar}.tar | (cd ${DEST} &amp;&amp; tar xof -)'" />
+                </exec>
+            </else>
+        </if>
+    </target>
+
+    <target name="dist" depends="getDependentLibs,getJtreg,getSsltestsTest" description="generate the distribution">
+        <copy todir="${DEST}">
+            <fileset dir="${src}" includes="*.xml,*.mk" />
+        </copy>
+    </target>
+
+    <target name="clean" depends="dist" description="clean up">
+        <!-- Delete the ${build} directory trees -->
+        <delete dir="${build}" />
+    </target>
+
+    <target name="build" >
+        <antcall target="clean" inheritall="true" />
+    </target>
+</project>
+

--- a/functional/security/ssl-tests/playlist.xml
+++ b/functional/security/ssl-tests/playlist.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
+	<test>
+		<testCaseName>ssl-tests</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+		-a -xml -v:fail,error,time,nopass,summary -timeoutFactor:2 \
+		-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+		-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+		-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+		$(Q)$(TEST_ROOT)$(D)functional$(D)security$(D)ssl-tests$(D)ssl-tests$(D)jtreg-wrappers$(Q); \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+	</test>
+</playlist>


### PR DESCRIPTION
Adds runner for ssl-tests suite. (Code is based on [CryptoTest runner](https://github.com/adoptium/aqa-tests/pull/4327) with some changes and later fixes included.)

This should wait until code adding dependencies is deployed on adoptium infra, see [my comment](https://github.com/adoptium/infrastructure/issues/3059#issuecomment-1778253849)  in issue for dependencies.
