### PR TITLE
Add ant/unzip: command not found in the error list

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -487,6 +487,8 @@ def runTest() {
                     List<String> errorList = new ArrayList<String>();
                     errorList.add(".*There is not enough space in the file system.*");
                     errorList.add(".*java.io.IOException: Cannot run program \"nohup\".*");
+                    errorList.add(".*unzip: command not found.*");
+                    errorList.add(".*ant: command not found.*");
 
                     // nightly/weekly builds should not have git clone issue
                     if (!env.JOB_NAME.contains("Grinder") && !env.JOB_NAME.contains("_Personal")) {


### PR DESCRIPTION
If the error is found in the console output, the node will be marked offline.

related: backlog/issues/983#issuecomment-67423294