### PR TITLE
Increase timeout for OpenJcePlusTests

### DIFF
--- a/functional/OpenJcePlusTests/test.xml
+++ b/functional/OpenJcePlusTests/test.xml
@@ -29,7 +29,7 @@
 				fork="true"
 				failonerror="true"
 				dir="${basedir}"
-				timeout="3600000"
+				timeout="7200000"
 				taskname="test">
 			<classpath>
 				<pathelement location="${ant.home}/lib/ant-launcher.jar" />


### PR DESCRIPTION
increase timeout to 2hrs

related: https://github.com/eclipse-openj9/openj9/issues/19200