### PR TITLE
Avoid unnecessary copying of system lib files

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -112,7 +112,6 @@ def setupEnv() {
 
 	env.LIGHT_WEIGHT_CHECKOUT = (params.LIGHT_WEIGHT_CHECKOUT == false) ? params.LIGHT_WEIGHT_CHECKOUT : true
 	env.GENERATE_JOBS = params.GENERATE_JOBS ?: false
-	env.isSVTTestRepo=false
 
 	if (JOB_NAME.contains("Grinder")) {
 		def currentDate = new Date()
@@ -511,6 +510,8 @@ def setup() {
 		VENDOR_TEST_BRANCHES = (params.VENDOR_TEST_BRANCHES) ? "--vendor_branches \"${params.VENDOR_TEST_BRANCHES}\"" : ""
 		VENDOR_TEST_DIRS = (params.VENDOR_TEST_DIRS) ? "--vendor_dirs \"${params.VENDOR_TEST_DIRS}\"" : ""
 		VENDOR_TEST_SHAS = (params.VENDOR_TEST_SHAS) ? "--vendor_shas \"${params.VENDOR_TEST_SHAS}\"" : ""
+		env.IS_SVT_TESTREPO = (params.VENDOR_TEST_REPOS  && params.VENDOR_TEST_REPOS.contains('SVTTestRepo')) ? true : false
+		echo "IS_SVT_TESTREPO is set to ${env.IS_SVT_TESTREPO}"
 
 		// handle three cases (true/false/null) in params.TEST_IMAGES_REQUIRED and params.DEBUG_IMAGES_REQUIRED
 		// Only set image required to false if params is set to false. In get.sh, the default value is true

--- a/get.sh
+++ b/get.sh
@@ -637,11 +637,7 @@ getVendorTestMaterial() {
 				continue
 			fi
 		fi
-
-		if [[ "$repoURL" =~ "SVTTestRepo" ]]; then
-			isSVTTestRepo=true
-		fi
-
+		
 		echo "git clone ${branchOption} $repoURL $dest"
 		git clone -q --depth 1 $branchOption $repoURL $dest
 

--- a/system/common.xml
+++ b/system/common.xml
@@ -350,16 +350,9 @@
 				</copy>
 			</then>
 		</if>
-		<condition property="isSVTTestRepo" value="true">
-			<isset property="env.isSVTTestRepo"/>
-		</condition>
-		<condition property="isSVTTestRepo" value="false">
-   		 	<not>
-				<isset property="env.isSVTTestRepo"/>
-			</not>
-		</condition>
+		
 		<if>
-			<equals arg1="${isSVTTestRepo}" arg2="true"/>
+			<equals arg1="${env.IS_SVT_TESTREPO}" arg2="true"/>
 			<then>
 				<mkdir dir="${SYSTEMTEST_DEST}/systemtest_prereqs"/>
 				<mkdir dir="${TEST_ROOT}/systemtest_prereqs"/>


### PR DESCRIPTION
- Ensure system lib files are only copied when IS_SVT_TESTREPO is set to true
- Prevent unnecessary copying of system lib files to systemtest_prereqs directory

related:https://github.ibm.com/runtimes/backlog/issues/1457