### PR TITLE
[v1.0.1-release] Exclude jdk_security4 test on jdk8 linux

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -284,6 +284,7 @@ sun/security/provider/DSA/TestAlgParameterGenerator.java https://github.com/adop
 
 sun/security/krb5/auto/ReplayCacheTestProc.java https://github.com/adoptium/aqa-tests/issues/2349 generic-all
 sun/security/krb5/auto/Unreachable.java https://github.com/adoptium/aqa-tests/issues/2353 aix-all,macosx-all
+sun/security/krb5/auto/rcache_usemd5.sh https://bugs.openjdk.org/browse/JDK-8258855 linux-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
Merging the changes of https://github.com/adoptium/aqa-tests/pull/5220 into the release branch