### PR TITLE
Stop running jdk_vector testing on OpenJ9 jdk17

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2221,6 +2221,18 @@
 	</test>
 	<test>
 		<testCaseName>jdk_vector</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/19360</comment>
+				<impl>openj9</impl>
+				<version>17</version>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/19360</comment>
+				<impl>ibm</impl>
+				<version>17</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>


### PR DESCRIPTION
vector is an incubator and by design there is no JIT support for jdk17 any more, resulting in test timeouts.

Issue https://github.com/eclipse-openj9/openj9/issues/19360