### PR TITLE
Exclude sanity.external targets for 22+

### DIFF
--- a/external/openliberty-mp-tck/playlist.xml
+++ b/external/openliberty-mp-tck/playlist.xml
@@ -74,6 +74,11 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/3381#issuecomment-1082095158</comment>
 				<version>17</version>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5117</comment>
+				<version>22+</version>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir openliberty-mp-tck --reportsrc /testResults/surefire-reports --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
                 $(TEST_STATUS); \

--- a/external/quarkus/playlist.xml
+++ b/external/quarkus/playlist.xml
@@ -26,6 +26,11 @@
 				<version>11+</version>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5117</comment>
+				<version>22+</version>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir quarkus --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
 		$(TEST_STATUS); \

--- a/external/quarkus_quickstarts/playlist.xml
+++ b/external/quarkus_quickstarts/playlist.xml
@@ -26,6 +26,11 @@
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5117</comment>
+				<version>22+</version>
+				<impl>hotspot</impl>
+			</disable>
+			<disable>
 				<comment>github_ibm/runtimes/backlog/issues/776 1169</comment>
 				<impl>openj9</impl>
 			</disable>


### PR DESCRIPTION
Related: https://github.com/adoptium/aqa-tests/issues/5117

Temporarily disable these test targets (re-enable once official Temurin Docker images become available) 