### PR TITLE
[FFI/JTReg] Enable the AIX related test suites on JDK22+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -498,13 +498,6 @@ java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
-java/foreign/TestDowncallScope.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
-java/foreign/TestDowncallStack.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
-java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/18941 aix-all
-java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
-java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
-java/foreign/nested/TestNested.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
-java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -498,13 +498,6 @@ java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
-java/foreign/TestDowncallScope.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
-java/foreign/TestDowncallStack.java https://github.com/eclipse-openj9/openj9/issues/18940 aix-all
-java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/18941 aix-all
-java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
-java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
-java/foreign/nested/TestNested.java https://github.com/eclipse-openj9/openj9/issues/18942 aix-all
-java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/18943 aix-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
 
 ############################################################################


### PR DESCRIPTION
The changes enable the FFI specific test suites excluded
on AIX previously given the issues with the alignment
setting for double on AIX has been resolved by removing
the pragma lines in the test code to accommodate our
own code with the 4-byte alignment on double.

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>