### PR TITLE
Exclude GetStackTraceALotWhenPinned on OpenJ9 for jdk22+ on zlinux

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22.txt
+++ b/openjdk/excludes/ProblemList_openjdk22.txt
@@ -66,6 +66,7 @@ java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
 java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
+java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -66,6 +66,7 @@ java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
 java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
+java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/issues/18908