### PR TITLE
Remove redundant exclusions of pkcs11 tests on jdk8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -240,13 +240,11 @@ java/security/KeyPairGenerator/SolarisShortDSA.java https://github.com/adoptium/
 java/security/MessageDigest/TestDigestIOStream.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 javax/xml/crypto/dsig/LineFeedOnlyTest.java https://github.com/adoptium/aqa-tests/issues/2356 windows-all
 sun/security/pkcs11/KeyStore/SecretKeysBasic.sh https://bugs.openjdk.java.net/browse/JDK-8189603 linux-all,macosx-all,windows-all
-sun/security/pkcs11/Secmod/AddTrustedCert.java https://github.com/adoptium/aqa-tests/issues/125 linux-all
 sun/security/pkcs11/Signature/TestDSAKeyLength.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
 sun/security/pkcs11/ec/TestECDH.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
 sun/security/pkcs11/ec/TestECDSA.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
 sun/security/pkcs11/ec/TestECGenSpec.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
 sun/security/pkcs11/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/issues/68 linux-all
-sun/security/pkcs11/tls/TestKeyMaterial.java https://github.com/adoptium/aqa-tests/issues/71 linux-all
 sun/security/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/issues/68 generic-all
 com/sun/crypto/provider/Mac/MacClone.java https://bugs.openjdk.java.net/browse/JDK-7087021 solaris-all
 javax/net/ssl/ServerName/BestEffortOnLazyConnected.java https://bugs.openjdk.org/browse/JDK-8155049 solaris-x64


### PR DESCRIPTION
These 2 tests were [problem listed ](https://github.com/openjdk/jdk8u/commit/8ee57825da3b49e86ca6a076d8b5625e3164a57d) in upstream jdk8u by [JDK-8195667](https://bugs.openjdk.org/browse/JDK-8195667):
```
sun/security/pkcs11/Secmod/AddTrustedCert.java
sun/security/pkcs11/tls/TestKeyMaterial.java
```
No longer need to be excluded here.