### PR TITLE
Problem list excludes for 5070 and 5097

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -232,7 +232,7 @@ java/rmi/activation/Activatable/nonExistentActivatable/NonExistentActivatable.ja
 
 ############################################################################
 
-# jdk_security
+# jdk_security1
 
 com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
@@ -256,6 +256,7 @@ sun/security/pkcs11/KeyStore/ClientAuth.sh https://bugs.openjdk.org/browse/JDK-7
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java https://bugs.openjdk.org/browse/JDK-8042583 solaris-x64
 sun/security/pkcs11/fips/ClientJSSEServerJSSE.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
 sun/security/ssl/SSLSocketImpl/AsyncSSLSocketClose.java https://bugs.openjdk.org/browse/JDK-8224829 solaris-x64
+java/security/cert/CertPathBuilder/akiExt/AKISerialNumber.java https://bugs.openjdk.org/browse/JDK-8325096 linux-arm
 
 ############################################################################
 

--- a/openjdk/excludes/vendors/azul/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/vendors/azul/ProblemList_openjdk8.txt
@@ -71,7 +71,7 @@ java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/a
 ############################################################################
 
 # jdk_security1
-java/security/Provider/ProviderVersionCheck.java
+java/security/Provider/ProviderVersionCheck.java https://github.com/adoptium/aqa-tests/issues/2826 generic-all
 
 ############################################################################
 # jdk_security2


### PR DESCRIPTION
Fixes #5070 
- Fix azul entry to have an issue and platform related to it

Fixes #5097 
- exclude AKISerialNumber on JDK8 arm_linux where fix is not yet ported to aarch32 branch