### PR TITLE
aix: exclude java/lang/String/concat/IntegerMinValue.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -65,6 +65,7 @@ jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/is
 java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64

--- a/openjdk/excludes/ProblemList_openjdk22.txt
+++ b/openjdk/excludes/ProblemList_openjdk22.txt
@@ -65,6 +65,7 @@ jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/is
 java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -65,6 +65,7 @@ jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/is
 java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64


### PR DESCRIPTION
This is a failure on JDK21+ sanity.openjdk runs and is apparently a problem if you do not use the xlc17 compiler
Ref: https://github.com/adoptium/aqa-tests/issues/4789 and https://bugs.openjdk.org/browse/JDK-8306007

Noting that a test by the same name is ok on JDK17 e.g. : https://ci.adoptium.net/job/Test_openjdk17_hs_sanity.openjdk_ppc64_aix/349/testReport/java_lang_String_concat_IntegerMinValue/

Also the failure can apparently be bypassed by running with ` -XX:-OptimizeStringConcat` although I haven't verified this myself and I'm not sure if it's practical to add that into the run instead of excluding.