### PR TITLE
Remove -XX:+EnableExtendedHCR not required

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -359,7 +359,7 @@
 			<variation>Mode1000</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
-	$(JTREG_BASIC_OPTIONS) -nativepath:"$(TESTIMAGE_PATH)/hotspot/jtreg/native" -vmoptions:$(Q)-Xmx512m -XX:+EnableExtendedHCR $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(JTREG_BASIC_OPTIONS) -nativepath:"$(TESTIMAGE_PATH)/hotspot/jtreg/native" -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
 	$(TIMEOUT_HANDLER) \
 	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \


### PR DESCRIPTION
Remove `-XX:+EnableExtendedHCR` not required

Related to
* https://github.com/eclipse-openj9/openj9/issues/19691

Signed-off-by: Jason Feng <fengj@ca.ibm.com>