### PR TITLE
Exclude TestHandshake in JDK17 and JDK21

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -455,6 +455,7 @@ java/foreign/TestCircularInit2.java https://github.com/adoptium/aqa-tests/issues
 java/foreign/TestCondy.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestDowncall.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestFunctionDescriptor.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/11027 generic-all
 java/foreign/TestIntrinsics.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -500,6 +500,7 @@ java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
+java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/17953 linux-ppc64le
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 


### PR DESCRIPTION
The new async handshake approach to fix synchronization issues was
introduced only in JDK22.

See https://bugs.openjdk.org/browse/JDK-8310644 for more details on
the async handshake approach.

JDK17 and JDK21 still use the old implementation, which has
synchronization issues. Thus, TestHandshake is being excluded in
JDK17 and JDK21.

Related: https://github.com/eclipse-openj9/openj9/issues/13211

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>