### PR TITLE
Generate junit xml in OpenJcePlusTests

### DIFF
--- a/functional/OpenJcePlusTests/build.xml
+++ b/functional/OpenJcePlusTests/build.xml
@@ -84,6 +84,9 @@
 		</jar>
 		<copy todir="${DEST}">
 			<fileset dir="${src}/../../" includes="*.xml,*.mk" />
+			<fileset dir="${LIB_DIR}/" includes="junit4.jar" />
+			<fileset dir="${LIB_DIR}/" includes="hamcrest-core.jar" />
+			<fileset dir="${LIB_DIR}/" includes="bcprov-jdk18on.jar" />
 		</copy>
 	</target>
 

--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -25,11 +25,7 @@
 				<platform>^((?!(ppc64_aix|ppc64le_linux|x86-64_linux|x86-64_windows)).)*$</platform>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	-cp $(Q)$(LIB_DIR)$(D)junit4.jar$(P)$(LIB_DIR)$(D)hamcrest-core.jar$(P)$(LIB_DIR)$(D)bcprov-jdk18on.jar$(P)$(TEST_RESROOT)$(D)openjceplus-tests.jar$(Q) \
-	--add-exports=java.base/sun.security.util=ALL-UNNAMED \
-	--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED \
-	ibm.jceplus.junit.TestAll; \
+		<command>ant -f ${BUILD_ROOT}/functional/OpenJcePlusTests/test.xml -DTEST_JAVA=$(Q)$(JAVA_COMMAND)$(Q) launch_test; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>

--- a/functional/OpenJcePlusTests/test.xml
+++ b/functional/OpenJcePlusTests/test.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+
+<!--
+# Licensed under the Apache License, Version 2.0 {the "License"};
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<project name="Launcher script for OpenJcePlusTests" default="help" basedir=".">
+	<target name="help">
+		<echo>Ant script to run the tests for ibm.jceplus.junit.TestAll.
+		</echo>
+	</target>
+
+	<target name="launch_test">
+		<echo message="Running ibm.jceplus.junit.TestAll in ${user.dir}" />
+		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestAll" />
+		<mkdir dir="junitreports" />
+		<java jvm="${TEST_JAVA}"
+				classname="org.apache.tools.ant.launch.Launcher"
+				fork="true"
+				failonerror="true"
+				dir="${basedir}"
+				timeout="3600000"
+				taskname="test">
+			<classpath>
+				<pathelement location="${ant.home}/lib/ant-launcher.jar" />
+			</classpath>
+			<jvmarg value="-showversion" />
+			<arg value="-buildfile" />
+			<arg file="${ant.file}" />
+			<arg value="test" />
+		</java>
+	</target>
+	<target name="test">
+		<junit fork="yes" printsummary="on" showoutput="yes" haltonfailure="yes">
+			<jvmarg line="--add-exports=java.base/sun.security.util=ALL-UNNAMED" />
+			<jvmarg line="--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED" />
+			<classpath>
+				<pathelement location="junit4.jar" />
+				<pathelement location="hamcrest-core.jar" />
+				<pathelement location="bcprov-jdk18on.jar" />
+				<pathelement location="openjceplus-tests.jar" />
+			</classpath>
+			<formatter type="xml" />
+			<test name="ibm.jceplus.junit.TestAll" todir="junitreports"/>
+		</junit>
+		<echo message="ALL TESTS COMPLETED" />
+	</target>
+</project>


### PR DESCRIPTION
`<junit>` is used to generate junit xml

related: https://github.com/adoptium/aqa-tests/issues/4979 and https://github.com/adoptium/aqa-tests/pull/5024#discussion_r1476522140