### PR TITLE
Generate correct summary for jck-runtime-api-javax_net

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -978,7 +978,7 @@
 		<command>$(GEN_JTB_GENERIC) tests=api/javax_net testsuite=RUNTIME; \
 		$(EXEC_RUNTIME_TEST); \
 		$(TEST_STATUS); \
-		$(GEN_SUMMARY_GENERIC) tests=api/javax_naming testsuite=RUNTIME
+		$(GEN_SUMMARY_GENERIC) tests=api/javax_net testsuite=RUNTIME
 		</command>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
Fix #5225 