### PR TITLE
[Jtreg/FFI] Enable the heap related test suites in JDK22+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -499,7 +499,6 @@ java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/open
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
-java/foreign/critical/TestCritical.java https://github.com/eclipse-openj9/openj9/issues/18939 generic-all
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
 java/foreign/TestDowncallScope.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
 java/foreign/TestDowncallStack.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
@@ -509,7 +508,6 @@ java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issue
 java/foreign/nested/TestNested.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
 java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
-java/foreign/TestAddressDereference.java https://github.com/eclipse-openj9/openj9/issues/18999 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -499,7 +499,6 @@ java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/open
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
-java/foreign/critical/TestCritical.java https://github.com/eclipse-openj9/openj9/issues/18939 generic-all
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
 java/foreign/TestDowncallScope.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
 java/foreign/TestDowncallStack.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
@@ -509,7 +508,6 @@ java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issue
 java/foreign/nested/TestNested.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
 java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
-java/foreign/TestAddressDereference.java https://github.com/eclipse-openj9/openj9/issues/18999 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The changes enable the heap related test suites in JDK22+
given the problems with the tests are resolved via:
[1] https://github.com/eclipse-openj9/openj9/pull/18930
[2] https://github.com/eclipse-openj9/openj9/pull/19002

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>