### PR TITLE
Exclude tests on aarch64_mac

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -340,7 +340,7 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
-				<platform>aarch64_mac</platform>
+				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -454,7 +454,7 @@
 			</disable>
 			<disable>
 				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
-				<platform>aarch64_mac</platform>
+				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -511,7 +511,7 @@
 			</disable>
 			<disable>
 				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
-				<platform>aarch64_mac</platform>
+				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -769,7 +769,7 @@
 			</disable>
 			<disable>
 				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
-				<platform>aarch64_mac</platform>
+				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -875,7 +875,7 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
-				<platform>aarch64_mac</platform>
+				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -1330,7 +1330,7 @@
 		<disables>
 			<disable>
 				<comment>Disabled on aarch64_mac due to backlog/issues/1300.</comment>
-				<platform>aarch64_mac</platform>
+				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>


### PR DESCRIPTION
- Exclude tests on aarch64_mac for all versions due to backlog/issues/1300 
- Added `aarch64_mac.*` for excluding aarch64_mac