### PR TITLE
riscv64 should not attempt robot tests

### DIFF
--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -486,10 +486,7 @@ public class JavatestUtil {
 			if (spec.contains("win")) {
 				libPath = "PATH";
 				robotAvailable = "Yes";
-			} else if (spec.contains("alpine-linux")) {
-				libPath = "LD_LIBRARY_PATH";
-				robotAvailable = "No";
-			} else if (spec.contains("riscv64")) {
+			} else if (spec.contains("alpine-linux") || spec.contains("riscv64")) {
 				libPath = "LD_LIBRARY_PATH";
 				robotAvailable = "No";
 			} else if (spec.contains("linux")) {

--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -489,6 +489,9 @@ public class JavatestUtil {
 			} else if (spec.contains("alpine-linux")) {
 				libPath = "LD_LIBRARY_PATH";
 				robotAvailable = "No";
+			} else if (spec.contains("riscv64")) {
+				libPath = "LD_LIBRARY_PATH";
+				robotAvailable = "No";
 			} else if (spec.contains("linux")) {
 				libPath = "LD_LIBRARY_PATH";
 				robotAvailable = "Yes";


### PR DESCRIPTION
This fixes failures caused by invalid `jti` files being created on the platform, preventing some of the suites from executing correctly.

I'm open to options here but this is the simplest that fits in with the current format of this "switch" statement.

Alternatives if reviewers wish to consider them:
- Split out the if clauses to set robot and libpath separately which might be neater
- Add the riscv64 check as an `or` into the Alpine one