### PR TITLE
Exclude krb5/auto/rcache_usemd5.sh on openj9 jdk8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -296,6 +296,7 @@ sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java	https://github.com/
 ############################################################################
 # jdk_security4
 
+sun/security/krb5/auto/rcache_usemd5.sh https://github.com/eclipse-openj9/openj9/issues/18980 linux-all
 sun/security/krb5/auto/ReplayCacheTestProc.java https://github.com/adoptium/aqa-tests/issues/2349 generic-all
 sun/security/krb5/auto/Unreachable.java https://github.com/eclipse-openj9/openj9/issues/13253 aix-all,macosx-all
 


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/18980