### PR TITLE
JdwpAttachTest is available on JDK 17+

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1796,7 +1796,7 @@
 			<level>extended</level>
 		</levels>
 		<versions>
-			<version>11+</version>
+			<version>17+</version>
 		</versions>
 		<impls>
 			<impl>ibm</impl>


### PR DESCRIPTION
`JdwpAttachTest` is available on `JDK 17+`

Failed at JDK11 across platforms.
```
[2024-04-29T23:23:42.428Z] TESTING:
[2024-04-29T23:23:43.332Z] Error: Cannot find file: /home/jenkins/workspace/Test_openjdk11_j9_extended.openjdk_aarch64_linux_testList_0/aqa-tests/TKG/../openjdk/openjdk-jdk/test/jdk/com/sun/jdi/JdwpAttachTest.java
[2024-04-29T23:23:43.332Z] -----------------------------------
[2024-04-29T23:23:43.332Z] JdwpAttachTest_0_FAILED
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>