### PR TITLE
Add external criu-functional-softmx test

### DIFF
--- a/external/criu-functional/build.xml
+++ b/external/criu-functional/build.xml
@@ -15,7 +15,29 @@
 		<mkdir dir="${DEST}"/>
 	</target>
 
-	<target name="dist" depends="move_scripts,clean_image,build_image" description="generate the distribution">
+	<target name="prepare_base_image" depends="move_scripts,clean_image" description="prepare the base image">
+		<echo message="Executing external.sh --prepare --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} --base_docker_registry_url 'docker.io' --base_docker_registry_dir 'default' --docker_args ${extra_docker_args} " />
+		<exec executable="bash" failonerror="true">
+			<arg value="${DEST_EXTERNAL}/external.sh"/>
+			<arg value="--prepare"/>
+			<arg value="--dir"/>
+			<arg value="${TEST}"/>
+			<arg value="--tag"/>
+			<arg value="${dockerImageTag}"/>
+			<arg value="--version"/>
+			<arg value="${JDK_VERSION}"/>
+			<arg value="--impl"/>
+			<arg value="${JDK_IMPL}"/>
+			<arg value="--base_docker_registry_url"/>
+			<arg value="docker.io"/>
+			<arg value="--base_docker_registry_dir"/>
+			<arg value="default"/>
+			<arg value="--docker_args"/>
+			<arg value="${extra_docker_args}"/>
+		</exec>
+	</target>
+
+	<target name="dist" depends="prepare_base_image,build_image" description="generate the distribution">
 		<copy todir="${DEST}">
 			<fileset dir="${src}" includes="*.xml, *.mk"/>
 		</copy>

--- a/external/criu-functional/playlist.xml
+++ b/external/criu-functional/playlist.xml
@@ -32,4 +32,29 @@
 			<group>external</group>
 		</groups>
 	</test>
+	<test>
+		<testCaseName>criu-functional-softmx</testCaseName>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir criu-functional --testtarget "_testList TESTLIST=disabled.cmdLineTester_criu_softmx" --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir criu-functional
+		</command>
+		<disables>
+			<disable>
+				<comment>Only applicable on xlinux, plinux, and zlinux atm</comment>
+				<platform>^((?!(x86-64_linux|ppc64le_linux|s390x_linux)).)*$</platform>
+			</disable>
+		</disables>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
 </playlist>


### PR DESCRIPTION
Depends on another PR: https://github.com/eclipse-openj9/openj9/pull/19134
- Since Softmx test has been added into openj9, add container test for it
- This test currently works only on x p z linux
- Also add dockerhub login function for it