### PR TITLE
(v1.0.1-release) Exclude java/rmi/Naming tests for macx64 (#5170)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -248,6 +248,8 @@ java/nio/file/Files/probeContentType/Basic.java https://github.com/eclipse-openj
 
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse-openj9/openj9/issues/7592	generic-all
+java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
+java/rmi/Naming/DefaultRegistryPort.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse-openj9/openj9/issues/8515	generic-all
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java   https://github.com/eclipse-openj9/openj9/issues/13259   aix-all
 java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse-openj9/openj9/issues/3377	generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -262,6 +262,8 @@ java/nio/file/Files/probeContentType/Basic.java https://github.com/eclipse-openj
 java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse-openj9/openj9/issues/6749 windows-all
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse-openj9/openj9/issues/7592	generic-all
+java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
+java/rmi/Naming/DefaultRegistryPort.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse-openj9/openj9/issues/8515	generic-all
 java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse-openj9/openj9/issues/3377	generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -335,6 +335,8 @@ java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/adoptiu
 java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse-openj9/openj9/issues/6749 windows-all
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java https://github.com/eclipse-openj9/openj9/issues/7592 generic-all
+java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
+java/rmi/Naming/DefaultRegistryPort.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
 java/rmi/server/RemoteServer/AddrInUse.java  https://github.com/eclipse-openj9/openj9/issues/3377 generic-all
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java https://github.com/eclipse-openj9/openj9/issues/8515 generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -337,6 +337,8 @@ java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/adoptiu
 java/rmi/activation/Activatable/checkAnnotations/CheckAnnotations https://github.com/eclipse-openj9/openj9/issues/6749 windows-all
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java https://github.com/eclipse-openj9/openj9/issues/7592 generic-all
+java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
+java/rmi/Naming/DefaultRegistryPort.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
 java/rmi/server/RemoteServer/AddrInUse.java  https://github.com/eclipse-openj9/openj9/issues/3377 generic-all
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java https://github.com/eclipse-openj9/openj9/issues/8515 generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java https://github.com/eclipse-openj9/openj9/issues/3347 generic-all

--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -232,6 +232,8 @@ java/rmi/activation/CommandEnvironment/SetChildEnv.java		https://github.com/ecli
 java/rmi/activation/rmidViaInheritedChannel/InheritedChannelNotServerSocket.java	https://github.ibm.com/runtimes/backlog/issues/622	windows-all
 java/rmi/dgc/dgcAckFailure/DGCAckFailure.java		https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
 java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java		https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
+java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
+java/rmi/Naming/DefaultRegistryPort.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
 java/rmi/registry/readTest/readTest.sh		https://github.com/eclipse-openj9/openj9/issues/13259	windows-all
 java/rmi/registry/serialFilter/RegistryFilterTest.java		https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java	https://github.com/eclipse-openj9/openj9/issues/4094	generic-all


### PR DESCRIPTION
- Exclude `java/rmi/Naming/legalRegistryNames/LegalRegistryNames` and `java/rmi/Naming/DefaultRegistryPort` tests for versions 8/11/17/21.

related: https://github.ibm.com/runtimes/backlog/issues/867