### PR TITLE
Update testhost1 default values.

### DIFF
--- a/jck/jtrunner/config/default/jcktest.properties
+++ b/jck/jtrunner/config/default/jcktest.properties
@@ -7,8 +7,8 @@
 # The tests default to using 'default' as the config name.  If another name is used it must be
 # supplied to the test at run time - see openjdk.test.jck/docs/README.md for more details.
 
-testhost1name=wiki.eclipse.org
-testhost1ip=198.41.30.195
+testhost1name=www.eclipse.org
+testhost1ip=198.41.30.198
 testhost2name=hg.openjdk.java.net
 testhost2ip=137.254.56.63
 httpurl=http://www.neverssl.com/index.html


### PR DESCRIPTION
Fixes #4877 

Update testHost1 value to remove defunct wiki.eclipse.org