### PR TITLE
Allow OpenJCEPlus test execution with Java 11

### DIFF
--- a/functional/OpenJcePlusTests/build.xml
+++ b/functional/OpenJcePlusTests/build.xml
@@ -112,7 +112,7 @@
 					<equals arg1="${JDK_VENDOR}" arg2="ibm" />
 					<equals arg1="${JDK_IMPL}" arg2="openj9" />
 					<not>
-						<matches string="${JDK_VERSION}" pattern="^(8|11)$$" />
+						<matches string="${JDK_VERSION}" pattern="^(8)$$" />
 					</not>
 					<or>
 						<contains string="${SPEC}" substring="aix_ppc-64"/>

--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -34,7 +34,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>17+</version>
+			<version>11+</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>


### PR DESCRIPTION
Java 11 now includes the OpenJCEPlus module and should be tested accordingly similar to other Java releases.