### PR TITLE
Unexclude fixed globalization tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -302,13 +302,7 @@ javax/sound/midi/Devices/InitializationHang.java https://github.com/adoptium/aqa
 
 # jdk_text
 
-java/text/BreakIterator/BreakIteratorTest.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-java/text/Format/DateFormat/DateFormatTest.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-java/text/Format/DateFormat/NonGregorianFormatTest.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-java/text/Format/MessageFormat/LargeMessageFormat.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-java/text/Format/NumberFormat/NumberRegression.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-java/text/Format/NumberFormat/NumberTest.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-sun/text/IntHashtable/Bug4170614Test.sh https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
+java/text/BreakIterator/BreakIteratorTest.java https://bugs.openjdk.org/browse/JDK-8229922 generic-all
 
 ############################################################################
 
@@ -366,13 +360,10 @@ com/sun/jdi/PrivateTransportTest.sh https://github.com/adoptium/aqa-tests/issues
 # jdk_util
 
 java/util/Arrays/TimSortStackSize2.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/Calendar/CalendarRegression.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-java/util/Calendar/JapanEraNameCompatTest.java https://bugs.openjdk.java.net/browse/JDK-8218781 generic-all
 java/util/Locale/LocaleProviders.sh https://github.com/adoptium/aqa-tests/issues/1261 windows-all
 java/util/Random/RandomTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/util/ResourceBundle/Control/Bug6530694.java https://github.com/adoptium/aqa-tests/issues/137 macosx-all
 java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-java/util/TimeZone/HongKong.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/adoptium/aqa-tests/issues/1259 macosx-all
 java/util/logging/TestLoggerWeakRefLeak.java https://github.com/adoptium/aqa-tests/issues/1259 macosx-all
 java/util/stream/boottest/java/util/stream/SpinedBufferTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x


### PR DESCRIPTION
Most "globalization tests" have been fixed. These tests are listed in [JDK-8229922](https://bugs.openjdk.org/browse/JDK-8229922). According to [comment](https://bugs.openjdk.org/browse/JDK-8229922?focusedId=14446231&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14446231) there, all have been fixed (also see linked issues there), except for `BreakIteratorTest.java`. This corresponds with observation on our infra.

**Additional changes:**
I have updated ProblemList, so that `java/text/BreakIterator/BreakIteratorTest.java` references appropriate bug (previous link was bug which backported that test to 8).

**Testing in Grinder:**
jdk_text: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/8718/)
jdk_util: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/8719/)