### PR TITLE
Do not cleanup processes on Mac due to no Orka VM isolation

### DIFF
--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -38,6 +38,8 @@ if [ "$OS" = "Windows_NT" ]; then
   else
       echo Woohoo - no rogue processes detected!
   fi
+elif [ `uname` = "Darwin" ]; then
+  echo "Mac type machine.. do not terminate any remaining processes as Orka mac VMs are not process isolated, see: https://github.com/adoptium/aqa-tests/issues/4964"
 else
   echo "Unix type machine.."
 


### PR DESCRIPTION
Orka x64 VMs do not seem to be process isolated, see: https://github.com/adoptium/aqa-tests/issues/4964
Which means currently the terminateProcess.sh pre&post test job will terminate any other test job processes that maybe visible on the Orka macstadium node that is being used.
