### PR TITLE
Enable ssl-tests on all platforms

### DIFF
--- a/functional/security/ssl-tests/playlist.xml
+++ b/functional/security/ssl-tests/playlist.xml
@@ -28,6 +28,5 @@
 		<groups>
 			<group>functional</group>
 		</groups>
-		<platformRequirements>bits.64,arch.x86</platformRequirements>
 	</test>
 </playlist>


### PR DESCRIPTION
Removed limit on platform for ssl-tests. Individual jtreg wrappers should skip themselfs, when not applicable.

Tests:
x86-64_linux: [OK](https://ci.adoptium.net/job/Grinder/8102/)
aarch64_linux: [OK](https://ci.adoptium.net/job/Grinder/8103/)
ppc64le_linux: [OK](https://ci.adoptium.net/job/Grinder/8104/)
x86-64_mac: [OK](https://ci.adoptium.net/job/Grinder/8105/)
x86-64_windows: [OK](https://ci.adoptium.net/job/Grinder/8106/)
x86-32_windows: [OK](https://ci.adoptium.net/job/Grinder/8107/)