### PR TITLE
Update ubuntu24 to use for CRIU docker based tests

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -181,6 +181,7 @@ timestamps{
             'aarch64_linux' : [
                     	// no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.20"],
                     	// https://github.ibm.com/runtimes/infrastructure/issues/9721 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.aarch64.armv8"],
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.24&&hw.arch.aarch64.armv8"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.aarch64.armv8"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.aarch64.armv8"]
                     ],
@@ -209,7 +210,8 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
                     ],
             'aarch64_linux' : [
-                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22"],
+                        // ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22"],
+                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.24"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
                     ],

--- a/external/criuSettings.mk
+++ b/external/criuSettings.mk
@@ -21,7 +21,7 @@ export CRIU_COMBO_LIST_linux_390_64_z13=sw.os.ubuntu.22-hw.arch.s390x.z13 sw.os.
 export CRIU_COMBO_LIST_linux_390_64_z14=sw.os.ubuntu.22-hw.arch.s390x.z14 sw.os.rhel.8-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z14 sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
 export CRIU_COMBO_LIST_linux_390_64_z15=sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
 
-export CRIU_COMBO_LIST_linux_aarch64=sw.os.rhel.9-hw.arch.aarch64.armv8 sw.os.rhel.8-hw.arch.aarch64.armv8
+export CRIU_COMBO_LIST_linux_aarch64=sw.os.rhel.9-hw.arch.aarch64.armv8 sw.os.rhel.8-hw.arch.aarch64.armv8 sw.os.ubuntu.24-hw.arch.aarch64.armv8
 # not available: sw.os.ubuntu.20-hw.arch.aarch64.armv8 sw.os.ubuntu.22-hw.arch.aarch64.armv8 
 
 export CRIU_COMBO_LIST_linux_ppc_64_p9=sw.os.rhel.9-hw.arch.ppc64le.p9


### PR DESCRIPTION
Update ubuntu24 to use for CRIU docker based tests
related: https://github.ibm.com/runtimes/backlog/issues/1487