### PR TITLE
Disable java/lang/ref/FinalizeOverride.java for Java 8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -57,6 +57,7 @@ java/lang/invoke/RicochetTest.java		https://github.com/eclipse-openj9/openj9/iss
 java/lang/invoke/VarargsArrayTest.java		https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/invoke/lambda/LambdaStackTrace.java		https://github.com/eclipse-openj9/openj9/issues/1128	generic-all
 java/lang/ref/EarlyTimeout.java		https://github.com/eclipse-openj9/openj9/issues/1128	generic-all
+java/lang/ref/FinalizeOverride.java https://github.com/eclipse-openj9/openj9/issues/9651 generic-all
 java/lang/ref/FinalizerHistogramTest.java		https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ref/NullQueue.java		https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ref/OOMEInReferenceHandler.java		https://github.com/adoptium/aqa-tests/issues/1297	generic-all


### PR DESCRIPTION
Disable `java/lang/ref/FinalizeOverride.java` for Java 8

Exclude `java/lang/ref/FinalizeOverride.java` for Java 8 as well.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>