### PR TITLE
Enable FinalWrapper for platforms

### DIFF
--- a/system/jcstress/playlist.xml
+++ b/system/jcstress/playlist.xml
@@ -394,6 +394,7 @@
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/16569</comment>
 				<impl>openj9</impl>
+				<platform>.*(aarch64_mac|ppc64_aix).*</platform>
 				<version>8+</version>
 			</disable>
 		</disables>


### PR DESCRIPTION
* Enabled FinalWrapper test for platforms other than aarch64_mac and ppc64_aix for openj9.

related: https://github.com/eclipse-openj9/openj9/issues/16569