### PR TITLE
openjdk: exclude runtime/os/TestTracePageSizes.java test

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -469,6 +469,10 @@ runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all
+runtime/os/TestTracePageSizes.java#with-G1 https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#with-Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#with-Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -454,6 +454,10 @@ runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all
+runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -453,6 +453,10 @@ runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all
+runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -453,6 +453,10 @@ runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all
+runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
Exclude `TestTracePageSizes`, as it [fails on rhel-7](https://ci.adoptium.net/view/Test_openjdk/job/Test_openjdk23_hs_dev.openjdk_x86-64_linux_testList_0/2/) (see [JDK-8337555](https://bugs.openjdk.org/browse/JDK-8337555) ). Test is jdk17+. Cases have little different name on 17 due to abence of [JDK-8273928](https://bugs.openjdk.org/browse/JDK-8273928).

**Testing (x86-64_linux):**
jdk17: [OK](https://ci.adoptium.net/job/Grinder/10667/) (test cases excluded)
jdk21: [OK](https://ci.adoptium.net/job/Grinder/10668/) (test cases excluded)