### PR TITLE
Excluding AKISerialNumber test on JDK8 until fix is merged

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -256,7 +256,7 @@ sun/security/pkcs11/KeyStore/ClientAuth.sh https://bugs.openjdk.org/browse/JDK-7
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java https://bugs.openjdk.org/browse/JDK-8042583 solaris-x64
 sun/security/pkcs11/fips/ClientJSSEServerJSSE.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
 sun/security/ssl/SSLSocketImpl/AsyncSSLSocketClose.java https://bugs.openjdk.org/browse/JDK-8224829 solaris-x64
-java/security/cert/CertPathBuilder/akiExt/AKISerialNumber.java https://bugs.openjdk.org/browse/JDK-8325096 linux-arm
+java/security/cert/CertPathBuilder/akiExt/AKISerialNumber.java https://bugs.openjdk.org/browse/JDK-8325096 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
This fix is in the dev branch, but is not yet merged into the master branch. This fix will likely be merged shortly after the April 2024 release.