### PR TITLE
(v1.0.1-release) JDK22+ excludes MBCS_Tests

### DIFF
--- a/functional/MBCS_Tests/formatter/playlist.xml
+++ b/functional/MBCS_Tests/formatter/playlist.xml
@@ -62,6 +62,13 @@ limitations under the License.
 		<testCaseName>MBCS_Tests_formatter_zh_TW_linux</testCaseName>
 		<command>LANG=zh_TW.UTF-8 bash $(TEST_RESROOT)$(D)test.sh; \
 	$(TEST_STATUS)</command>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/19083</comment>
+				<version>22+</version>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<platformRequirements>os.linux</platformRequirements>
 		<levels>
 			<level>special</level>

--- a/functional/MBCS_Tests/i18n/playlist.xml
+++ b/functional/MBCS_Tests/i18n/playlist.xml
@@ -32,6 +32,13 @@ limitations under the License.
 		<testCaseName>MBCS_Tests_i18n_ko_KR_linux</testCaseName>
 		<command>LANG=ko_KR.UTF-8 perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/19083</comment>
+				<version>22+</version>
+				<impl>openj9</impl>
+			</disable>
+		</disables>
 		<platformRequirements>os.linux</platformRequirements>
 		<levels>
 			<level>special</level>


### PR DESCRIPTION
JDK22+ excludes MBCS_Tests

Excluding `MBCS_Tests_formatter_zh_TW_linux` & `MBCS_Tests_i18n_ko_KR_linux`.

Cherry-pick
* https://github.com/adoptium/aqa-tests/pull/5189

Signed-off-by: Jason Feng <fengj@ca.ibm.com>