### PR TITLE
Temporarily move criu softmx test to special

### DIFF
--- a/external/criu-functional/playlist.xml
+++ b/external/criu-functional/playlist.xml
@@ -51,7 +51,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<levels>
-			<level>dev</level>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>external</group>


### PR DESCRIPTION
- Criu softmx test image got deleted before test in dev.external
- Temporarily move it to special, and move back once fixed