### PR TITLE
RISC-V: Increase timeout for OpenJDK tests

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -80,7 +80,7 @@ JTREG_BASIC_OPTIONS += -retain:fail,error,*.dmp,javacore.*,heapdump.*,*.trc
 JTREG_IGNORE_OPTION = -ignore:quiet
 JTREG_BASIC_OPTIONS += $(JTREG_IGNORE_OPTION)
 # riscv64 machines aren't very fast (yet!!)
-ifeq ($(ARCH),riscv64)
+ifeq ($(ARCH), riscv64)
 	JTREG_TIMEOUT_OPTION = -timeoutFactor:16
 else
 # Multiple by 8 the timeout numbers, except on zOS use 2

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -81,7 +81,7 @@ JTREG_IGNORE_OPTION = -ignore:quiet
 JTREG_BASIC_OPTIONS += $(JTREG_IGNORE_OPTION)
 # riscv64 machines aren't very fast (yet!!)
 ifeq ($(ARCH),riscv64)
-	JTREG_TIMEOUT_OPTION =  -timeoutFactor:16
+	JTREG_TIMEOUT_OPTION = -timeoutFactor:16
 else
 # Multiple by 8 the timeout numbers, except on zOS use 2
 ifneq ($(OS),OS/390)

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -79,11 +79,16 @@ JTREG_BASIC_OPTIONS += -retain:fail,error,*.dmp,javacore.*,heapdump.*,*.trc
 # Ignore tests are not run and completely silent about it
 JTREG_IGNORE_OPTION = -ignore:quiet
 JTREG_BASIC_OPTIONS += $(JTREG_IGNORE_OPTION)
+# riscv64 machines aren't very fast (yet!!)
+ifeq ($(ARCH),riscv64)
+	JTREG_TIMEOUT_OPTION =  -timeoutFactor:16
+else
 # Multiple by 8 the timeout numbers, except on zOS use 2
 ifneq ($(OS),OS/390)
 	JTREG_TIMEOUT_OPTION =  -timeoutFactor:8
 else
 	JTREG_TIMEOUT_OPTION =  -timeoutFactor:2
+endif
 endif
 JTREG_BASIC_OPTIONS += $(JTREG_TIMEOUT_OPTION)
 # Create junit xml


### PR DESCRIPTION
Some tests are timing out even though they are not stuck. Increase the timeoutFactor to give them a chance to finish

Relates to https://github.com/adoptium/aqa-tests/issues/4976