### PR TITLE
adjust Xvfb timeout to 20s for HiFive Unleashed

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -724,7 +724,7 @@ def runTest( ) {
 			echo "ITERATION: ${i}/${ITERATIONS}"
 			if (env.SPEC.contains('linux') && !(LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') && (BUILD_LIST != "external")) {
 				// Add an additional 10 second timeout due to issue: https://github.com/adoptium/temurin-build/issues/2368#issuecomment-756683888
-				wrap([$class: 'Xvfb', autoDisplayName: true, timeout:10]) {
+				wrap([$class: 'Xvfb', autoDisplayName: true, timeout:20]) {
 					def DISPLAY = sh (
 							script: 'ps -f  | grep \'[X]vfb\' | awk \'{print \$9}\'',
 							returnStdout: true


### PR DESCRIPTION
Increase timeout as some of the machines are taking longer thean 10 seconds to fully initiate the Xvfb process, causing a failure to kick off the tests but no obvious reason why.

Ref: https://github.com/adoptium/aqa-tests/issues/4930 (This does not fix the lack of error message, but should stop things failing. I've verified that it seems ok (sample size of one test run) on the unl1 node which this issue was seen on.

Ref general RISC-V plan at https://github.com/adoptium/temurin-build/issues/3591