### PR TITLE
OpenJCEPlusFIPS testing for Java 21, 22 and s390x

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -106,7 +106,7 @@ def setupEnv() {
 	NUM_MACHINES = params.NUM_MACHINES ? params.NUM_MACHINES.toInteger() : 1
 	env.LIB_DIR="${WORKSPACE}/../../testDependency/lib"
 	env.OPENJCEPLUS_GIT_REPO = params.OPENJCEPLUS_GIT_REPO ?: "https://github.com/IBM/OpenJCEPlus.git"
-	env.OPENJCEPLUS_GIT_BRANCH = params.OPENJCEPLUS_GIT_BRANCH ?: "main"
+	env.OPENJCEPLUS_GIT_BRANCH = params.OPENJCEPLUS_GIT_BRANCH ?: "java${params.JDK_VERSION}"
 
 
 	if (JOB_NAME.contains("Grinder")) {

--- a/functional/OpenJcePlusTests/build.xml
+++ b/functional/OpenJcePlusTests/build.xml
@@ -51,7 +51,7 @@
 			<property name="openjceplusGitBranch" value="${env.OPENJCEPLUS_GIT_BRANCH}"/>
 		</then>
 		<else>
-			<property name="openjceplusGitBranch" value="main"/>
+			<property name="openjceplusGitBranch" value="java${JDK_VERSION}"/>
 		</else>
 	</if>
 
@@ -111,12 +111,15 @@
 				<and>
 					<equals arg1="${JDK_VENDOR}" arg2="ibm" />
 					<equals arg1="${JDK_IMPL}" arg2="openj9" />
-					<equals arg1="${JDK_VERSION}" arg2="17" />
+					<not>
+						<matches string="${JDK_VERSION}" pattern="^(8|11)$$" />
+					</not>
 					<or>
 						<contains string="${SPEC}" substring="aix_ppc-64"/>
 						<contains string="${SPEC}" substring="linux_ppc-64_le"/>
 						<contains string="${SPEC}" substring="linux_x86-64"/>
 						<contains string="${SPEC}" substring="win_x86-64"/>
+						<contains string="${SPEC}" substring="linux_390-64"/>
 					</or>
 				</and>
 			</or>

--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -21,8 +21,8 @@
 				<vendor>eclipse</vendor>
 			</disable>
 			<disable>
-				<comment>Only applicable on aix, pliunx, xlinux and wins64 atm</comment>
-				<platform>^((?!(ppc64_aix|ppc64le_linux|x86-64_linux|x86-64_windows)).)*$</platform>
+				<comment>Only applicable on aix, pliunx, xlinux, wins64 and zlinux atm</comment>
+				<platform>^((?!(ppc64_aix|ppc64le_linux|x86-64_linux|x86-64_windows|s390x_linux)).)*$</platform>
 			</disable>
 		</disables>
 		<command>ant -f ${BUILD_ROOT}/functional/OpenJcePlusTests/test.xml -DTEST_JAVA=$(Q)$(JAVA_COMMAND)$(Q) launch_test; \
@@ -34,7 +34,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>17</version>
+			<version>17+</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>


### PR DESCRIPTION
The OpenJCEPlus provider is now being bunlded on Java 21 and Java 22 releases. In addition the s390x platform also now bundles OpenJCEPlus on Java 17, 21, and 22.