### PR TITLE
Use CRIU 0.43.0-release for docker based CRIU tests

### DIFF
--- a/external/dockerfile_functions.sh
+++ b/external/dockerfile_functions.sh
@@ -397,7 +397,7 @@ print_criu_install() {
                 "\n\t&& git clone https://github.com/ibmruntimes/criu.git \\" \
                 "\n\t&& cd criu \\" \
                 "\n\t&& git fetch origin \\" \
-                "\n\t&& git reset --hard origin/0.40-release \\" \
+                "\n\t&& git reset --hard origin/0.43.0-release \\" \
                 "\n\t&& make PREFIX=/usr install \\" \
                 "\n\t&& criu -V " \
                 "\n" >> ${file}


### PR DESCRIPTION
Use `CRIU` `0.43.0-release` for docker based `CRIU` tests

`0.43.0-release` is the latest `ibmruntimes/criu` release.

Related to [backlog/issues/1315](https://github.ibm.com/runtimes/backlog/issues/1315)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>