### PR TITLE
Exclude specific Windows testcases

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -281,6 +281,7 @@ compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/i
 compiler/c2/TestReplaceEquivPhis.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/codegen/TestCharVect2.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopopts/TestRemoveEmptyCountedLoop.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestConservativeAntiDep.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -283,6 +283,7 @@ tools/jpackage/windows/WinShortcutTest.java https://github.com/adoptium/infrastr
 tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/Win8282351Test.java https://github.com/adoptium/infrastructure/issues/2885 windows-all
 tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
 tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 generic-all
 tools/jlink/JLinkReproducibleTest.java https://bugs.openjdk.java.net/browse/JDK-8217166 aix-all
@@ -397,7 +398,10 @@ compiler/whitebox/BlockingCompilation.java https://github.com/adoptium/aqa-tests
 compiler/whitebox/GetCodeHeapEntriesTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/MakeMethodNotCompilableTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/codecache/MHIntrinsicAllocFailureTest.java https://github.com/adoptium/aqa-tests/issues/4515#issuecomment-1512404678 windows-x86,linux-arm
-
+compiler/loopopts/TestBackedgeLoadArrayFillMain.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
+compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
+compiler/loopopts/TestRemoveEmptyCountedLoop.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
+compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 ############################################################################
 
 # jdk_jfr

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -402,6 +402,8 @@ compiler/loopopts/TestBackedgeLoadArrayFillMain.java https://bugs.openjdk.org/br
 compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/loopopts/TestRemoveEmptyCountedLoop.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
+compiler/splitif/TestCrashAtIGVNSplitIfSubType.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
+
 ############################################################################
 
 # jdk_jfr

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -145,6 +145,7 @@ sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/ado
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 # alpine-linux https://github.com/adoptium/aqa-tests/issues/3238
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://bugs.openjdk.java.net/browse/JDK-8031420 linux-all
+sun/management/jmxremote/startstop/JMXStartStopTest.java https://bugs.openjdk.org/browse/JDK-8274337 windows-x86
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -145,7 +145,6 @@ sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/ado
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 # alpine-linux https://github.com/adoptium/aqa-tests/issues/3238
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://bugs.openjdk.java.net/browse/JDK-8031420 linux-all
-sun/management/jmxremote/startstop/JMXStartStopTest.java https://bugs.openjdk.org/browse/JDK-8274337 windows-x86
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 
 ############################################################################


### PR DESCRIPTION
As per https://github.com/adoptium/aqa-tests/issues/4960#issuecomment-1890821702 and https://github.com/adoptium/aqa-tests/issues/4960#issuecomment-1890465850, exclude 5 testcases
Related: https://github.com/adoptium/infrastructure/issues/2885
Related: https://bugs.openjdk.org/browse/JDK-8311964
