### PR TITLE
Exclude jdk_imageio and jdk_security3 tests that fail on Windows

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -203,6 +203,12 @@ com/sun/net/httpserver/bugs/B6361557.java	https://github.com/adoptium/aqa-tests/
 
 ############################################################################
 
+# jdk_imageio
+
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclipse-openj9/openj9/issues/19527 windows-all
+
+############################################################################
+
 # jdk_io
 
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -207,6 +207,12 @@ java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclip
 
 ############################################################################
 
+# jdk_imageio
+
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclipse-openj9/openj9/issues/19527 windows-all
+
+############################################################################
+
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java	https://github.com/adoptium/aqa-tests/issues/1500	generic-all

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -228,6 +228,12 @@ jdk/net/ExtendedSocketOption/DontFragmentTest.java https://github.com/adoptium/a
 
 ############################################################################
 
+# jdk_imageio
+
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclipse-openj9/openj9/issues/19527 windows-all
+
+############################################################################
+
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
@@ -374,6 +380,7 @@ sun/security/mscapi/CngCipher.java 	https://github.ibm.com/runtimes/backlog/issu
 sun/security/mscapi/InteropWithSunRsaSign.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/KeyAlgorithms.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/KeyStoreEmptyCertChain.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/NonAsciiAlias.java https://github.com/eclipse-openj9/openj9/issues/19528 windows-all
 sun/security/mscapi/PublicKeyInterop.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/RSAEncryptDecrypt.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/SetDupNameEntry.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -229,6 +229,12 @@ jdk/net/ExtendedSocketOption/DontFragmentTest.java https://github.com/adoptium/a
 
 ############################################################################
 
+# jdk_imageio
+
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclipse-openj9/openj9/issues/19527 windows-all
+
+############################################################################
+
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
@@ -375,6 +381,7 @@ sun/security/mscapi/CngCipher.java 	https://github.ibm.com/runtimes/backlog/issu
 sun/security/mscapi/InteropWithSunRsaSign.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/KeyAlgorithms.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/KeyStoreEmptyCertChain.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/NonAsciiAlias.java https://github.com/eclipse-openj9/openj9/issues/19528 windows-all
 sun/security/mscapi/PublicKeyInterop.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/RSAEncryptDecrypt.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/SetDupNameEntry.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -231,6 +231,12 @@ jdk/net/ExtendedSocketOption/DontFragmentTest.java https://github.com/adoptium/a
 
 ############################################################################
 
+# jdk_imageio
+
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclipse-openj9/openj9/issues/19527 windows-all
+
+############################################################################
+
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
@@ -375,6 +381,7 @@ sun/security/mscapi/CngCipher.java 	https://github.ibm.com/runtimes/backlog/issu
 sun/security/mscapi/InteropWithSunRsaSign.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/KeyAlgorithms.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/KeyStoreEmptyCertChain.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
+sun/security/mscapi/NonAsciiAlias.java https://github.com/eclipse-openj9/openj9/issues/19528 windows-all
 sun/security/mscapi/PublicKeyInterop.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/RSAEncryptDecrypt.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/SetDupNameEntry.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all

--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -405,6 +405,7 @@ com/sun/jndi/ldap/LdapDnsProviderTest.java https://github.com/adoptium/aqa-tests
 
 # jdk_imageio
 
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclipse-openj9/openj9/issues/19527 windows-all
 javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github.com/adoptium/aqa-tests/issues/2321 aix-all
 
 ############################################################################


### PR DESCRIPTION
These tests often fail and then cause re-runs which take a long time.

javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java
https://github.com/eclipse-openj9/openj9/issues/19527

sun/security/mscapi/NonAsciiAlias.java
https://github.com/eclipse-openj9/openj9/issues/19528 related to https://github.ibm.com/runtimes/backlog/issues/795