### PR TITLE
openjdk: Unexclude fixed hotspot_compiler tests on windows-x86

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -244,8 +244,6 @@ compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/iss
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/TestReplaceEquivPhis.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/codegen/TestCharVect2.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/TestRemoveEmptyCountedLoop.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -255,7 +253,6 @@ compiler/intrinsics/unsafe/HeapByteBufferTest.java#id1 https://github.com/adopti
 compiler/loopopts/superword/TestPeeledReductionNode.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tests/issues/2671 windows-x86
-compiler/vectorization/TestVectorsNotSavedAtSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/graalunit/ApiDirectivesTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/ApiTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/AsmAarch64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -385,16 +385,12 @@ compiler/compilercontrol/jcmd/ClearDirectivesStackTest.java https://github.com/a
 compiler/compilercontrol/jcmd/ControlIntrinsicTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/compilercontrol/jcmd/PrintDirectivesTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/compilercontrol/logcompilation/LogTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
-compiler/rangechecks/TestRangeCheckSmearing.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/AllocationCodeBlobTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/BlockingCompilation.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/GetCodeHeapEntriesTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/MakeMethodNotCompilableTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/codecache/MHIntrinsicAllocFailureTest.java https://github.com/adoptium/aqa-tests/issues/4515#issuecomment-1512404678 windows-x86,linux-arm
-compiler/loopopts/TestBackedgeLoadArrayFillMain.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
-compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/loopopts/TestRemoveEmptyCountedLoop.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
-compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/splitif/TestCrashAtIGVNSplitIfSubType.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 
 ############################################################################
@@ -423,8 +419,6 @@ jdk/incubator/vector/Byte128VectorLoadStoreTests.java https://github.com/adoptiu
 # jvm_compiler
 
 compiler/arguments/CheckCICompilerCount.java https://github.com/adoptium/aqa-tests/issues/5378 windows-x86
-compiler/arraycopy/TestCloneAccess.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/arraycopy/TestCloneAccessStressGCM.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -433,11 +427,6 @@ compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tes
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/TestReplaceEquivPhis.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/TestShiftRightAndAccumulate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/codegen/TestCharVect2.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/loopopts/superword/Vec_MulAddS2I.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/intrinsics/unsafe/HeapByteBufferTest.java#id1 https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/superword/TestPeeledReductionNode.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/ClearArray.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -448,10 +437,6 @@ compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.
 compiler/loopstripmining/TestConservativeAntiDep.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/types/TestSubTypeCheckMacroNodeWrongMem.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/vectorization/TestVectorsNotSavedAtSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/codegen/ClearArrayTest.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/TestJumpTable.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/vectorapi/TestNoInline.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/TestCMoveInfiniteGVN.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -461,11 +446,7 @@ compiler/loopopts/FillArrayWithUnsafe.java https://github.com/adoptium/aqa-tests
 compiler/loopopts/TestPredicateInputBelowLoopPredicate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/print/PrintInlining.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/TestRemoveEmptyLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestFewIterationsCountedLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 
 # jdk_container/hotspot_container
 

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -360,9 +360,6 @@ compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/is
 # compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -359,9 +359,6 @@ compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/is
 # compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -359,9 +359,6 @@ compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/is
 # compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86


### PR DESCRIPTION
Unexcluded fixed hotspot_compiler tests on windows-x86:

[JDK-8264179](https://bugs.openjdk.org/browse/JDK-8264179):
```
compiler/loopopts/superword/Vec_MulAddS2I.java
compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java
compiler/types/TestSubTypeCheckMacroNodeWrongMem.java
compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
```

[JDK-8269029](https://bugs.openjdk.org/browse/JDK-8269029):
```
compiler/codegen/TestCharVect2.java
```

[JDK-8269129](https://bugs.openjdk.org/browse/JDK-8269129) (jdk17+):
```
compiler/arraycopy/TestCloneAccess.java
compiler/arraycopy/TestCloneAccessStressGCM.java
compiler/c2/TestJumpTable.java
compiler/c2/TestReplaceEquivPhis.java
compiler/c2/TestShiftRightAndAccumulate.java
compiler/codegen/ClearArrayTest.java
```

[JDK-8285980](https://bugs.openjdk.org/browse/JDK-8285980):
```
compiler/c2/irTests/TestFewIterationsCountedLoop.java
compiler/c2/irTests/TestSkeletonPredicates.java
compiler/c2/irTests/TestStripMiningDropsSafepoint.java
compiler/c2/irTests/TestSuperwordFailsUnrolling.java
```

[JDK-8287801](https://bugs.openjdk.org/browse/JDK-8287801):
```
compiler/rangechecks/TestRangeCheckSmearing.java
```

[JDK-8311964](https://bugs.openjdk.org/browse/JDK-8311964):
```
compiler/loopopts/TestBackedgeLoadArrayFillMain.java
compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java
compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java
```
  
**Testing:**
windows-x86:
jdk 11: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10504/)
jdk 17: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10502/)


Sophia-guo: 
Closes #2382
Closes #3620 