### PR TITLE
openjdk: add missing workdir arg to hostspot_gc target

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -278,6 +278,7 @@
 		<testCaseName>hotspot_gc</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JVM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
 	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
 	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
 	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \


### PR DESCRIPTION
Fix for missing `-w` arg in `hotspot_gc` openjdk test target, reported on slack. Seems like option was [removed accidentally](https://github.com/adoptium/aqa-tests/commit/0d860c74ea1a71ce29e91bee8a1dff8613a7b461#diff-d2ae1ce824e94cb07603a5a77c2d8ab3c5b00617153e8d66e54a78a3ccfb4f1dL78).

Testing:
x86-64_linux / jdk17: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10682/)