### PR TITLE
Update jtreg version selection

### DIFF
--- a/functional/security/Crypto/build.xml
+++ b/functional/security/Crypto/build.xml
@@ -52,31 +52,25 @@
 		<mkdir dir="${DEST}" />
 	</target>
 	<if>
-		<or>
-			<matches pattern="^[89]{1}$" string="${JDK_VERSION}"/>
-			<matches pattern="^[1][023456]" string="${JDK_VERSION}"/>
-		</or>
+		<matches pattern="^([89]|1[02-6])$" string="${JDK_VERSION}"/>
 		<then>
 			<property name="jtregTar" value="jtreg_5_1_b01"/>
 		</then>
+		<elseif>
+			<matches pattern="^11$" string="${JDK_VERSION}"/>
+			<then>
+				<property name="jtregTar" value="jtreg_6_1"/>
+			</then>
+		</elseif>
+		<elseif>
+			<!-- versions 17, 21, 22 -->
+			<matches pattern="^(17|2[12])$" string="${JDK_VERSION}"/>
+			<then>
+				<property name="jtregTar" value="jtreg_7_3_1_1"/>
+			</then>
+		</elseif>
 		<else>
-			<if> 
-				<matches pattern="^[1][17]" string="${JDK_VERSION}"/>
-				<then>
-					<property name="jtregTar" value="jtreg_6_1"/>
-				</then>
-				<else>
-					<if>
-						<matches pattern="^[1][89]" string="${JDK_VERSION}"/>
-						<then>
-							<property name="jtregTar" value="jtreg_6_1_1"/>
-						</then>
-						<else>
-							<property name="jtregTar" value="jtreg_7_1_1_1"/>
-						</else>
-					</if>
-				</else>
-			</if>
+			<fail message="Unsupported JDK version: ${JDK_VERSION}"/>
 		</else>
 	</if>
 	<if>
@@ -146,4 +140,3 @@
 		<antcall target="clean" inheritall="true" />
 	</target>
 </project>
-

--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -48,15 +48,15 @@
 			<property name="jtregTar" value="jtreg_5_1_b01"/>
 		</then>
 		<elseif>
-			<!-- versions 11, 17 -->
-			<matches pattern="^1[17]$" string="${JDK_VERSION}"/>
+			<!-- version 11 -->
+			<matches pattern="^11$" string="${JDK_VERSION}"/>
 			<then>
 				<property name="jtregTar" value="jtreg_6_1"/>
 			</then>
 		</elseif>
 		<elseif>
-			<!-- version 21, 22 -->
-			<matches pattern="^2[12]$" string="${JDK_VERSION}"/>
+			<!-- versions 17, 21, 22 -->
+			<matches pattern="^(17|2[12])$" string="${JDK_VERSION}"/>
 			<then>
 				<property name="jtregTar" value="jtreg_7_3_1_1"/>
 			</then>


### PR DESCRIPTION
The minimum jtreg version changed from 6.1 to 7.3.1 in jdk17; see:
* https://github.com/openjdk/jdk17u/blob/master/make/autoconf/lib-tests.m4#L31
* https://github.com/ibmruntimes/openj9-openjdk-jdk17/blob/openj9-staging/make/autoconf/lib-tests.m4#L31

Without this change, testing is failing:
```
Error: The testsuite at /home/jenkins/workspace/Test_openjdk17_j9_sanity.openjdk_ppc64_aix_OpenJDK17_testList_2/aqa-tests/openjdk/openjdk-jdk/test/jdk requires jtreg version 7.3.1 b1 or higher and this is jtreg version 6-dev+1.
```