### PR TITLE
Excluding Test8009761 because it needs a backported fix

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -27,6 +27,7 @@ compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tes
 # compiler/6894807/IsInstanceTest.java https://github.com/adoptium/adoptium/issues/58 aix-all
 compiler/6894807/IsInstanceTest.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/8004051/Test8004051.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
+compiler/8009761/Test8009761.java https://github.com/adoptium/aqa-tests/issues/5221 linux-ppc64le
 compiler/criticalnatives/argumentcorruption/Test8167409.sh https://github.com/adoptium/aqa-tests/issues/2984 linux-arm
 compiler/c2/cr6340864/TestByteVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
 compiler/c2/cr6340864/TestDoubleVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86


### PR DESCRIPTION
Upstream bug JDK-8021775 changed this test in JDK9+ to include a 1+/- tolerance on the failing variable.

This fix was meant to be backported 10 years ago, but seems to have been forgotten about.

I've made sure that the associated Adoptium issue is tagged for an upcoming iteration, so we will be reminded to backport this fix after the April release.

P.S. A cherry-picked branch for the release branch has been prepared, as advised in my previous PR [here](https://github.com/adoptium/aqa-tests/pull/5215#issuecomment-2051772205).