### PR TITLE
Unexclude TestHandshake

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -455,7 +455,6 @@ java/foreign/TestCircularInit2.java https://github.com/adoptium/aqa-tests/issues
 java/foreign/TestCondy.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestDowncall.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestFunctionDescriptor.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestIntrinsics.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -500,7 +500,6 @@ java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/17953 linux-ppc64le
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -502,7 +502,6 @@ java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -506,7 +506,6 @@ java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
-java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all


### PR DESCRIPTION
TestHandshake has been fixed by

- https://github.com/eclipse-openj9/openj9/pull/19167
- https://github.com/eclipse-openj9/openj9/pull/19412

Related: https://github.com/eclipse-openj9/openj9/issues/13211