### PR TITLE
Made both CryptoTests_jtreg and CryptoTests targets vendor neutral

### DIFF
--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -36,8 +36,7 @@
 				<platform>.*solaris</platform>
 			</disable>
 			<disable>
-				<comment
-					>This target is for those using GH actions or the Jenkins jtreg-plugin. The run.sh script provides extra functionality, tarring of results, downloading of bespoke jtreg.jar from a particular untagged commit SHA that is not yet upstreamed to a release version of jtreg that is used see complete output in jtr.xml files. In addition it simplify enable/disable of kerberos-based tests which needs remote, pre-set KDC.
+				<comment>This target is for those using GH actions or the Jenkins jtreg-plugin. The run.sh script provides extra functionality, tarring of results, downloading of bespoke jtreg.jar from a particular untagged commit SHA that is not yet upstreamed to a release version of jtreg that is used to see complete output in jtr.xml files. In addition, it simplifies enable/disable of kerberos-based tests which needs remote, pre-set KDC.
 				</comment>
 			</disable>
 		</disables>

--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -35,6 +35,11 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/4336</comment>
 				<platform>.*solaris</platform>
 			</disable>
+			<disable>
+				<comment
+					>This target is for those using GH actions or the Jenkins jtreg-plugin. The run.sh script provides extra functionality, tarring of results, downloading of bespoke jtreg.jar from a particular untagged commit SHA that is not yet upstreamed to a release version of jtreg that is used see complete output in jtr.xml files. In addition it simplify enable/disable of kerberos-based tests which needs remote, pre-set KDC.
+				</comment>
+			</disable>
 		</disables>
 		<command>
 			JTREG_HOME="$(TEST_RESROOT)$(D)jtreg" \

--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -49,17 +49,10 @@
 		<groups>
 			<group>functional</group>
 		</groups>
-		<vendors>
-			<vendor>redhat</vendor>
-		</vendors>
 	</test>
 	<test>
 		<testCaseName>CryptoTests_jtreg</testCaseName>
 		<disables>
-			<disable>
-				<comment>for redhat, please see CryptoTests</comment>
-				<vendor>redhat</vendor>
-			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/16712</comment>
 				<version>19+</version>


### PR DESCRIPTION
It is passing for all vendors, the differences lies in underlyng OS, not JDK