### PR TITLE
Move custom targets to dev level

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -25,7 +25,7 @@
 		$(GEN_SUMMARY_GENERIC) testsuite=COMPILER tests="$(JCKCOMPILER_CUSTOM_TARGET)" isCustomTarget="isCustomTarget"
 		</command>
 		<levels>
-			<level>extended</level>
+			<level>dev</level>
 		</levels>
 		<groups>
 			<group>jck</group>

--- a/jck/devtools.java2schema/playlist.xml
+++ b/jck/devtools.java2schema/playlist.xml
@@ -24,7 +24,7 @@
 		$(GEN_SUMMARY_GENERIC) testsuite=DEVTOOLS tests="$(JCKDEVTOOLS_CUSTOM_TARGET)" isCustomTarget="isCustomTarget"
 		</command>
 		<levels>
-			<level>extended</level>
+			<level>dev</level>
 		</levels>
 		<groups>
 			<group>jck</group>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -25,7 +25,7 @@
 		$(GEN_SUMMARY_GENERIC) testsuite=RUNTIME tests="$(JCKRUNTIME_CUSTOM_TARGET)" isCustomTarget="isCustomTarget"
 		</command>
 		<levels>
-			<level>extended</level>
+			<level>dev</level>
 		</levels>
 		<groups>
 			<group>jck</group>


### PR DESCRIPTION
So the custom targets do not need to run as part of an extended job, move them from extended to dev level.