### PR TITLE
Permanently disable VThreadInHeapDump & GetStackTraceAndRetransformTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -562,9 +562,9 @@ serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java https://githu
 serviceability/jvmti/vthread/ToggleNotifyJvmtiTest/ToggleNotifyJvmtiTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#default https://github.com/eclipse-openj9/openj9/issues/18426 generic-all
 serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/18426 generic-all
-serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java https://github.com/eclipse-openj9/openj9/issues/18811 generic-all
+serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java https://github.com/eclipse-openj9/openj9/issues/18810 generic-all
-serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetStackTraceAndRetransformTest.java https://github.com/eclipse-openj9/openj9/issues/18809 generic-all
+serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetStackTraceAndRetransformTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/18807 generic-all
 
 # jdk_container

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -562,9 +562,9 @@ serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java https://githu
 serviceability/jvmti/vthread/ToggleNotifyJvmtiTest/ToggleNotifyJvmtiTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#default https://github.com/eclipse-openj9/openj9/issues/18426 generic-all
 serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/18426 generic-all
-serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java https://github.com/eclipse-openj9/openj9/issues/18811 generic-all
+serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java https://github.com/eclipse-openj9/openj9/issues/18810 generic-all
-serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetStackTraceAndRetransformTest.java https://github.com/eclipse-openj9/openj9/issues/18809 generic-all
+serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetStackTraceAndRetransformTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/18807 generic-all
 
 # jdk_container


### PR DESCRIPTION
For OpenJ9 JDK22+, the following tests are disabled:
- `VThreadInHeapDump` relies upon `-Xlog:heapdump` which is unsupported in OpenJ9.
- `GetStackTraceAndRetransformTest` utilizes the `WhiteBox` API, which is also unsupported in OpenJ9.

Closes: https://github.com/eclipse-openj9/openj9/issues/18809
Closes: https://github.com/eclipse-openj9/openj9/issues/18811