### PR TITLE
Add additional OpenJCEPlusFIPS test dependencies

### DIFF
--- a/functional/OpenJcePlusTests/test.xml
+++ b/functional/OpenJcePlusTests/test.xml
@@ -43,7 +43,7 @@
 		</java>
 	</target>
 	<target name="test">
-		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMemStressAll" />
+		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMemStressAll" />
 		<junit fork="yes" printsummary="on" showoutput="yes" haltonfailure="yes">
 			<jvmarg line="--add-exports=java.base/sun.security.util=ALL-UNNAMED" />
 			<jvmarg line="--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED" />
@@ -52,12 +52,18 @@
 				<pathelement location="hamcrest-core.jar" />
 				<pathelement location="bcprov-jdk18on.jar" />
 				<pathelement location="openjceplus-tests.jar" />
+				<pathelement location="junit-vintage-engine.jar" />
+				<pathelement location="junit-platform-suite.jar" />
+				<pathelement location="junit-jupiter-api.jar" />
+				<pathelement location="junit-jupiter-engine.jar" />
+				<pathelement location="junit-jupiter-params.jar" />
+				<pathelement location="junit-platform-suite-api.jar" />
 			</classpath>
 			<formatter type="xml" />
 			<test name="ibm.jceplus.junit.TestMemStressAll" todir="junitreports"/>
 		</junit>
 		<echo message="TestMemStressAll COMPLETED" />
-		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMultiThread" />
+		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMultiThread" />
 		<junit fork="yes" printsummary="on" showoutput="yes" haltonfailure="yes">
 			<jvmarg line="--add-exports=java.base/sun.security.util=ALL-UNNAMED" />
 			<jvmarg line="--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED" />
@@ -66,12 +72,18 @@
 				<pathelement location="hamcrest-core.jar" />
 				<pathelement location="bcprov-jdk18on.jar" />
 				<pathelement location="openjceplus-tests.jar" />
+				<pathelement location="junit-vintage-engine.jar" />
+				<pathelement location="junit-platform-suite.jar" />
+				<pathelement location="junit-jupiter-api.jar" />
+				<pathelement location="junit-jupiter-engine.jar" />
+				<pathelement location="junit-jupiter-params.jar" />
+				<pathelement location="junit-platform-suite-api.jar" />
 			</classpath>
 			<formatter type="xml" />
 			<test name="ibm.jceplus.junit.TestMultithread" todir="junitreports"/>
 		</junit>
 		<echo message="TestMultithread COMPLETED" />
-		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMultiThreadFIPS" />
+		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMultiThreadFIPS" />
 		<junit fork="yes" printsummary="on" showoutput="yes" haltonfailure="yes">
 			<jvmarg line="--add-exports=java.base/sun.security.util=ALL-UNNAMED" />
 			<jvmarg line="--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED" />
@@ -80,12 +92,18 @@
 				<pathelement location="hamcrest-core.jar" />
 				<pathelement location="bcprov-jdk18on.jar" />
 				<pathelement location="openjceplus-tests.jar" />
+				<pathelement location="junit-vintage-engine.jar" />
+				<pathelement location="junit-platform-suite.jar" />
+				<pathelement location="junit-jupiter-api.jar" />
+				<pathelement location="junit-jupiter-engine.jar" />
+				<pathelement location="junit-jupiter-params.jar" />
+				<pathelement location="junit-platform-suite-api.jar" />
 			</classpath>
 			<formatter type="xml" />
 			<test name="ibm.jceplus.junit.TestMultithreadFIPS" todir="junitreports"/>
 		</junit>
 		<echo message="TestMultithreadFIPS COMPLETED" />
-		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestAll" />
+		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestAll" />
 		<junit fork="yes" printsummary="on" showoutput="yes" haltonfailure="yes">
 			<jvmarg line="--add-exports=java.base/sun.security.util=ALL-UNNAMED" />
 			<jvmarg line="--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED" />
@@ -94,6 +112,12 @@
 				<pathelement location="hamcrest-core.jar" />
 				<pathelement location="bcprov-jdk18on.jar" />
 				<pathelement location="openjceplus-tests.jar" />
+				<pathelement location="junit-vintage-engine.jar" />
+				<pathelement location="junit-platform-suite.jar" />
+				<pathelement location="junit-jupiter-api.jar" />
+				<pathelement location="junit-jupiter-engine.jar" />
+				<pathelement location="junit-jupiter-params.jar" />
+				<pathelement location="junit-platform-suite-api.jar" />
 			</classpath>
 			<formatter type="xml" />
 			<test name="ibm.jceplus.junit.TestAll" todir="junitreports"/>


### PR DESCRIPTION
When executing the OpenJCEPlusFIPS tests some junit 5 related dependencies are missing. These files are already downloaded during compilation for OpenJCEPlusFIPS, they are just not available during execution.