### PR TITLE
(v1.0.1-release) Increase timeout for OpenJcePlusTests (#5174)

### DIFF
--- a/functional/OpenJcePlusTests/test.xml
+++ b/functional/OpenJcePlusTests/test.xml
@@ -29,7 +29,7 @@
 				fork="true"
 				failonerror="true"
 				dir="${basedir}"
-				timeout="3600000"
+				timeout="7200000"
 				taskname="test">
 			<classpath>
 				<pathelement location="${ant.home}/lib/ant-launcher.jar" />


### PR DESCRIPTION
cherry pick: https://github.com/adoptium/aqa-tests/pull/5174