### PR TITLE
Microsoft problem listing for July 2024 PSU

### DIFF
--- a/openjdk/excludes/vendors/microsoft/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/vendors/microsoft/ProblemList_openjdk17.txt
@@ -99,6 +99,7 @@ java/lang/module/ModuleDescriptorHashCodeTest.java https://bugs.openjdk.org/brow
 tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/JStackStressTest.java https://github.com/adoptium/aqa-tests/issues/5499 windows-x64
 
 ############################################################################
 


### PR DESCRIPTION
Hey team!

We would like to problem list JStackStressTest.java from running on Microsoft's build of OpenJDK 17u. This test is reliably failing due to connecting to WinDBG. At least that is what I can tell from the logs. The issue we see is described well in this [JBS bug](https://bugs.openjdk.org/browse/JDK-8204994). Though we see if for the test we are wanting to problem list. 

I have created a new Github issue for this entry. I hope that is the correct thing to do!
https://github.com/adoptium/aqa-tests/issues/5499

If there are any questions or concerns, please let me know!