### PR TITLE
RISC-V: Disable some known failing tests

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -327,6 +327,14 @@
 	</test>
 	<test>
 		<testCaseName>renaissance-philosophers</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
+				<version>17+</version>
+				<impl>hotspot</impl>
+				<platform>riscv64_linux</platform>
+			</disable>
+		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)philosophers.json$(Q) philosophers; \
 		$(TEST_STATUS)</command>
 		<levels>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -40,6 +40,14 @@
 	</test>
 	<test>
 		<testCaseName>MauveSingleThrdLoad_HS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
+				<version>17+</version>
+				<impl>hotspot</impl>
+				<platform>riscv64_linux</platform>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -80,6 +88,14 @@
 	</test>
 	<test>
 		<testCaseName>MauveSingleInvocLoad_HS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
+				<version>17+</version>
+				<impl>hotspot</impl>
+				<platform>riscv64_linux</platform>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -99,6 +115,14 @@
 	</test>
 	<test>
 		<testCaseName>MauveMultiThrdLoad_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
+				<version>17+</version>
+				<impl>hotspot</impl>
+				<platform>riscv64_linux</platform>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -40,6 +40,12 @@
 				<impl>hotspot</impl>
 				<platform>ppc64_aix|s390x_linux|ppc64le_linux</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
+				<version>17+</version>
+				<impl>hotspot</impl>
+				<platform>riscv64_linux</platform>
+			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -67,6 +73,12 @@
 				<platform>ppc64_aix|ppc64le_linux</platform>
 				<impl>hotspot</impl>
 				<version>17+</version>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
+				<version>17+</version>
+				<impl>hotspot</impl>
+				<platform>riscv64_linux</platform>
 			</disable>
 		</disables>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -debug-generation -java-debug-args=$(Q)-Xmx3g -Xms3g$(Q) -test-args=$(Q)timeLimit=5m$(Q) -java-args-execute-initial=$(Q)$(ADD_OPENS_CMD) -Xmx3g -Xms3g$(Q); \
@@ -170,6 +182,12 @@
 				<version>11+</version>
 				<impl>hotspot</impl>
 				<platform>ppc64_aix|s390x_linux|ppc64le_linux</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
+				<version>17+</version>
+				<impl>hotspot</impl>
+				<platform>riscv64_linux</platform>
 			</disable>
 		</disables>
 		<variations>


### PR DESCRIPTION
The tests are broken and should be disabled until fixed.

Based on results from https://ci.adoptium.net/job/build-scripts/job/jobs/job/evaluation/job/jobs/job/jdk21u/job/jdk21u-evaluation-linux-riscv64-temurin/112

Relates to https://github.com/adoptium/aqa-tests/issues/4976