### PR TITLE
Temporarily exclude cent7 machines for sanity.external

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -297,7 +297,7 @@ timestamps{
                 env.EXTRA_OPTIONS += " -Dsemeru.fips=true -Dsemeru.customprofile=${opts}"
             }
 
-            // Temporarily exclude Cent machines for sanity.external pipeline due to docker issue
+            // Temporarily exclude CentOS 7 machines for sanity.external pipeline due to docker issue
             if (JOB_NAME.contains ("sanity.external")) {
                 LABEL += "&&!sw.os.cent.7"
             }

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -297,9 +297,9 @@ timestamps{
                 env.EXTRA_OPTIONS += " -Dsemeru.fips=true -Dsemeru.customprofile=${opts}"
             }
 
-            // Temporarily exclude ubuntu 22 machines for criu sanity.external pipeline
-            if (JOB_NAME.contains ("sanity.external") && JOB_NAME.contains("_criu")) {
-                LABEL += "&&!sw.os.ubuntu.22"
+            // Temporarily exclude Cent machines for sanity.external pipeline due to docker issue
+            if (JOB_NAME.contains ("sanity.external")) {
+                LABEL += "&&!sw.os.cent.7"
             }
 
             if (params.DOCKER_REQUIRED) {


### PR DESCRIPTION
- Sanity.external test will run on Rhel and Ubuntu machines
- Cent machines have different docker versions and caused failure
- Related Issue: runtimes/backlog/1383