### PR TITLE
Add new dependencies required for OpenJCEPlus tests

### DIFF
--- a/functional/OpenJcePlusTests/build.xml
+++ b/functional/OpenJcePlusTests/build.xml
@@ -26,7 +26,7 @@
 	<!--Properties for this particular build-->
 	<property name="src" location="./OpenJCEPlus/src/" />
 	<property name="build" location="./bin" />
-	<property name="LIB" value="junit4,hamcrest_core,bcprov_jdk18on,junit_vintage_engine,junit_platform_suite,junit_jupiter_api,junit_jupiter_engine,junit_jupiter_params,junit_platform_suite_api"/>
+	<property name="LIB" value="junit4,hamcrest_core,bcprov_jdk18on,bcpkix-jdk18on,bcprov-ext-jdk18on,junit_vintage_engine,junit_platform_suite,junit_jupiter_api,junit_jupiter_engine,junit_jupiter_params,junit_platform_suite_api"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 	<property environment="env" />
 
@@ -121,6 +121,8 @@
 				<pathelement location="${LIB_DIR}/junit4.jar" />
 				<pathelement location="${LIB_DIR}/hamcrest-core.jar" />
 				<pathelement location="${LIB_DIR}/bcprov-jdk18on.jar" />
+				<pathelement location="${LIB_DIR}/bcprov-ext-jdk18on.jar" />
+				<pathelement location="${LIB_DIR}/bcpkix-jdk18on.jar" />
 				<pathelement location="${LIB_DIR}/junit-vintage-engine.jar" />
 				<pathelement location="${LIB_DIR}/junit-platform-suite.jar" />
 				<pathelement location="${LIB_DIR}/junit-jupiter-api.jar" />
@@ -141,6 +143,8 @@
 			<fileset dir="${LIB_DIR}/" includes="junit4.jar" />
 			<fileset dir="${LIB_DIR}/" includes="hamcrest-core.jar" />
 			<fileset dir="${LIB_DIR}/" includes="bcprov-jdk18on.jar" />
+			<fileset dir="${LIB_DIR}/" includes="bcprov-ext-jdk18on.jar" />
+			<fileset dir="${LIB_DIR}/" includes="bcpkix-jdk18on.jar" />
 			<fileset dir="${LIB_DIR}/" includes="junit-vintage-engine.jar" />
 			<fileset dir="${LIB_DIR}/" includes="junit-platform-suite.jar" />
 			<fileset dir="${LIB_DIR}/" includes="junit-jupiter-api.jar" />

--- a/functional/OpenJcePlusTests/test.xml
+++ b/functional/OpenJcePlusTests/test.xml
@@ -43,7 +43,7 @@
 		</java>
 	</target>
 	<target name="test">
-		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMemStressAll" />
+		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:bcprov-ext-jdk18on.jar:bcpkix-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMemStressAll" />
 		<junit fork="yes" printsummary="on" showoutput="yes" haltonfailure="yes">
 			<jvmarg line="--add-exports=java.base/sun.security.util=ALL-UNNAMED" />
 			<jvmarg line="--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED" />
@@ -51,6 +51,8 @@
 				<pathelement location="junit4.jar" />
 				<pathelement location="hamcrest-core.jar" />
 				<pathelement location="bcprov-jdk18on.jar" />
+				<pathelement location="bcprov-ext-jdk18on.jar" />
+				<pathelement location="bcpkix-jdk18on.jar" />
 				<pathelement location="openjceplus-tests.jar" />
 				<pathelement location="junit-vintage-engine.jar" />
 				<pathelement location="junit-platform-suite.jar" />
@@ -63,7 +65,7 @@
 			<test name="ibm.jceplus.junit.TestMemStressAll" todir="junitreports"/>
 		</junit>
 		<echo message="TestMemStressAll COMPLETED" />
-		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMultiThread" />
+		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:bcprov-ext-jdk18on.jar:bcpkix-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMultiThread" />
 		<junit fork="yes" printsummary="on" showoutput="yes" haltonfailure="yes">
 			<jvmarg line="--add-exports=java.base/sun.security.util=ALL-UNNAMED" />
 			<jvmarg line="--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED" />
@@ -71,6 +73,8 @@
 				<pathelement location="junit4.jar" />
 				<pathelement location="hamcrest-core.jar" />
 				<pathelement location="bcprov-jdk18on.jar" />
+				<pathelement location="bcprov-ext-jdk18on.jar" />
+				<pathelement location="bcpkix-jdk18on.jar" />
 				<pathelement location="openjceplus-tests.jar" />
 				<pathelement location="junit-vintage-engine.jar" />
 				<pathelement location="junit-platform-suite.jar" />
@@ -83,7 +87,7 @@
 			<test name="ibm.jceplus.junit.TestMultithread" todir="junitreports"/>
 		</junit>
 		<echo message="TestMultithread COMPLETED" />
-		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMultiThreadFIPS" />
+		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:bcprov-ext-jdk18on.jar:bcpkix-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestMultiThreadFIPS" />
 		<junit fork="yes" printsummary="on" showoutput="yes" haltonfailure="yes">
 			<jvmarg line="--add-exports=java.base/sun.security.util=ALL-UNNAMED" />
 			<jvmarg line="--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED" />
@@ -91,6 +95,8 @@
 				<pathelement location="junit4.jar" />
 				<pathelement location="hamcrest-core.jar" />
 				<pathelement location="bcprov-jdk18on.jar" />
+				<pathelement location="bcprov-ext-jdk18on.jar" />
+				<pathelement location="bcpkix-jdk18on.jar" />
 				<pathelement location="openjceplus-tests.jar" />
 				<pathelement location="junit-vintage-engine.jar" />
 				<pathelement location="junit-platform-suite.jar" />
@@ -103,7 +109,7 @@
 			<test name="ibm.jceplus.junit.TestMultithreadFIPS" todir="junitreports"/>
 		</junit>
 		<echo message="TestMultithreadFIPS COMPLETED" />
-		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestAll" />
+		<echo message="Command: ${TEST_JAVA} -cp junit4.jar:hamcrest-core.jar:bcprov-jdk18on.jar:bcprov-ext-jdk18on.jar:bcpkix-jdk18on.jar:openjceplus-tests.jar:junit-vintage-engine.jar:junit-platform-suite.jar:junit-jupiter-api.jar:junit-jupiter-engine.jar:junit-jupiter-params.jar:junit-platform-suite-api.jar --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED ibm.jceplus.junit.TestAll" />
 		<junit fork="yes" printsummary="on" showoutput="yes" haltonfailure="yes">
 			<jvmarg line="--add-exports=java.base/sun.security.util=ALL-UNNAMED" />
 			<jvmarg line="--add-exports=openjceplus/com.ibm.crypto.plus.provider.ock=ALL-UNNAMED" />
@@ -111,6 +117,8 @@
 				<pathelement location="junit4.jar" />
 				<pathelement location="hamcrest-core.jar" />
 				<pathelement location="bcprov-jdk18on.jar" />
+				<pathelement location="bcprov-ext-jdk18on.jar" />
+				<pathelement location="bcpkix-jdk18on.jar" />
 				<pathelement location="openjceplus-tests.jar" />
 				<pathelement location="junit-vintage-engine.jar" />
 				<pathelement location="junit-platform-suite.jar" />


### PR DESCRIPTION
The OpenJCEPlus tests require a new test dependency for interop testing with bouncy castle.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>