### PR TITLE
openjdk: langtools_all target

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -452,3 +452,7 @@ jdk/jfr/jcmd/TestJcmdStopReadOnlyFile.java https://github.com/adoptium/aqa-tests
 jfr/api/consumer/TestRecordedFrame.java https://bugs.openjdk.org/browse/JDK-8247203 linux-aarch64,linux-ppc64le
 jdk/jfr/api/consumer/TestRecordedFrame.java https://bugs.openjdk.java.net/browse/JDK-8247203 linux-arm,linux-ppc64le
 jdk/jfr/event/compiler/TestCompilerInlining.java https://github.com/adoptium/aqa-tests/issues/3277 windows-all
+
+# langtools_all
+
+tools/javac/defaultMethods/Assertions.java https://bugs.openjdk.org/browse/JDK-8047675 generic-all

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2736,4 +2736,25 @@
 		</vendors>
 		<platformRequirements>spec.linux_x86-64</platformRequirements>
 	</test>
+	<test>
+		<testCaseName>langtools_all</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx768m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(TIMEOUT_HANDLER) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_LANGTOOLS_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(JTREG_LANGTOOLS_TEST_DIR)$(Q); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+	</test>
 </playlist>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2738,6 +2738,16 @@
 	</test>
 	<test>
 		<testCaseName>langtools_all</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/19605</comment>
+				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/19605</comment>
+				<impl>ibm</impl>
+			</disable>
+		</disables>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx768m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
 	$(TIMEOUT_HANDLER) \


### PR DESCRIPTION
This adds `langtools_all` target to openjdk to run langtools tests (see: https://github.com/adoptium/aqa-tests/issues/5318).

Testing:
x86-64_linux:
jdk 21: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10115/)
jdk 17: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10116/)
jdk 11: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10117/)
jdk 8: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10118/)

x86-64_windows
jdk 21: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10119/)
jdk 8: [FAILED](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10125/) (infra issue?, rerun [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10130/))

x86-64_mac
jdk 21: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10120/)
jdk 8: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10124/)