### PR TITLE
Exclude jfr tests on aarch32 linux

### DIFF
--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk8.txt
@@ -120,4 +120,3 @@ java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issu
 ############################################################################
 
 # jdk_jfr
-jdk/jfr linux-arm

--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk8.txt
@@ -120,3 +120,4 @@ java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issu
 ############################################################################
 
 # jdk_jfr
+jdk/jfr linux-arm

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1476,6 +1476,10 @@
 		<testCaseName>jdk_jfr</testCaseName>
 		<disables>
 			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/3115#issuecomment-2256561374</comment>
+				<vendor>eclipse</vendor>
+			</disable>
+			<disable>
 				<comment>https://bugs.openjdk.java.net/browse/JDK-8203290</comment>
 				<platform>.*aix.*</platform>
 			</disable>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1478,6 +1478,8 @@
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3115#issuecomment-2256561374</comment>
 				<vendor>eclipse</vendor>
+				<platform>arm_linux</platform>
+				<version>8</version>
 			</disable>
 			<disable>
 				<comment>https://bugs.openjdk.java.net/browse/JDK-8203290</comment>


### PR DESCRIPTION
JFR tests will fail on aarch32. We should exclude them to avoid false positives. See explanation here: https://github.com/adoptium/aqa-tests/issues/3115#issuecomment-2256561374
