### PR TITLE
Update excluded JFR tests in JDK8 ProblemList with proper links to upstream JBS issues

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -414,7 +414,7 @@ jdk/jfr/event/sampling/TestNative.java https://github.com/adoptium/aqa-tests/iss
 jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java https://github.com/adoptium/aqa-tests/issues/2766 generic-all
 # jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/2985 generic-all
-jdk/jfr/event/compiler/TestCompilerPhase.java https://github.com/adoptium/aqa-tests/issues/3045 generic-all
+jdk/jfr/event/compiler/TestCompilerPhase.java https://bugs.openjdk.org/browse/JDK-8326521 generic-all
 jdk/jfr/event/compiler/TestCompile.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/collection/TestGCCauseWithG1ConcurrentMark.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/collection/TestGCCauseWithG1FullCollection.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
@@ -437,7 +437,7 @@ jdk/jfr/event/runtime/TestSizeTFlags.java https://github.com/adoptium/aqa-tests/
 jdk/jfr/jvm/TestLargeJavaEvent512k.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/compiler/TestCodeSweeper.java https://github.com/adoptium/aqa-tests/issues/3043 macosx-all,windows-all
 jdk/jfr/event/compiler/TestCodeCacheFull.java https://github.com/adoptium/aqa-tests/issues/3042 macosx-all,windows-all
-jdk/jfr/event/compiler/TestCompilerCompile.java https://github.com/adoptium/aqa-tests/issues/3046 generic-all
+jdk/jfr/event/compiler/TestCompilerCompile.java https://bugs.openjdk.org/browse/JDK-8326529 generic-all
 jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventDefNewSerial.java https://github.com/adoptium/aqa-tests/issues/3254 solaris-sparcv9
 jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventPSParOld.java https://github.com/adoptium/aqa-tests/issues/3254 solaris-sparcv9
 jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventPSSerial.java https://github.com/adoptium/aqa-tests/issues/3254 solaris-sparcv9


### PR DESCRIPTION
I've created upstream PRs for fixing `TestCompilerCompile` and `TestCompilerPhase`. The PR for `TestCompilerCompile` has been [merged](https://github.com/openjdk/jdk/pull/18010), but will take a while to backport ([because I need to do it for 22, 21, 17, 11, then finally 8](https://github.com/openjdk/jdk8u-dev/pull/463#issuecomment-1972052026)). Since, it might take some time to backport and the fix only affects the test, the best temporary solution is probably to keep the test excluded. So for now I'd just like to update the ProblemList links to point to the correct JBS issues so people can understand why these tests must be disabled.  