### PR TITLE
Fix LIGHT_WEIGHT_CHECKOUT error

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1182,6 +1182,9 @@ def addGrinderLink() {
 		url = url.replace(rerunIterations,"RERUN_ITERATIONS=0")
 	}
 
+	// reset LIGHT_WEIGHT_CHECKOUT to false in Rerun in Grinder link
+	url = url.replace("LIGHT_WEIGHT_CHECKOUT=true", "LIGHT_WEIGHT_CHECKOUT=false")
+
 	currentBuild.description += "<br><a href=\"https://github.com/adoptium/aqa-tests/wiki/How-to-Run-a-Grinder-Build-on-Jenkins\">Grinder Wiki</a>"
 	echo "Rerun in Grinder: ${url}"
 	currentBuild.description += "<br><a href=${url}>Rerun in Grinder</a> Change TARGET to run only the failed test targets."


### PR DESCRIPTION
- Fix: https://github.com/adoptium/aqa-tests/issues/4841 about parameter LIGHT_WEIGHT_CHECKOUT error with personal forked branch.
- Jenkins build on grinder: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/37960