### PR TITLE
Disabled NaN-related tests on RISC-V more broadly

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -330,7 +330,6 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
-				<version>17+</version>
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -43,7 +43,6 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
-				<version>17+</version>
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
@@ -91,7 +90,6 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
-				<version>17+</version>
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
@@ -118,7 +116,6 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
-				<version>17+</version>
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -42,7 +42,6 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
-				<version>17+</version>
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
@@ -76,7 +75,6 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
-				<version>17+</version>
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
@@ -185,7 +183,6 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
-				<version>17+</version>
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>


### PR DESCRIPTION
The issue is not related with the version of the JDK, but rather with how the RISC-V architecture handles NaN and the expectations of the test.