### PR TITLE
Update GH permissions

### DIFF
--- a/.github/workflows/autoTestPR.yml
+++ b/.github/workflows/autoTestPR.yml
@@ -2,6 +2,9 @@ name: "Auto test PR"
 on:
   issue_comment:
     types: [created]
+permissions:
+      contents: write
+      issues: write
 jobs:
   autoTestPR:
     runs-on: ubuntu-latest

--- a/.github/workflows/directoriesFilesChangePR.yml
+++ b/.github/workflows/directoriesFilesChangePR.yml
@@ -1,7 +1,6 @@
 name: 'Directories/Files Change Test PR'
 on:
-  pull_request:
-    types: [ready_for_review]
+  workflow_dispatch:
     paths-ignore:
       - '.gitignore'
       - '*.md'

--- a/.github/workflows/runAqa.yml
+++ b/.github/workflows/runAqa.yml
@@ -2,6 +2,9 @@ name: "PR Comment Build Action for aqa-tests"
 on:
   issue_comment:
     types: [created]
+permissions:
+      contents: write
+      issues: write
 jobs:
   parseComment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix #5198 
- Several workflow files in this repo read/write comments, so update permissions
- Change trigger type for directoriesFileChangePR.yml, as it does not work for personal branches and may eventually be removed (related: https://github.com/adoptium/aqa-tests/issues/4855)