### PR TITLE
Disable openJcePlusTests for all platforms

### DIFF
--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -21,8 +21,8 @@
 				<vendor>eclipse</vendor>
 			</disable>
 			<disable>
-				<comment>Only applicable on aix, pliunx, xlinux, wins64 and zlinux atm</comment>
-				<platform>^((?!(ppc64_aix|ppc64le_linux|x86-64_linux|x86-64_windows|s390x_linux)).)*$</platform>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/19205</comment>
+				<!-- platform>^((?!(ppc64_aix|ppc64le_linux|x86-64_linux|x86-64_windows|s390x_linux)).)*$</platform -->
 			</disable>
 		</disables>
 		<command>ant -f ${BUILD_ROOT}/functional/OpenJcePlusTests/test.xml -DTEST_JAVA=$(Q)$(JAVA_COMMAND)$(Q) launch_test; \


### PR DESCRIPTION
Disable `openJcePlusTests` for all platforms

related to https://github.com/eclipse-openj9/openj9/issues/19205

This test failed consistently across Java level/platforms, disabled it temporarily. 
Tested in [an internal grinder](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/40937/console)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>