### PR TITLE
Crypto test original target now allows to run kereberos tests

### DIFF
--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -37,8 +37,9 @@
 			</disable>
 		</disables>
 		<command>
-			JTREG_HOME="$(TEST_RESROOT)$(D)jtreg" \
-			SKIP_AGENT_TESTS=1 $(TEST_ROOT)$(D)functional$(D)security$(D)Crypto$(D)CryptoTest$(D)run.sh "$(TEST_JDK_HOME)" ; $(TEST_STATUS)
+			export JTREG_HOME="$(TEST_RESROOT)$(D)jtreg" ; \
+			if [ "x${SKIP_AGENT_TESTS}" = "x" ] ; then export SKIP_AGENT_TESTS=1 ; fi ; \
+			$(TEST_ROOT)$(D)functional$(D)security$(D)Crypto$(D)CryptoTest$(D)run.sh "$(TEST_JDK_HOME)" ; $(TEST_STATUS)
 		</command>
 		<features>
 			<feature>FIPS140_2:nonapplicable</feature>


### PR DESCRIPTION
if both
   SKIP_AGENT_TESTS=false
   AGENT_HOSTNAME=some.krb.enabled.agent
are provided, the 5 kerberos based tests will run too

part of https://github.com/adoptium/aqa-tests/issues/5246