### PR TITLE
Disable CryptoTests, ssl-tests on OpenJ9 for x86-64_mac

### DIFF
--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -28,7 +28,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/19164</comment>
-				<platform>(?:aarch64_mac|s390x_linux).*</platform>
+				<platform>(?:aarch64_mac|x86-64_mac|s390x_linux).*</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>

--- a/functional/security/ssl-tests/playlist.xml
+++ b/functional/security/ssl-tests/playlist.xml
@@ -18,7 +18,7 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/19164</comment>
-				<platform>aarch64_mac.*</platform>
+				<platform>.*mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
 		</disables>


### PR DESCRIPTION
Disable `CryptoTests`, `ssl-tests` on OpenJ9 for `x86-64_mac`

Related to
* https://github.com/eclipse-openj9/openj9/issues/19164

Tested at [an internal grinder](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/39409/console)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>