### PR TITLE
(v1.0.0-release) Exclude CryptoTests for OpenJ9 FIPS

### DIFF
--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -38,6 +38,9 @@
 		-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
 		$(Q)$(TEST_ROOT)$(D)functional$(D)security$(D)Crypto$(D)CryptoTest$(Q); \
 		$(TEST_STATUS)</command>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+		</features>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Exclude CryptoTests for OpenJ9 FIPS

Cherry-pick of https://github.com/adoptium/aqa-tests/pull/5003

Signed-off-by: Jason Feng <fengj@ca.ibm.com>