### PR TITLE
Remove JFR TestCompilerCompile from JDK8 problemlist

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -436,7 +436,6 @@ jdk/jfr/event/runtime/TestSizeTFlags.java https://github.com/adoptium/aqa-tests/
 jdk/jfr/jvm/TestLargeJavaEvent512k.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/compiler/TestCodeSweeper.java https://github.com/adoptium/aqa-tests/issues/3043 macosx-all,windows-all
 jdk/jfr/event/compiler/TestCodeCacheFull.java https://github.com/adoptium/aqa-tests/issues/3042 macosx-all,windows-all
-jdk/jfr/event/compiler/TestCompilerCompile.java https://bugs.openjdk.org/browse/JDK-8326529 generic-all
 jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventDefNewSerial.java https://github.com/adoptium/aqa-tests/issues/3254 solaris-sparcv9
 jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventPSParOld.java https://github.com/adoptium/aqa-tests/issues/3254 solaris-sparcv9
 jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventPSSerial.java https://github.com/adoptium/aqa-tests/issues/3254 solaris-sparcv9


### PR DESCRIPTION
The issue with jdk/jfr/event/compiler/TestCompilerCompile.java has been resolved and backported to JDK8.  The fix is in openjdk8u432. So this PR removes that test from the ProblemList.

https://github.com/adoptium/aqa-tests/issues/3046#issue-1031362441
https://bugs.openjdk.org/browse/JDK-8326987