### PR TITLE
[Jtreg/FFI] Disable the failing test suites in JDK22+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -505,8 +505,11 @@ java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues
 java/foreign/critical/TestCritical.java https://github.com/eclipse-openj9/openj9/issues/18939 generic-all
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
 java/foreign/TestDowncallScope.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
+java/foreign/TestDowncallStack.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
 java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/18941 aix-all
 java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
+java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
+java/foreign/nested/TestNested.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
 java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
 

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -505,8 +505,11 @@ java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues
 java/foreign/critical/TestCritical.java https://github.com/eclipse-openj9/openj9/issues/18939 generic-all
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
 java/foreign/TestDowncallScope.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
+java/foreign/TestDowncallStack.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
 java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/18941 aix-all
 java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
+java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
+java/foreign/nested/TestNested.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
 java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
 


### PR DESCRIPTION
Add tests missed in https://github.com/adoptium/aqa-tests/pull/5056