### PR TITLE
Exclude TestHeadlessComponents test for openj9 and ibm

### DIFF
--- a/functional/testHeadlessComponents/playlist.xml
+++ b/functional/testHeadlessComponents/playlist.xml
@@ -15,7 +15,17 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<test>
 		<testCaseName>TestHeadlessComponents</testCaseName>
-		<command> 
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5224</comment>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5224</comment>
+				<impl>ibm</impl>
+			</disable>
+		</disables>
+		<command>
 			export OJDK_VERSION_NUMBER=$(JDK_VERSION) JREJDK="jdk" TMPRESULTS=$(Q)$(REPORTDIR)$(D)report$(Q); \
 			bash $(TEST_ROOT)$(D)functional$(D)testHeadlessComponents$(D)TestHeadlessComponents$(D)testHeadlessComponents.sh; \
 			$(TEST_STATUS)
@@ -23,13 +33,13 @@
 		<levels>
 			<level>dev</level>
 		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
 		<platformRequirementsList>
 			<platformRequirements>os.linux</platformRequirements>
 			<platformRequirements>os.win</platformRequirements>
 			<platformRequirements>os.osx</platformRequirements>
 		</platformRequirementsList>
-		<groups>
-			<group>functional</group>
-		</groups>
 	</test>
 </playlist>


### PR DESCRIPTION
- Disabled TestHeadlessComponents on all platforms, versions for openj9 and ibm.

related: https://github.com/adoptium/aqa-tests/issues/5224