### PR TITLE
Add CRIU container-based functional test

### DIFF
--- a/external/common_functions.sh
+++ b/external/common_functions.sh
@@ -30,7 +30,7 @@ supported_packages="jdk jre"
 supported_builds="full"
 
 # Supported tests
-supported_tests="external_custom camel criu-portable-checkpoint criu-portable-restore criu-ubi-portable-checkpoint criu-ubi-portable-restore derby elasticsearch jacoco jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test tomcat tomee wildfly wycheproof netty spring zookeeper"
+supported_tests="external_custom camel criu-functional criu-portable-checkpoint criu-portable-restore criu-ubi-portable-checkpoint criu-ubi-portable-restore derby elasticsearch jacoco jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test tomcat tomee wildfly wycheproof netty spring zookeeper"
 
 function check_version() {
     version=$1

--- a/external/criu-functional/build.xml
+++ b/external/criu-functional/build.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<project name="criu-functional" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build criu-functional Docker image
+	</description>
+	<import file="${TEST_ROOT}/external/build.xml"/>
+
+	<!-- set properties for this build -->
+	<property name="TEST" value="criu-functional" />
+	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
+	<property name="src" location="." />
+
+	<target name="init">
+		<mkdir dir="${DEST}"/>
+	</target>
+
+	<target name="dist" depends="move_scripts,clean_image,build_image" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml, *.mk"/>
+		</copy>
+	</target>
+
+	<target name="build">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/external/criu-functional/playlist.xml
+++ b/external/criu-functional/playlist.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/playlist.xsd">
+	<test>
+		<testCaseName>criu-functional</testCaseName>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir criu-functional --testtarget "_testList TESTLIST=cmdLineTester_criu_security,cmdLineTester_criu_random" --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS) --tmpfs /run"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir criu-functional
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+</playlist>

--- a/external/criu-functional/test.properties
+++ b/external/criu-functional/test.properties
@@ -1,0 +1,6 @@
+github_url="https://github.com/adoptium/aqa-tests.git"
+test_results="testResults"
+gradle_version="5.1"
+environment_variable="MODE=java CC=gcc-7 CXX=g++-7"
+ubuntu_packages="ant-contrib build-essential git asciidoc"
+criu_version="latest"

--- a/external/criu-functional/test.sh
+++ b/external/criu-functional/test.sh
@@ -1,0 +1,38 @@
+#/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source $(dirname "$0")/test_base_functions.sh
+# Set up Java to be used by the functional test
+echo_setup
+
+echo "export GLIBC_TUNABLES=glibc.pthread.rseq=0:glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load";
+export GLIBC_TUNABLES=glibc.pthread.rseq=0:glibc.cpu.hwcaps=-XSAVEC,-XSAVE,-AVX2,-ERMS,-AVX,-AVX_Fast_Unaligned_Load
+echo "export LD_BIND_NOT=on";
+export LD_BIND_NOT=on
+
+export TEST_JDK_HOME=$JAVA_HOME
+echo "TEST_JDK_HOME is : $TEST_JDK_HOME"
+export JDK_VERSION=
+echo "TEST_JDK_HOME has been unset, use auto-detect instead."
+export DYNAMIC_COMPILE=true
+export BUILD_LIST=functional
+
+cd /aqa-tests
+./get.sh
+cd /aqa-tests/TKG
+
+set -e
+echo "Generating make files and running the target tests"
+make $1
+set +e

--- a/external/dockerfile_functions.sh
+++ b/external/dockerfile_functions.sh
@@ -500,7 +500,7 @@ print_clone_project() {
     # Cause Test name to be capitalized
     test_tag="$(sanitize_test_names ${test} | tr a-z A-Z)_TAG"
     git_branch_tag="master"
-    if [[ "$test_tag" != *"PORTABLE"* ]]; then
+    if [[ "$test_tag" != *"CRIU"* ]]; then
         git_branch_tag=$test_tag
     fi
 

--- a/external/external.sh
+++ b/external/external.sh
@@ -61,7 +61,7 @@ usage () {
 	echo 'Usage : external.sh  --dir TESTDIR --tag DOCKERIMAGE_TAG --version JDK_VERSION --impl JDK_IMPL [--docker_os docker_os][--platform PLATFORM] [--portable portable] [--node_name node_name] [--node_labels node_labels] [--docker_registry_required docker_registry_required] [--docker_registry_url DOCKER_REGISTRY_URL] [--docker_registry_dir DOCKER_REGISTRY_DIR] [--base_docker_registry_url baseDockerRegistryUrl] [--base_docker_registry_dir baseDockerRegistryDir] [--mount_jdk mount_jdk] [--test_root TEST_ROOT] [--reportsrc appReportDir] [--reportdst REPORTDIR] [--testtarget target] [--docker_args EXTRA_DOCKER_ARGS] [--build|--run|--load|--clean]'
 }
 
-supported_tests="external_custom aot camel criu-portable-checkpoint  criu-portable-restore criu-ubi-portable-checkpoint criu-ubi-portable-restore derby elasticsearch jacoco jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test tomcat tomee wildfly wycheproof netty spring"
+supported_tests="external_custom aot camel criu-functional criu-portable-checkpoint  criu-portable-restore criu-ubi-portable-checkpoint criu-ubi-portable-restore derby elasticsearch jacoco jenkins functional-test kafka lucene-solr openliberty-mp-tck payara-mp-tck quarkus quarkus_quickstarts scala system-test tomcat tomee wildfly wycheproof netty spring"
 
 function check_test() {
     test=$1

--- a/external/functional-test/playlist.xml
+++ b/external/functional-test/playlist.xml
@@ -27,28 +27,6 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>criu_test</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/4410</comment>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
-		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir functional-test --testtarget "_testList TESTLIST=cmdLineTester_criu,cmdLineTester_criu_nonPortableRestore,cmdLineTester_criu_security,cmdLineTester_criu_random" --reportdst $(REPORTDIR) --docker_args "-v /var/run/docker.sock:/var/run/docker.sock $(EXTRA_DOCKER_ARGS) --tmpfs /run"; \
-		$(TEST_STATUS); \
-		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir functional-test
-		</command>
-		<features>
-			<feature>CRIU:required</feature>
-		</features>
-		<levels>
-			<level>dev</level>
-		</levels>
-		<groups>
-			<group>external</group>
-		</groups>
-	</test>
-	<test>
 		<testCaseName>extended_functional</testCaseName>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir functional-test --testtarget _extended.functional.regular --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
 		$(TEST_STATUS); \


### PR DESCRIPTION
- Add CRIU container-based functional test
- More CRIU cmdlinetests will be added to the target later
- Related Issue: https://github.com/adoptium/aqa-tests/issues/4410