### PR TITLE
openjdk.mk: make MEMORY_SIZE computation portable

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -27,7 +27,7 @@ ifeq ($(OS),Linux)
 	#
 	# // If this machine/container uses cgroups to limit the amount of 
 	# // memory available to us, we should use that as out memory size.
-	# if [[ -r /sys/fs/cgroup/memory.max ]]; then
+	# if [ -r /sys/fs/cgroup/memory.max ]; then
 	#     // Use this to identify memory maximum (bytes) for cgroup v2.
 	#     CGMEM=`cat /sys/fs/cgroup/memory.max 2>1`; 
 	# else
@@ -37,7 +37,7 @@ ifeq ($(OS),Linux)
 	#
 	# // If those files were empty, or didn't exist, or had non-numbers
 	# // in them, then use /proc/meminfo (converted to bytes).
-	# if [[ ! $$(CGMEM) =~ ^[0-9]+$$ ]]; then
+	# if echo "$${CGMEM}" | grep -Eqv '^[0-9]+$$' ; then
 	#     CGMEM=`expr $${KMEMMB} \* 1024 \* 1024`; 
 	# fi; 
 	#
@@ -50,7 +50,7 @@ ifeq ($(OS),Linux)
 	# if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then 
 	#     echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; 
 	# fi
-	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [[ -r /sys/fs/cgroup/memory.max ]]; then CGMEM=`cat /sys/fs/cgroup/memory.max 2>1`; else CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>1`; fi; if [[ ! $${CGMEM} =~ ^[0-9]+$$ ]]; then CGMEM=`expr $${KMEMMB} \* 1024 \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1024 / 1024`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
+	MEMORY_SIZE:=$(shell KMEMMB=`awk '/^MemTotal:/{print int($$2/1024)}' /proc/meminfo`; if [ -r /sys/fs/cgroup/memory.max ]; then CGMEM=`cat /sys/fs/cgroup/memory.max 2>1`; else CGMEM=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>1`; fi; if echo "$${CGMEM}" | grep -Eqv '^[0-9]+$$' ; then CGMEM=`expr $${KMEMMB} \* 1024 \* 1024`; fi; CGMEMMB=`expr $${CGMEM} / 1024 / 1024`; if [ "$${KMEMMB}" -lt "$${CGMEMMB}" ]; then echo "$${KMEMMB}"; else echo "$${CGMEMMB}"; fi)
 endif
 ifeq ($(OS),Darwin)
 	NPROCS:=$(shell sysctl -n hw.ncpu)


### PR DESCRIPTION
Fixes non-portable (bash specific) code causing [errors](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10082/console) in log on some systems (ubuntu):
```
...
18:43:25  /bin/sh: 1: [[: not found
18:43:25  /bin/sh: 1: [[: not found
18:43:25  expr: syntax error: unexpected argument '1024'
18:43:25  /bin/sh: 1: [: Illegal number: 
18:43:25  expr: syntax error: unexpected argument '2048'
18:43:25  expr: syntax error: missing argument after '>'
...
```

testing: 
linux_x86-64 [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10082/console)