### PR TITLE
Exclude GetStackTraceALotWhenPinned on OpenJ9 for jdk22+ on zlinux

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -120,6 +120,7 @@ java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://git
 java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issues/17638 windows-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
+java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all

--- a/openjdk/excludes/ProblemList_openjdk22.txt
+++ b/openjdk/excludes/ProblemList_openjdk22.txt
@@ -66,7 +66,6 @@ java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
 java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
-java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -120,6 +120,7 @@ java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://git
 java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issues/17638 windows-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
+java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -66,7 +66,6 @@ java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
 java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
-java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64


### PR DESCRIPTION
Fix https://github.com/adoptium/aqa-tests/pull/5042 which added the excludes to the wrong files.

Issue https://github.com/eclipse-openj9/openj9/issues/18908