### PR TITLE
Re-exclude StackWalker/CallerSensitiveMethod/Main.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -94,6 +94,7 @@ java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aq
 java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/StackWalker/ReflectionFrames.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/StackWalker/VerifyStackTrace.java https://github.com/adoptium/aqa-tests/issues/1273 generic-all
+java/lang/StackWalker/CallerSensitiveMethod/Main.java https://github.com/eclipse-openj9/openj9/issues/18696 generic-all
 java/lang/String/CaseConvertSameInstance.java https://github.com/eclipse-openj9/openj9/issues/6672 generic-all
 java/lang/String/CaseInsensitiveComparator.java https://github.com/eclipse-openj9/openj9/issues/6665 generic-all
 java/lang/String/CompactString/IndexOf.java  https://github.com/eclipse-openj9/openj9/issues/6673 generic-all

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -94,6 +94,7 @@ java/lang/StackWalker/LocalsAndOperands.java#id0  https://github.com/adoptium/aq
 java/lang/StackWalker/LocalsAndOperands.java#id1  https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/StackWalker/ReflectionFrames.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/StackWalker/VerifyStackTrace.java https://github.com/adoptium/aqa-tests/issues/1273 generic-all
+java/lang/StackWalker/CallerSensitiveMethod/Main.java https://github.com/eclipse-openj9/openj9/issues/18696 generic-all
 java/lang/String/CaseConvertSameInstance.java https://github.com/eclipse-openj9/openj9/issues/6672 generic-all
 java/lang/String/CaseInsensitiveComparator.java https://github.com/eclipse-openj9/openj9/issues/6665 generic-all
 java/lang/String/CompactString/IndexOf.java  https://github.com/eclipse-openj9/openj9/issues/6673 generic-all


### PR DESCRIPTION
This reverts commit 63c7c9edda33c0a9a186b87fc533eb9fb71b6fa8.

eclipse-openj9/openj9#18926 was reverted and eclipse-openj9/openj9#18696 was reopened.