### PR TITLE
serviceability_jvmti_j9 runs with -XX:+EnableExtendedHCR

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -412,7 +412,7 @@
 			<variation>Mode1000</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
-	$(JTREG_BASIC_OPTIONS) -nativepath:"$(TESTIMAGE_PATH)/hotspot/jtreg/native" -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(JTREG_BASIC_OPTIONS) -nativepath:"$(TESTIMAGE_PATH)/hotspot/jtreg/native" -vmoptions:$(Q)-Xmx512m -XX:+EnableExtendedHCR $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
 	$(TIMEOUT_HANDLER) \
 	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \


### PR DESCRIPTION
`serviceability_jvmti_j9` runs with `-XX:+EnableExtendedHCR`

Verified locally that `serviceability/jvmti/thread/GetStackTrace/getstacktr07/getstacktr07.java` passes.

closes https://github.com/eclipse-openj9/openj9/issues/19691

Signed-off-by: Jason Feng <fengj@ca.ibm.com>