### PR TITLE
Propagate JAVA_TOOL_OPTIONS down to external tests in container

### DIFF
--- a/external/dockerfile_functions.sh
+++ b/external/dockerfile_functions.sh
@@ -197,11 +197,11 @@ print_jdk_install() {
             "\n\t PATH=\"/opt/java/openjdk/bin:\$PATH\" " \
             "\n" >> ${file}
 
-    echo -e "\nENV JAVA_TOOL_OPTIONS=\"-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle\" " \
+    echo -e "\nENV JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS -XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle\" " \
             "\n" >> ${file}
 
     echo -e "\nENV RANDFILE=/tmp/.rnd  \\" \
-            "\n\t OPENJ9_JAVA_OPTIONS=\"-XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Dosgi.checkConfiguration=false\" " \
+            "\n\t OPENJ9_JAVA_OPTIONS=\"$OPENJ9_JAVA_OPTIONS  -XX:+IgnoreUnrecognizedVMOptions -XX:+IdleTuningGcOnIdle -Dosgi.checkConfiguration=false\" " \
             "\n" >> ${file}
 
 }
@@ -445,7 +445,7 @@ print_maven_install() {
 print_java_tool_options() {
     local file=$1
 
-    echo -e "ENV JAVA_TOOL_OPTIONS=\"-Dfile.encoding=UTF8 -Djava.security.egd=file:/dev/./urandom\"\n" >> ${file}
+    echo -e "ENV JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8 -Djava.security.egd=file:/dev/./urandom\"\n" >> ${file}
 }
 
 print_environment_variable() {

--- a/external/jenkins/test.sh
+++ b/external/jenkins/test.sh
@@ -16,7 +16,7 @@ source $(dirname "$0")/test_base_functions.sh
 # Set up Java to be used by the jenkins test
 echo_setup
 
-export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8"
 #begin jenkins test
 
 set -e

--- a/external/scala/test.sh
+++ b/external/scala/test.sh
@@ -17,7 +17,7 @@ source $(dirname "$0")/test_base_functions.sh
 echo_setup
 
 TEST_SUITE=$1
-export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
+export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8"
 #begin scala test
 set -e
 


### PR DESCRIPTION
Currently the external tests are swallowng the JAVA_TOOL_OPTIONS and thus the tested JDK does miss the global config. This pr should be fixing that