### PR TITLE
Exclude MBCS test targets

### DIFF
--- a/functional/MBCS_Tests/formatter/playlist.xml
+++ b/functional/MBCS_Tests/formatter/playlist.xml
@@ -68,6 +68,12 @@ limitations under the License.
 				<version>22+</version>
 				<impl>openj9</impl>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5148</comment>
+				<version>22+</version>
+				<impl>hotspot</impl>
+				<platform>s390x_linux</platform>
+			</disable>
 		</disables>
 		<platformRequirements>os.linux</platformRequirements>
 		<levels>
@@ -202,6 +208,12 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_formatter_Zh_TW_aix</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5148</comment>
+				<version>22+</version>
+			</disable>
+		</disables>
 		<command>LANG=Zh_TW ksh $(TEST_RESROOT)$(D)test.sh; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>
@@ -217,6 +229,12 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_formatter_zh_TW_aix</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5148</comment>
+				<version>22+</version>
+			</disable>
+		</disables>
 		<command>LANG=zh_TW ksh $(TEST_RESROOT)$(D)test.sh; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>
@@ -232,6 +250,12 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_formatter_ZH_TW_aix</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5148</comment>
+				<version>22+</version>
+			</disable>
+		</disables>
 		<command>LANG=ZH_TW ksh $(TEST_RESROOT)$(D)test.sh; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>
@@ -307,6 +331,12 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_formatter_tw_windows</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5148</comment>
+				<version>22+</version>
+			</disable>
+		</disables>
 		<command>$(TEST_RESROOT)$(D)test2.bat windows zh tw MS950 TEST_STRING; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.win</platformRequirements>

--- a/functional/MBCS_Tests/i18n/playlist.xml
+++ b/functional/MBCS_Tests/i18n/playlist.xml
@@ -30,6 +30,13 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_i18n_ko_KR_linux</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5148</comment>
+				<version>22+</version>
+				<impl>hotspot</impl>
+				<platform>s390x_linux</platform>
+			</disable>
 		<command>LANG=ko_KR.UTF-8 perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<disables>
@@ -127,6 +134,12 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_i18n_ko_KR_aix</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5148</comment>
+				<version>22+</version>
+			</disable>
+		</disables>
 		<command>LANG=ko_KR perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>
@@ -142,6 +155,12 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_i18n_KO_KR_aix</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5148</comment>
+				<version>22+</version>
+			</disable>
+		</disables>
 		<command>LANG=KO_KR perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>


### PR DESCRIPTION
Related to https://github.com/adoptium/aqa-tests/issues/5148, these targets are test material issues, not blocking so exclude until can be fixed.