### PR TITLE
[v1.0.2-release] Cherry pick: openjdk: Unexclude fixed hotspot_compiler tests on windows-x86

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -263,8 +263,6 @@ compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/iss
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/TestReplaceEquivPhis.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/codegen/TestCharVect2.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/TestRemoveEmptyCountedLoop.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/loopstripmining/AntiDependentLoadInOuterStripMinedLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -274,7 +272,6 @@ compiler/intrinsics/unsafe/HeapByteBufferTest.java#id1 https://github.com/adopti
 compiler/loopopts/superword/TestPeeledReductionNode.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tests/issues/2671 windows-x86
-compiler/vectorization/TestVectorsNotSavedAtSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/graalunit/ApiDirectivesTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/ApiTest.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all
 compiler/graalunit/AsmAarch64Test.java https://github.com/adoptium/aqa-tests/issues/2804 generic-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -405,16 +405,12 @@ compiler/compilercontrol/jcmd/ClearDirectivesStackTest.java https://github.com/a
 compiler/compilercontrol/jcmd/ControlIntrinsicTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/compilercontrol/jcmd/PrintDirectivesTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/compilercontrol/logcompilation/LogTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
-compiler/rangechecks/TestRangeCheckSmearing.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/AllocationCodeBlobTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/BlockingCompilation.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/GetCodeHeapEntriesTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/whitebox/MakeMethodNotCompilableTest.java https://github.com/adoptium/aqa-tests/issues/3620 windows-x86
 compiler/codecache/MHIntrinsicAllocFailureTest.java https://github.com/adoptium/aqa-tests/issues/4515#issuecomment-1512404678 windows-x86,linux-arm
-compiler/loopopts/TestBackedgeLoadArrayFillMain.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
-compiler/loopopts/TestInfiniteLoopWithUnmergedBackedgesMain.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/loopopts/TestRemoveEmptyCountedLoop.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
-compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/splitif/TestCrashAtIGVNSplitIfSubType.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 
 ############################################################################
@@ -442,8 +438,6 @@ jdk/incubator/vector/Byte128VectorLoadStoreTests.java https://github.com/adoptiu
 
 # jvm_compiler
 
-compiler/arraycopy/TestCloneAccess.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/arraycopy/TestCloneAccessStressGCM.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -452,11 +446,6 @@ compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tes
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/TestReplaceEquivPhis.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/TestShiftRightAndAccumulate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/codegen/TestCharVect2.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/loopopts/superword/Vec_MulAddS2I.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/intrinsics/unsafe/HeapByteBufferTest.java#id1 https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/superword/TestPeeledReductionNode.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/ClearArray.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -467,10 +456,6 @@ compiler/loopstripmining/LoadDependsOnIfIdenticalToLoopExit.java https://github.
 compiler/loopstripmining/TestConservativeAntiDep.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestEliminatedLoadPinnedOnBackedge.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/rangechecks/RangeCheckEliminationScaleNotOne.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/types/TestSubTypeCheckMacroNodeWrongMem.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/vectorization/TestVectorsNotSavedAtSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/codegen/ClearArrayTest.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/TestJumpTable.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/vectorapi/TestNoInline.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/TestCMoveInfiniteGVN.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -480,11 +465,7 @@ compiler/loopopts/FillArrayWithUnsafe.java https://github.com/adoptium/aqa-tests
 compiler/loopopts/TestPredicateInputBelowLoopPredicate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/print/PrintInlining.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/TestRemoveEmptyLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestFewIterationsCountedLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -379,9 +379,6 @@ compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/is
 # compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -378,9 +378,6 @@ compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/is
 # compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/irTests/TestSuperwordFailsUnrolling.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86


### PR DESCRIPTION
See: https://github.com/adoptium/aqa-tests/pull/5416#issuecomment-2203540965

Was not clean:
- problem list for jdk24 does not yet exist on 1.0.2
- minor conflict in jdk17 problem list due to context change by intermediate change not present in 1.0.2 -> resolved manually