### PR TITLE
Improve core count detection

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -19,7 +19,7 @@ OS:=$(shell uname -s)
 
 ifeq ($(OS),Linux)
 	NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
-	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`; else CGMEM=`expr $${KMEMMB} \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1048576`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
+	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`; else CGMEM=`expr $${KMEMMB} \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1024`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
 endif
 ifeq ($(OS),Darwin)
 	NPROCS:=$(shell sysctl -n hw.ncpu)
@@ -46,7 +46,7 @@ endif
 # Upstream OpenJDK, roughly, sets concurrency based on the
 # following: min(NPROCS/2, MEM_IN_GB/2).
 MEM := $(shell expr $(MEMORY_SIZE) / 2048)
-CORE := $(shell expr $(NPROCS) / 2)
+CORE := $(shell expr $(NPROCS) / 2 + 1)
 CONC := $(CORE)
 ifeq ($(shell expr $(CORE) \> $(MEM)), 1)
 	CONC := $(MEM)


### PR DESCRIPTION
I drafted and tested this a few months for the RISC-V case (everything was getting `concurrency:1`) but since we're paying more attention to the AQA test jobs for RISC-V now I want to get this in so we can make use of the multicore machines that we have.

Ref: https://github.com/adoptium/temurin-build/issues/3591

Machine | With this fix | Result
---|---|---
[sxa-unl1](https://ci.adoptium.net/job/Test_openjdk21_hs_sanity.openjdk_riscv64_linux/117/console) | No | concurrency:1
[test-plct-1](https://ci.adoptium.net/job/Test_openjdk21_hs_sanity.openjdk_riscv64_linux/67/consoleFull) | Yes | concurrency:3
[test-plct-3](https://ci.adoptium.net/job/Test_openjdk21_hs_sanity.openjdk_riscv64_linux/67/consoleFull) | Yes | concurrency:3
[build-plct-0](https://ci.adoptium.net/job/Grinder/8341/console) | No | ?
[test-plct-7](https://ci.adoptium.net/job/Grinder/8342/console) | No | ?
[test-plct-6](https://ci.adoptium.net/job/Grinder/8338/console) | Yes | concurrency:3
[odroid-2](https://ci.adoptium.net/job/Grinder/8329/console) | Yes | concurrency:1 (2Gb RAM)
[odroid-2](https://ci.adoptium.net/job/Grinder/8336/console) | No | concurrency:1 (2Gb RAM)
[odroid-1](https://ci.adoptium.net/job/Grinder/8330/console) | Yes | concurrency:1
[docker-2004-armv7l-1](https://ci.adoptium.net/job/Test_openjdk21_hs_sanity.openjdk_arm_linux/120/consoleFull) | No | concurrency:4
[docker-2004-armv7l-1](https://ci.adoptium.net/job/Grinder/8340/console) | Yes | concurrency:81 [*]
[aix72-2](https://ci.adoptium.net/job/Grinder/8331/consoleFull) | Yes | concurrency:1
[aix72-5](https://ci.adoptium.net/job/Test_openjdk21_hs_sanity.openjdk_ppc64_aix/103/consoleFull) | No | concurrency:1
[win2022-1](https://ci.adoptium.net/job/Test_openjdk21_hs_sanity.openjdk_x86-64_windows/137/consoleFull) | No | concurrency:2
[win2022-2](https://ci.adoptium.net/job/Grinder/8332/console) | Yes | concurrency:3

[*] - This value of 81 suggests that the detection in a docker container is not working as it should and will need to be revised before this is merged, hence the draft status at present.