### PR TITLE
Add JdwpAttachTest OpenJ9 JDK11+

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1773,6 +1773,39 @@
 			<group>openjdk</group>
 		</groups>
 	</test>
+	<!-- JdwpAttachTest is a subtest of jdk_jdi. Once jdk_jdi is fully enabled in openj9/ibm, the JdwpAttachTest below can be removed  -->
+	<test>
+		<testCaseName>JdwpAttachTest</testCaseName>
+		<variations>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_JDK_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(OPENJDK_DIR)$(D)test$(D)jdk$(D)com$(D)sun$(D)jdi$(D)JdwpAttachTest.java$(Q); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<impls>
+			<impl>ibm</impl>
+			<impl>openj9</impl>
+		</impls>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+	</test>
 	<test>
 		<testCaseName>jdk_build</testCaseName>
 		<disables>


### PR DESCRIPTION
Add `JdwpAttachTest` OpenJ9 `JDK11+`

Tested in [a personal grinder](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/40146/)

Related to
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/591
* https://github.com/eclipse-openj9/openj9/pull/19405

Signed-off-by: Jason Feng <fengj@ca.ibm.com>