### PR TITLE
Exclude java/nio/channels/DatagramChannel/BasicMulticastTests subtest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -232,6 +232,7 @@ java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/infras
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/BasicMulticastTests.java https://github.ibm.com/runtimes/backlog/issues/966 macosx-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all,linux-s390x
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
@@ -317,7 +318,7 @@ sun/security/mscapi/VeryLongAlias.java	https://github.ibm.com/runtimes/backlog/i
 sun/security/pkcs11/Provider/MultipleLogins.sh	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
 sun/security/pkcs11/Secmod/AddTrustedCert.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
 #sun/security/pkcs12/KeytoolOpensslInteropTest.java is not supported on z/OS
-sun/security/pkcs12/KeytoolOpensslInteropTest.java	https://github.com/adoptium/aqa-tests/issues/1297	z/OS-s390x    
+sun/security/pkcs12/KeytoolOpensslInteropTest.java	https://github.com/adoptium/aqa-tests/issues/1297	z/OS-s390x
 sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java	https://github.ibm.com/runtimes/backlog/issues/809	linux-aarch64
 sun/security/provider/SecureRandom/StrongSecureRandom.java	https://github.ibm.com/runtimes/backlog/issues/809	linux-aarch64
 sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
@@ -335,7 +336,7 @@ sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://gith
 # jdk_security_4
 
 sun/security/krb5/auto/NoAddresses.java https://github.com/adoptium/aqa-tests/issues/4566 z/OS-s390x
- 
+
 ######################################################################################################
 
 # jdk_security_infra


### PR DESCRIPTION
-Exclude `java/nio/channels/DatagramChannel/BasicMulticastTests.java` for mac platform

related:https://github.ibm.com/runtimes/backlog/issues/966 related:https://github.ibm.com/runtimes/backlog/issues/1053