### PR TITLE
Add 21 and 22 as supported versions in external tests

### DIFF
--- a/external/common_functions.sh
+++ b/external/common_functions.sh
@@ -14,7 +14,7 @@
 #
 
 # Supported versions
-supported_versions="8 11 17"
+supported_versions="8 11 17 21 22"
 
 # Supported JVMs
 supported_jvms="hotspot openj9"


### PR DESCRIPTION
related: https://github.com/adoptium/aqa-tests/issues/4949