### PR TITLE
jck: run riscv tests in headless mode

### DIFF
--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -532,7 +532,7 @@ public class JavatestUtil {
 			}
 
 			if ( testsRequireDisplay(tests) ) {
-				if (spec.contains("zos") || spec.contains("alpine-linux")) {
+				if (spec.contains("zos") || spec.contains("alpine-linux") || spec.contains("riscv")) {
 					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
 				}
 				else {


### PR DESCRIPTION
For now we are only shipping a headless build for riscv64