### PR TITLE
Issue 5428: Allow JRE testing for other testsuite aside from JCK

### DIFF
--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -126,11 +126,6 @@ ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
 	APPLICATION_OPTIONS+=$(Q)
 endif
 
-JAVA_TO_TEST = $(JAVA_COMMAND)
-ifeq ($(USE_JRE),1)
-  JAVA_TO_TEST = $(JRE_COMMAND)
-endif
-
 JCK_CMD_TEMPLATE = $(JAVA_TO_TEST) -Djvm.options=$(Q)$(JVM_OPTIONS)$(Q) -Dother.opts=$(Q)$(OTHER_OPTS)$(Q) -cp $(TEST_ROOT)/jck/jtrunner/bin JavatestUtil workdir=$(REPORTDIR) testRoot=$(TEST_ROOT) jckRoot=$(JCK_ROOT) jckversion=$(JCK_VERSION) spec=$(SPEC) configAltPath=$(CONFIG_ALT_PATH) $(APPLICATION_OPTIONS)
 WORKSPACE=/home/jenkins/jckshare/workspace/output_$(UNIQUEID)/$@
 


### PR DESCRIPTION
moving JAVA_TO_TEST definition to TKG settings.mk file
https://github.com/adoptium/aqa-tests/issues/5428