### PR TITLE
Add CryptoTests_jtreg

### DIFF
--- a/functional/security/Crypto/build.xml
+++ b/functional/security/Crypto/build.xml
@@ -42,10 +42,8 @@
 		</else>
 	</if>
 	<target name="getCryptoTest" depends="cryptoTest.check" unless="cryptoTestdir.exists">
-		<exec executable="git" failonerror="true">
-			<arg value="clone" />
-			<arg value="${GIT_REPO}rh-openjdk/CryptoTest.git" />
-		</exec>
+		<getFileWithRetry file="CryptoTest" command="git clone --depth 1 -q ${GIT_REPO}rh-openjdk/CryptoTest.git -b master CryptoTest"/>
+		<checkGitRepoSha repoDir="CryptoTest"/>
 	</target>
 	
 	<target name="init">

--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -49,5 +49,47 @@
 		<groups>
 			<group>functional</group>
 		</groups>
+		<vendors>
+			<vendor>redhat</vendor>
+		</vendors>
+	</test>
+	<test>
+		<testCaseName>CryptoTests_jtreg</testCaseName>
+		<disables>
+			<disable>
+				<comment>for redhat, please see CryptoTests</comment>
+				<vendor>redhat</vendor>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/16712</comment>
+				<version>19+</version>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/16710</comment>
+				<platform>.*windows</platform>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4336</comment>
+				<platform>.*solaris</platform>
+			</disable>
+		</disables>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+		-a -xml -v:fail,error,time,nopass,summary -Dcryptotests.skipAgentTests=1 -timeoutFactor:2 \
+		-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+		-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+		-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+		$(Q)$(TEST_ROOT)$(D)functional$(D)security$(D)Crypto$(D)CryptoTest$(Q); \
+		$(TEST_STATUS)</command>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+		</features>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
 	</test>
 </playlist>


### PR DESCRIPTION
- add CryptoTests_jtreg back (based on the original change https://github.com/adoptium/aqa-tests/pull/5134/files)
- CryptoTests_jtreg directly triggers the tests via jtreg and it runs against all vendors except redhat
- CryptoTests only runs for vendor=redhat
- re-enable CryptoTests_jtreg on aarch64_mac|x86-64_mac|s390x_linux (related to run.sh issue. See https://github.com/eclipse-openj9/openj9/issues/19164)
- add retry for git clone to mitigate network issue
- add check CryptoTest repo sha

related: https://github.com/adoptium/aqa-tests/issues/5206