### PR TITLE
Only one disables section is allowed

### DIFF
--- a/functional/MBCS_Tests/i18n/playlist.xml
+++ b/functional/MBCS_Tests/i18n/playlist.xml
@@ -30,6 +30,8 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_i18n_ko_KR_linux</testCaseName>
+		<command>LANG=ko_KR.UTF-8 perl $(TEST_RESROOT)$(D)test.pl; \
+	$(TEST_STATUS)</command>
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/5148</comment>
@@ -37,10 +39,6 @@ limitations under the License.
 				<impl>hotspot</impl>
 				<platform>s390x_linux</platform>
 			</disable>
-		</disables>
-		<command>LANG=ko_KR.UTF-8 perl $(TEST_RESROOT)$(D)test.pl; \
-	$(TEST_STATUS)</command>
-		<disables>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/19083</comment>
 				<version>22+</version>


### PR DESCRIPTION
Only one `disables` section is allowed

Related to 
* https://github.com/adoptium/aqa-tests/pull/5454

Tested in [a personal grinder](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/42097/)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>