### PR TITLE
Include LogGeneratedClassesTest on openj9 for jdk11+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -98,7 +98,6 @@ java/lang/invoke/VarargsArrayTest.java	https://github.com/adoptium/aqa-tests/iss
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse-openj9/openj9/issues/7158	aix-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse-openj9/openj9/issues/3394	generic-all
-java/lang/invoke/lambda/LogGeneratedClassesTest.java https://github.com/eclipse-openj9/openj9/issues/18556 generic-all
 java/lang/ref/CleanerTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ref/EarlyTimeout.java	https://github.com/eclipse-openj9/openj9/issues/7225	generic-all
 java/lang/ref/FinalizeOverride.java	https://github.com/eclipse-openj9/openj9/issues/9651	generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -98,7 +98,6 @@ java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://g
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/condy/CondyNestedResolutionTest.java	https://github.com/eclipse-openj9/openj9/issues/7158	aix-all
 java/lang/invoke/lambda/LambdaStackTrace.java	https://github.com/eclipse-openj9/openj9/issues/3394	generic-all
-java/lang/invoke/lambda/LogGeneratedClassesTest.java https://github.com/eclipse-openj9/openj9/issues/18556 generic-all
 java/lang/ref/CleanerTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ref/EarlyTimeout.java	https://github.com/eclipse-openj9/openj9/issues/7225	generic-all
 java/lang/ref/FinalizeOverride.java	https://github.com/eclipse-openj9/openj9/issues/9651	generic-all

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -41,7 +41,6 @@ java/lang/invoke/condy/CondyNestedResolutionTest.java https://github.com/eclipse
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/FindAccessTest.java  https://github.com/eclipse-openj9/openj9/issues/6868 generic-all
 java/lang/invoke/lambda/LambdaStackTrace.java https://github.com/eclipse-openj9/openj9/issues/3394 generic-all
-java/lang/invoke/lambda/LogGeneratedClassesTest.java https://github.com/eclipse-openj9/openj9/issues/18556 generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java https://github.com/eclipse-openj9/openj9/issues/7043 generic-all
 java/lang/invoke/PrivateInvokeTest.java https://github.com/eclipse-openj9/openj9/issues/7071 generic-all

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -41,7 +41,6 @@ java/lang/invoke/condy/CondyNestedResolutionTest.java https://github.com/eclipse
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/FindAccessTest.java  https://github.com/eclipse-openj9/openj9/issues/6868 generic-all
 java/lang/invoke/lambda/LambdaStackTrace.java https://github.com/eclipse-openj9/openj9/issues/3394 generic-all
-java/lang/invoke/lambda/LogGeneratedClassesTest.java https://github.com/eclipse-openj9/openj9/issues/18556 generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java https://github.com/eclipse-openj9/openj9/issues/7043 generic-all
 java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java https://github.com/eclipse-openj9/openj9/issues/18805 generic-all

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -41,7 +41,6 @@ java/lang/invoke/condy/CondyNestedResolutionTest.java https://github.com/eclipse
 java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/openj9/issues/4127 linux-ppc64le
 java/lang/invoke/FindAccessTest.java  https://github.com/eclipse-openj9/openj9/issues/6868 generic-all
 java/lang/invoke/lambda/LambdaStackTrace.java https://github.com/eclipse-openj9/openj9/issues/3394 generic-all
-java/lang/invoke/lambda/LogGeneratedClassesTest.java https://github.com/eclipse-openj9/openj9/issues/18556 generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java https://github.com/eclipse-openj9/openj9/issues/7043 generic-all
 java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java https://github.com/eclipse-openj9/openj9/issues/18805 generic-all


### PR DESCRIPTION
Depends-on: https://github.com/eclipse-openj9/openj9/pull/18968
Issue: https://github.com/eclipse-openj9/openj9/issues/18556
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>