### PR TITLE
Temporarily Move Criu-functional test to special level

### DIFF
--- a/external/criu-functional/playlist.xml
+++ b/external/criu-functional/playlist.xml
@@ -26,7 +26,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<levels>
-			<level>dev</level>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>external</group>


### PR DESCRIPTION
- Criu-functional test image got cleaned before test in sanity level
- temporarily move it to special level first
- Related Issue: https://github.com/adoptium/aqa-tests/issues/4410