### PR TITLE
Issue 5428: Allow JRE testing for other testsuite aside from JCK

### DIFF
--- a/commonSetup.mk
+++ b/commonSetup.mk
@@ -1,0 +1,18 @@
+##############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+JAVA_TO_TEST = $(JAVA_COMMAND)
+ifeq ($(USE_JRE),1)
+  JAVA_TO_TEST = $(JRE_COMMAND)
+endif

--- a/functional/functional.mk
+++ b/functional/functional.mk
@@ -1,0 +1,15 @@
+##############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+include $(TEST_ROOT)/commonSetup.mk

--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -126,10 +126,7 @@ ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
 	APPLICATION_OPTIONS+=$(Q)
 endif
 
-JAVA_TO_TEST = $(JAVA_COMMAND)
-ifeq ($(USE_JRE),1)
-  JAVA_TO_TEST = $(JRE_COMMAND)
-endif
+include $(TEST_ROOT)/commonSetup.mk
 
 JCK_CMD_TEMPLATE = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavatestUtil workdir=$(REPORTDIR) testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) spec=$(SPEC) configAltPath=$(CONFIG_ALT_PATH) $(APPLICATION_OPTIONS)
 WORKSPACE=/home/jenkins/jckshare/workspace/output_$(UNIQUEID)/$@


### PR DESCRIPTION
JAVA_TO_TEST definition moved to allow for JRE testing of other than just JCK testsuite

https://github.com/adoptium/aqa-tests/issues/5428