### PR TITLE
Update TestUnrollLimitPreciseType exclusion with JBS link

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -22,7 +22,7 @@ compiler/intrinsics/sha/TestSHA.java https://github.com/adoptium/aqa-tests/issue
 
 # hotspot_jre
 
-compiler/loopopts/TestUnrollLimitPreciseType.java#test1 https://github.com/adoptium/aqa-tests/issues/5475 linux-arm,windows-x86
+compiler/loopopts/TestUnrollLimitPreciseType.java#test1 https://bugs.openjdk.org/browse/JDK-8338125 linux-arm,windows-x86
 compiler/c2/Test8202414.java https://bugs.openjdk.java.net/browse/JDK-8251152 linux-arm
 compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tests/issues/2671 linux-ppc64le,aix-all,linux-arm,windows-x86
 # compiler/6894807/IsInstanceTest.java https://github.com/adoptium/adoptium/issues/58 aix-all


### PR DESCRIPTION
Related: https://github.com/adoptium/aqa-tests/issues/5475