### PR TITLE
Set platform requirements for ssl-tests

### DIFF
--- a/functional/security/ssl-tests/playlist.xml
+++ b/functional/security/ssl-tests/playlist.xml
@@ -25,6 +25,11 @@
 		<levels>
 			<level>dev</level>
 		</levels>
+		<platformRequirementsList>
+			<platformRequirements>os.linux</platformRequirements>
+			<platformRequirements>os.win</platformRequirements>
+			<platformRequirements>os.osx</platformRequirements>
+		</platformRequirementsList>
 		<groups>
 			<group>functional</group>
 		</groups>


### PR DESCRIPTION
Fixes: https://github.com/adoptium/aqa-tests/issues/4943