### PR TITLE
[Jtreg/FFI] Disable TestAddressDereference in JDK22+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -509,6 +509,7 @@ java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issue
 java/foreign/nested/TestNested.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
 java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
+java/foreign/TestAddressDereference.java https://github.com/eclipse-openj9/openj9/issues/18999 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -509,6 +509,7 @@ java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issue
 java/foreign/nested/TestNested.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
 java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
+java/foreign/TestAddressDereference.java https://github.com/eclipse-openj9/openj9/issues/18999 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The change disables the failing FFI test suite detected
in JDK22+ for the moment and will be re-enabled once the
issue is resolved.

Related: #eclipse-openj9/openj9/issues/18999

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>