### PR TITLE
Exclude jdk_other,jdk_rmi subtests on all versions

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -249,11 +249,13 @@ java/nio/file/Files/probeContentType/Basic.java https://github.com/eclipse-openj
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse-openj9/openj9/issues/7592	generic-all
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse-openj9/openj9/issues/8515	generic-all
-java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java   https://github.com/eclipse-openj9/openj9/issues/13259   aix-all
+#java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java on windows-x64 issue https://github.ibm.com/runtimes/backlog/issues/1024
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java   https://github.com/eclipse-openj9/openj9/issues/13259  aix-all,windows-x64
 java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse-openj9/openj9/issues/3377	generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse-openj9/openj9/issues/4094 generic-all
 java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
+java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java https://github.com/eclipse-openj9/openj9/issues/12948 windows-x64
 
 ############################################################################
 
@@ -362,6 +364,8 @@ java/util/zip/ZipFile/TestCleaner.java	https://github.com/eclipse-openj9/openj9/
 
 # jdk_other
 
+com/sun/jndi/dns/ConfigTests/Timeout.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
+com/sun/jndi/dns/ConfigTests/PortUnreachable.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java	https://github.ibm.com/runtimes/backlog/issues/655	windows-all
 jdk/internal/misc/VM/GetNanoTimeAdjustment.java		https://github.com/eclipse-openj9/openj9/issues/7184		generic-all
 jdk/internal/misc/VM/RuntimeArguments.java		https://github.com/eclipse-openj9/openj9/issues/7186		generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -264,10 +264,12 @@ java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse-openj9/openj9/issues/7592	generic-all
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse-openj9/openj9/issues/8515	generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java  https://github.ibm.com/runtimes/backlog/issues/1024 windows-x64
 java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse-openj9/openj9/issues/3377	generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse-openj9/openj9/issues/4094 generic-all
 java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
+java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java https://github.com/eclipse-openj9/openj9/issues/12948 windows-x64
 
 ############################################################################
 
@@ -398,6 +400,8 @@ java/util/Random/RandomTestBsi1999.java		https://github.com/eclipse-openj9/openj
 
 # jdk_other
 
+com/sun/jndi/dns/ConfigTests/Timeout.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
+com/sun/jndi/dns/ConfigTests/PortUnreachable.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java  https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -337,9 +337,11 @@ java/rmi/dgc/dgcAckFailure/DGCAckFailure.java https://github.com/eclipse-openj9/
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java https://github.com/eclipse-openj9/openj9/issues/7592 generic-all
 java/rmi/server/RemoteServer/AddrInUse.java  https://github.com/eclipse-openj9/openj9/issues/3377 generic-all
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java https://github.com/eclipse-openj9/openj9/issues/8515 generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java  https://github.ibm.com/runtimes/backlog/issues/1024 windows-x64
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse-openj9/openj9/issues/4094 generic-all
 java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
+java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java https://github.com/eclipse-openj9/openj9/issues/12948 windows-x64
 
 ############################################################################
 
@@ -456,6 +458,8 @@ java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/
 
 # jdk_other
 
+com/sun/jndi/dns/ConfigTests/Timeout.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
+com/sun/jndi/dns/ConfigTests/PortUnreachable.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 javax/rmi/ssl/SSLSocketParametersTest.java https://github.com/eclipse-openj9/openj9/issues/12168 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -339,9 +339,11 @@ java/rmi/dgc/dgcAckFailure/DGCAckFailure.java https://github.com/eclipse-openj9/
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java https://github.com/eclipse-openj9/openj9/issues/7592 generic-all
 java/rmi/server/RemoteServer/AddrInUse.java  https://github.com/eclipse-openj9/openj9/issues/3377 generic-all
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java https://github.com/eclipse-openj9/openj9/issues/8515 generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java  https://github.ibm.com/runtimes/backlog/issues/1024 windows-x64
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse-openj9/openj9/issues/4094 generic-all
 java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
+java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java https://github.com/eclipse-openj9/openj9/issues/12948 windows-x64
 
 ############################################################################
 
@@ -458,6 +460,8 @@ java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/
 
 # jdk_other
 
+com/sun/jndi/dns/ConfigTests/Timeout.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
+com/sun/jndi/dns/ConfigTests/PortUnreachable.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 javax/rmi/ssl/SSLSocketParametersTest.java https://github.com/eclipse-openj9/openj9/issues/12168 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -339,9 +339,11 @@ java/rmi/dgc/dgcAckFailure/DGCAckFailure.java https://github.com/eclipse-openj9/
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java https://github.com/eclipse-openj9/openj9/issues/7592 generic-all
 java/rmi/server/RemoteServer/AddrInUse.java  https://github.com/eclipse-openj9/openj9/issues/3377 generic-all
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java https://github.com/eclipse-openj9/openj9/issues/8515 generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java   https://github.ibm.com/runtimes/backlog/issues/1024  windows-x64
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse-openj9/openj9/issues/4094 generic-all
 java/rmi/server/UnicastServerRef/serialFilter/FilterUSRTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
+java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java https://github.com/eclipse-openj9/openj9/issues/12948 windows-x64
 
 ############################################################################
 
@@ -458,6 +460,8 @@ java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/
 
 # jdk_other
 
+com/sun/jndi/dns/ConfigTests/Timeout.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
+com/sun/jndi/dns/ConfigTests/PortUnreachable.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 javax/rmi/ssl/SSLSocketParametersTest.java https://github.com/eclipse-openj9/openj9/issues/12168 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all

--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -237,8 +237,10 @@ java/rmi/registry/serialFilter/RegistryFilterTest.java		https://github.com/eclip
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java	https://github.com/eclipse-openj9/openj9/issues/4094	generic-all
 java/rmi/server/RMISocketFactory/useSocketFactory/activatable/UseCustomSocketFactory.java	https://github.com/eclipse-openj9/openj9/issues/4685	linux-ppc64le
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse-openj9/openj9/issues/8515	generic-all
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java   https://github.ibm.com/runtimes/backlog/issues/1024 windows-x64
 java/rmi/server/RemoteObject/notExtending/NotExtending.java		https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
 java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse-openj9/openj9/issues/3377	generic-all
+java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java https://github.com/eclipse-openj9/openj9/issues/12948 windows-x64
 java/rmi/transport/dgcDeadLock/DGCDeadLock.java	https://github.com/adoptium/aqa-tests/issues/1259	macosx-all
 java/rmi/transport/handshakeTimeout/HandshakeTimeout.java	https://github.ibm.com/runtimes/backlog/issues/722	macosx-all
 java/rmi/transport/runtimeThreadInheritanceLeak/RuntimeThreadInheritanceLeak.java		https://github.com/eclipse-openj9/openj9/issues/1144	generic-all


### PR DESCRIPTION
- Exclude `com/sun/jndi/dns/ConfigTests/Timeout` and `com/sun/jndi/dns/ConfigTests/PortUnreachable` subtests for macos and windows_x64.
- Exclude `java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java` for all versions on windows-x64
- Exclude `java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java` for all versions on windows-x64


related:https://github.ibm.com/runtimes/backlog/issues/1287
related:https://github.ibm.com/runtimes/backlog/issues/1024
related:https://github.com/eclipse-openj9/openj9/issues/12948