### PR TITLE
Exclude java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java for linux on jdk17

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -120,6 +120,7 @@ com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-82
 
 # jdk_net
 
+java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java https://bugs.openjdk.org/browse/JDK-8314164 linux-all
 java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
 java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -130,7 +130,6 @@ jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openj
 
 # jdk_net
 
-java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java https://bugs.openjdk.org/browse/JDK-8314164 linux-all
 java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
 java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -130,6 +130,7 @@ jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openj
 
 # jdk_net
 
+java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java https://bugs.openjdk.org/browse/JDK-8314164 linux-all
 java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
 java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all


### PR DESCRIPTION
This test is faillng on our [arm64](https://github.com/adoptium/infrastructure/issues/2514) and [x64](https://github.com/adoptium/infrastructure/issues/2360#issuecomment-1933837174) nodes for jdk17. Theres an upstream issue for this failing test https://bugs.openjdk.org/browse/JDK-8314164

```
16:59:55  FINEST: ProxySelector Request for http://localhost:54321/
16:59:55  Feb 07, 2024 4:57:47 PM sun.net.www.protocol.http.HttpURLConnection plainConnect0
16:59:55  FINEST: Proxy used: DIRECT
16:59:55  Feb 07, 2024 4:57:47 PM sun.net.www.protocol.http.HttpURLConnection writeRequests
16:59:55  FINE: sun.net.www.MessageHeader@402fb34410 pairs: {POST / HTTP/1.1: null}{Connection: Close}{Expect: 100-Continue}{Cache-Control: no-cache}{Pragma: no-cache}{User-Agent: Java/17.0.10}{Host: localhost:54321}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Content-type: application/x-www-form-urlencoded}{Transfer-Encoding: chunked}
16:59:55  java.net.SocketTimeoutException: Read timed out
16:59:55  	at java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:288)
16:59:55  	at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:314)
16:59:55  	at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:355)
16:59:55  	at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:808)
```

Passes on jdk21