### PR TITLE
JDK17 excludes javax/rmi/ssl/SSLSocketParametersTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -407,7 +407,7 @@ java/util/Random/RandomTestBsi1999.java		https://github.com/eclipse-openj9/openj
 com/sun/jndi/dns/ConfigTests/Timeout.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
 com/sun/jndi/dns/ConfigTests/PortUnreachable.java   https://github.ibm.com/runtimes/backlog/issues/1287 windows-x64,macosx-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java  https://github.ibm.com/runtimes/backlog/issues/655 windows-all
-
+javax/rmi/ssl/SSLSocketParametersTest.java https://github.com/eclipse-openj9/openj9/issues/12168 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_G1GC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_ParallelGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 jdk/dynalink/TypeConverterFactoryMemoryLeakTest.java#with_SerialGC https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
`JDK17` excludes `javax/rmi/ssl/SSLSocketParametersTest.java`

Already excluded for `JDK21+`.

This is to address recent appearances of [JDK17 test failures](https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdk17_j9_extended.openjdk_aarch64_linux_testList_0/47/)

Tested in [an internal grinder](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/40500/console).

Signed-off-by: Jason Feng <fengj@ca.ibm.com>