### PR TITLE
Adoptopenjdk_repo can only be changed in grinders

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -227,7 +227,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeader('Repositories where we pull test material from. Unless you are testing test code, these do not need to be changed.')
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
-							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. Can only be changed in grinders and generated child jobs.")
+							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. Changes will only be used in grinders and generated child jobs.")
 							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch.")
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")
 							stringParam('OPENJ9_BRANCH', "master", "OpenJ9 branch")

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -227,8 +227,8 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeader('Repositories where we pull test material from. Unless you are testing test code, these do not need to be changed.')
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
-							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos.")
-							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch")
+							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. Can only be changed in grinders.")
+							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch. Can only be changed in grinders.")
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")
 							stringParam('OPENJ9_BRANCH', "master", "OpenJ9 branch")
 							stringParam('OPENJ9_SHA', "", "OpenJ9 sha")

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -227,7 +227,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeader('Repositories where we pull test material from. Unless you are testing test code, these do not need to be changed.')
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
-							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. Changes will only be used in grinders and generated child jobs.")
+							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. New values will only be used in grinders and generated child jobs.")
 							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch")
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")
 							stringParam('OPENJ9_BRANCH', "master", "OpenJ9 branch")

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -227,8 +227,8 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeader('Repositories where we pull test material from. Unless you are testing test code, these do not need to be changed.')
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
-							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. Can only be changed in grinders.")
-							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch. Can only be changed in grinders.")
+							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. Can only be changed in grinders and generated child jobs.")
+							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch.")
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")
 							stringParam('OPENJ9_BRANCH', "master", "OpenJ9 branch")
 							stringParam('OPENJ9_SHA', "", "OpenJ9 sha")

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -227,7 +227,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeader('Repositories where we pull test material from. Unless you are testing test code, these do not need to be changed.')
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
-							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. New values will only be used in grinders and generated child jobs.")
+							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. Note: New values will only be used in grinders and generated child jobs.")
 							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch")
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")
 							stringParam('OPENJ9_BRANCH', "master", "OpenJ9 branch")

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -228,7 +228,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
 							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos. Changes will only be used in grinders and generated child jobs.")
-							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch.")
+							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch")
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")
 							stringParam('OPENJ9_BRANCH', "master", "OpenJ9 branch")
 							stringParam('OPENJ9_SHA', "", "OpenJ9 sha")


### PR DESCRIPTION
This change is to alert jenkins users that non-grinder test jobs will ignore any changes to these two variables.