### PR TITLE
Do not cleanup processes on Mac due to no Orka VM isolation (#4967)

### DIFF
--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -38,6 +38,8 @@ if [ "$OS" = "Windows_NT" ]; then
   else
       echo Woohoo - no rogue processes detected!
   fi
+elif [ `uname` = "Darwin" ]; then
+  echo "Mac type machine.. do not terminate any remaining processes as Orka mac VMs are not process isolated, see: https://github.com/adoptium/aqa-tests/issues/4964"
 else
   echo "Unix type machine.."
 


### PR DESCRIPTION
Merge workaround for Orka x64 process terminations https://github.com/adoptium/aqa-tests/issues/4964 into v1.0.0-release
