### PR TITLE
Exclude tests on aarch64_mac

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -337,6 +337,13 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-signaturetest</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
+				<platform>aarch64_mac</platform>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -445,6 +452,11 @@
 				<version>8</version>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
+				<platform>aarch64_mac</platform>
+				<impl>openj9</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -495,6 +507,11 @@
 				<comment>Disabled on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>ppc64_aix</platform>
 				<version>11</version>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
+				<platform>aarch64_mac</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -750,6 +767,11 @@
 				<platform>ppc64_aix</platform>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
+				<platform>aarch64_mac</platform>
+				<impl>openj9</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>NoOptions</variation>
@@ -850,6 +872,13 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-javax_imageio</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
+				<platform>aarch64_mac</platform>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
@@ -1298,6 +1327,13 @@
 	</test>
 	<test>
 		<testCaseName>jck-runtime-api-serializabletypes</testCaseName>
+		<disables>
+			<disable>
+				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
+				<platform>aarch64_mac</platform>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>


### PR DESCRIPTION
- Exclude tests on aarch64_mac for all versions due to backlog/issues/1300