### PR TITLE
[v1.0.0-release]: Update arm32 tag for dry run

### DIFF
--- a/testenv/testenv_arm32.properties
+++ b/testenv/testenv_arm32.properties
@@ -1,5 +1,5 @@
 TKG_REPO=https://github.com/adoptium/TKG.git
-TKG_BRANCH=v1.0.0
+TKG_BRANCH=v1.0.0.1
 OPENJ9_REPO=https://github.com/eclipse-openj9/openj9.git
 OPENJ9_BRANCH=v0.43.0-release
 STF_REPO=https://github.com/adoptium/STF.git
@@ -9,6 +9,6 @@ OPENJ9_SYSTEMTEST_BRANCH=openj9-0.41.0
 ADOPTOPENJDK_SYSTEMTEST_REPO=https://github.com/adoptium/aqa-systemtest.git
 ADOPTOPENJDK_SYSTEMTEST_BRANCH=v1.0.0
 JDK8_REPO=https://github.com/adoptium/aarch32-jdk8u.git
-JDK8_BRANCH=dev
+JDK8_BRANCH=jdk8u402-b05-aarch32-20231219
 AQA_REQUIRED_TARGETS=sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,extended.perf
 


### PR DESCRIPTION
Using https://github.com/adoptium/aqa-tests/commit/e1354c201f15f37f0479178d3f46c67f5111ad2c as a guide, I have updated the arm32 tag to be used in a dry run. Using the latest _adopt tag in https://github.com/adoptium/aarch32-jdk8u/tags

fyi @ShelleyLambert @sophia-guo 