### PR TITLE
Apply USE_TESTENV_PROPERTIES only on container tests with aqa-tests

### DIFF
--- a/external/criu-functional/test.properties
+++ b/external/criu-functional/test.properties
@@ -1,3 +1,4 @@
+github_url="https://github.com/adoptium/aqa-tests.git"
 test_results="testResults"
 gradle_version="5.1"
 environment_variable="MODE=java CC=gcc-7 CXX=g++-7"

--- a/external/criu-portable-checkpoint/test.properties
+++ b/external/criu-portable-checkpoint/test.properties
@@ -1,3 +1,4 @@
+github_url="https://github.com/adoptium/aqa-tests.git"
 test_results="testResults"
 gradle_version="5.1"
 environment_variable="MODE=java CC=gcc-7 CXX=g++-7"

--- a/external/criu-ubi-portable-checkpoint/test.properties
+++ b/external/criu-ubi-portable-checkpoint/test.properties
@@ -1,3 +1,4 @@
+github_url="https://github.com/adoptium/aqa-tests.git"
 test_results="testResults"
 gradle_version="5.1"
 environment_variable="MODE=java"

--- a/external/dockerfile_functions.sh
+++ b/external/dockerfile_functions.sh
@@ -457,10 +457,10 @@ print_environment_variable() {
 
 print_home_path() {
     local file=$1
-    local aqa_tests_repo=$2
+    local github_url=$2
 
     # Get Github folder name
-    local folder="$(echo ${aqa_tests_repo} | awk -F'/' '{print $NF}' | sed 's/.git//g')"
+    local folder="$(echo ${github_url} | awk -F'/' '{print $NF}' | sed 's/.git//g')"
     echo -e "ENV TEST_HOME /${folder}\n" >> ${file}
 }
 
@@ -506,29 +506,36 @@ print_testInfo_env() {
             "\nENV JDK_VERSION=${version}" \
             "\nENV JDK_IMPL=${vm}" \
             "\n" >> ${file}
-    echo -e "\nENV USE_TESTENV_PROPERTIES ${USE_TESTENV_PROPERTIES} \n" >> ${file}
 }
 
 print_clone_project() {
     local file=$1
     local test=$2
-    local aqa_tests_repo=$3
-    local aqa_tests_branch=$4
+    local github_url=$3
 
     # Cause Test name to be capitalized
     test_tag="$(sanitize_test_names ${test} | tr a-z A-Z)_TAG"
-    if [[ "$test_tag" != *"CRIU"* && "$test_tag" != *"TCK"* ]]; then
-        aqa_tests_branch=$test_tag
+    git_branch_tag="master"
+    if [[ "${github_url}" == *"aqa-tests"* ]]; then
+        if [[ ! -z ${USE_TESTENV_PROPERTIES} ]]; then
+            if [[ "${USE_TESTENV_PROPERTIES}" == "true" && ! -z ${ADOPTOPENJDK_REPO} && ! -z ${ADOPTOPENJDK_BRANCH} ]]; then
+                github_url=${ADOPTOPENJDK_REPO}
+                git_branch_tag=${ADOPTOPENJDK_BRANCH}
+                echo -e "\nENV USE_TESTENV_PROPERTIES=true\n" >> ${file}
+            fi
+        fi
+    else
+        git_branch_tag=\$${test_tag}
     fi
 
     # Get Github folder name
-    folder="$(echo ${aqa_tests_repo} | awk -F'/' '{print $NF}' | sed 's/.git//g')"
+    folder="$(echo ${github_url} | awk -F'/' '{print $NF}' | sed 's/.git//g')"
 
     echo -e "# Clone ${test} source" \
             "\nENV ${test_tag}=\$${test_tag}" \
-            "\nRUN git clone ${aqa_tests_repo}" \
+            "\nRUN git clone ${github_url}" \
             "\nWORKDIR /${folder}/" \
-            "\nRUN git checkout ${aqa_tests_branch}" \
+            "\nRUN git checkout ${git_branch_tag}" \
             "\nWORKDIR /" \
             "\n" >> ${file}
 }
@@ -657,9 +664,9 @@ generate_dockerfile() {
         print_test_results ${file};
     fi
 
-    print_home_path ${file} ${ADOPTOPENJDK_REPO};
+    print_home_path ${file} ${github_url};
     print_testInfo_env ${test} ${tag_version} ${os} ${version} ${vm}
-    print_clone_project ${file} ${test} ${ADOPTOPENJDK_REPO} ${ADOPTOPENJDK_BRANCH} ;
+    print_clone_project ${file} ${test} ${github_url};
     print_test_files ${file} ${test} ${localPropertyFile};
 
     if [[ "$check_external_custom_test" == "1" ]]; then


### PR DESCRIPTION
- Since container tests without github_url of aqa-tests don't need to inherit testenv
- Modify USE_TESTENV_PROPERTIE to only apply with container tests with aqa-tests
Related Issue: https://github.com/adoptium/aqa-tests/issues/5403