### PR TITLE
Add markdown file with links to AQAvit resources

### DIFF
--- a/docs/pages/AQAvitResources.md
+++ b/docs/pages/AQAvitResources.md
@@ -1,0 +1,7 @@
+# AQAvit Resourceis
+
+## Recording
+[AQAvit Triage Lightning Talk Recording](https://www.youtube.com/watch?v=TWD_b8cwIVg)
+
+## PDF Slides
+[AQAvit Triage Lightning Slides](https://github.com/adoptium/aqa-tests/files/15349378/AQAvitTriageLightningSlides.pdf)


### PR DESCRIPTION
Resolves issue #5328 by adding a markdown file `AQAvitResources.md` in the `docs/pages` directory. This file contains links to the AQAvit Triage Lightning Talk recording and the AQAvit Triage Lightning Slides PDF.

### Changes:
- Added `AQAvitResources.md` with links to the recording and the PDF file.
