### PR TITLE
[Jtreg/FFI] Enable test suites in JDK22+

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1579,13 +1579,6 @@
 	</test>
 	<test>
 		<testCaseName>jdk_foreign</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/17872</comment>
-				<version>22+</version>
-				<impl>openj9</impl>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>


### PR DESCRIPTION
The change enables the FFI specific test suites in JDK22+ 
given the issue with the heap arguments is resolved via 
https://github.com/eclipse-openj9/openj9/pull/18930.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
