### PR TITLE
[Jtreg/FFI] Disable the failing test suites in JDK22+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -502,6 +502,14 @@ java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/open
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
+java/foreign/critical/TestCritical.java https://github.com/eclipse-openj9/openj9/issues/18939 generic-all
+java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
+java/foreign/TestDowncallScope.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
+java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/18941 aix-all
+java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
+java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
+java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
+
 ############################################################################
 
 # com_sun_crypto

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -502,6 +502,14 @@ java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/open
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
+java/foreign/critical/TestCritical.java https://github.com/eclipse-openj9/openj9/issues/18939 generic-all
+java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
+java/foreign/TestDowncallScope.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
+java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/18941 aix-all
+java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
+java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
+java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
+
 ############################################################################
 
 # com_sun_crypto


### PR DESCRIPTION
The change disables the failing FFI test suites detected
in JDK22+ for the moment given these failures have been
captured in these issues, in which case these test suites
will be re-enabled once they are resolved.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>
