### PR TITLE
Use nproc instead of /proc/cpuinfo to find number of processors for concurrency

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -64,7 +64,7 @@ ifeq ($(JTREG_CONC), 0)
 		JTREG_CONC := 1
 	endif
 endif
-EXTRA_JTREG_OPTIONS += -concurrency:$(JTREG_CONC)
+EXTRA_JTREG_OPTIONS += -concurrency:2
 
 JTREG_BASIC_OPTIONS += -agentvm
 # Only run automatic tests

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -85,9 +85,9 @@ ifeq ($(ARCH), riscv64)
 else
 # Multiple by 8 the timeout numbers, except on zOS use 2
 ifneq ($(OS),OS/390)
-	JTREG_TIMEOUT_OPTION =  -timeoutFactor:8
+	JTREG_TIMEOUT_OPTION =  -timeoutFactor:40
 else
-	JTREG_TIMEOUT_OPTION =  -timeoutFactor:16
+	JTREG_TIMEOUT_OPTION =  -timeoutFactor:2
 endif
 endif
 JTREG_BASIC_OPTIONS += $(JTREG_TIMEOUT_OPTION)

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -19,7 +19,7 @@ OS:=$(shell uname -s)
 ARCH:=$(shell uname -m)
 
 ifeq ($(OS),Linux)
-	NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
+	NPROCS:=$(shell nproc)
 	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`; else CGMEM=`expr $${KMEMMB} \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1024`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
 endif
 ifeq ($(OS),Darwin)
@@ -64,7 +64,7 @@ ifeq ($(JTREG_CONC), 0)
 		JTREG_CONC := 1
 	endif
 endif
-EXTRA_JTREG_OPTIONS += -concurrency:2
+EXTRA_JTREG_OPTIONS += -concurrency:$(CONC)
 
 JTREG_BASIC_OPTIONS += -agentvm
 # Only run automatic tests
@@ -85,7 +85,7 @@ ifeq ($(ARCH), riscv64)
 else
 # Multiple by 8 the timeout numbers, except on zOS use 2
 ifneq ($(OS),OS/390)
-	JTREG_TIMEOUT_OPTION =  -timeoutFactor:40
+	JTREG_TIMEOUT_OPTION =  -timeoutFactor:8
 else
 	JTREG_TIMEOUT_OPTION =  -timeoutFactor:2
 endif

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -64,7 +64,7 @@ ifeq ($(JTREG_CONC), 0)
 		JTREG_CONC := 1
 	endif
 endif
-EXTRA_JTREG_OPTIONS += -concurrency:$(CONC)
+EXTRA_JTREG_OPTIONS += -concurrency:$(JTREG_CONC)
 
 JTREG_BASIC_OPTIONS += -agentvm
 # Only run automatic tests

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -87,7 +87,7 @@ else
 ifneq ($(OS),OS/390)
 	JTREG_TIMEOUT_OPTION =  -timeoutFactor:8
 else
-	JTREG_TIMEOUT_OPTION =  -timeoutFactor:2
+	JTREG_TIMEOUT_OPTION =  -timeoutFactor:16
 endif
 endif
 JTREG_BASIC_OPTIONS += $(JTREG_TIMEOUT_OPTION)


### PR DESCRIPTION
See https://github.com/adoptium/infrastructure/issues/3360#issuecomment-1924438777

For docker containers, `grep -c ^processor /proc/cpuinfo` will return the number of processors of the host, not the container. Whereas `nproc` will return the number of processors of the container (given the container is run using the `--cpuset-cpus="0-n"` option.

`nproc` works on linux hosts so should not affect non docker nodes and it comes pre installed