### PR TITLE
Temporarily disable criu test on rhel9 skylake

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -176,7 +176,7 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.amd"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.skylake"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.amd"],
-                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.skylake"]
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.broadwell"]
                     ],
             'aarch64_linux' : [
                         // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.20"],

--- a/external/criuSettings.mk
+++ b/external/criuSettings.mk
@@ -13,8 +13,8 @@
 ##############################################################################
 
 # - is shell metacharacter. In PLATFORM value, replace - with _
-export CRIU_COMBO_LIST_linux_x86_64=sw.os.ubuntu.22-hw.arch.x86.broadwell sw.os.ubuntu.22-hw.arch.x86.amd sw.os.rhel.8-hw.arch.x86.broadwell sw.os.rhel.8-hw.arch.x86.amd sw.os.rhel.8-hw.arch.x86.skylake sw.os.rhel.9-hw.arch.x86.amd sw.os.rhel.9-hw.arch.x86.skylake
-# not available: sw.os.ubuntu.22-hw.arch.x86.skylake sw.os.rhel.9-hw.arch.x86.broadwell
+export CRIU_COMBO_LIST_linux_x86_64=sw.os.ubuntu.22-hw.arch.x86.broadwell sw.os.ubuntu.22-hw.arch.x86.amd sw.os.rhel.8-hw.arch.x86.broadwell sw.os.rhel.8-hw.arch.x86.amd sw.os.rhel.8-hw.arch.x86.skylake sw.os.rhel.9-hw.arch.x86.amd sw.os.rhel.9-hw.arch.x86.broadwell
+# not available: sw.os.ubuntu.22-hw.arch.x86.skylake sw.os.rhel.9-hw.arch.skylake
 
 export CRIU_COMBO_LIST_linux_390_64_z13=sw.os.ubuntu.22-hw.arch.s390x.z13 sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
 # not available: sw.os.rhel.8-hw.arch.s390x.z13


### PR DESCRIPTION
- Since rhel 9 skylake machine is missing, temporarily disable it from pipeline
- Related Issue: runtimes_infrastructure 8970