### PR TITLE
Temporarily exclude MaxSizeUTF16String on OpenJ9 jdk23

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -95,6 +95,7 @@ java/lang/StackWalker/VerifyStackTrace.java https://github.com/adoptium/aqa-test
 java/lang/String/CaseConvertSameInstance.java https://github.com/eclipse-openj9/openj9/issues/6672 generic-all
 java/lang/String/CaseInsensitiveComparator.java https://github.com/eclipse-openj9/openj9/issues/6665 generic-all
 java/lang/String/CompactString/IndexOf.java  https://github.com/eclipse-openj9/openj9/issues/6673 generic-all
+java/lang/String/CompactString/MaxSizeUTF16String.java https://github.com/eclipse-openj9/openj9/issues/19309 generic-all
 java/lang/String/EqualsIgnoreCase.java https://github.com/eclipse-openj9/openj9/issues/6666 generic-all
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
 java/lang/StringBuffer/HugeCapacity.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/19309