### PR TITLE
Remove redundant non-capturing group  special constructs

### DIFF
--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -28,7 +28,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/19164</comment>
-				<platform>(?:aarch64_mac|x86-64_mac|s390x_linux).*</platform>
+				<platform>(aarch64_mac|x86-64_mac|s390x_linux).*</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -1080,7 +1080,7 @@
 		<disables>
 			<disable>
 				<comment>Temporarily disabled on x64 + aarch64 Mac for backlog/issues/718</comment>
-				<platform>(?:aarch64_mac.*|x86-64_mac.*)</platform>
+				<platform>(aarch64_mac|x86-64_mac).*</platform>
 				<impl>openj9</impl>
 				<version>11+</version>
 			</disable>


### PR DESCRIPTION
I'm failing to see why there should be `?:` construct in the platform matching regexes. 

it had to be some copypaste error in past. If I'm wrong, then I'm looking forward for info. Thanx!