### PR TITLE
Update openjdk testcases in playlist to skip FIPS tests.

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -93,6 +93,11 @@
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>hotspot_custom</testCaseName>
@@ -243,6 +248,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<platformRequirementsList>
 			<platformRequirements>os.linux</platformRequirements>
 		</platformRequirementsList>
@@ -273,6 +283,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<platformRequirements>os.linux</platformRequirements>
 	</test>
 	<test>
@@ -409,6 +424,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -442,6 +462,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -482,6 +507,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>hotspot_sanity</testCaseName>
@@ -576,6 +606,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_beans</testCaseName>
@@ -611,6 +646,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_io</testCaseName>
@@ -637,6 +677,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_lang</testCaseName>
@@ -663,6 +708,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_lang_j9</testCaseName>
@@ -687,6 +737,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -719,6 +774,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_lang_native_win</testCaseName>
@@ -747,6 +807,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<platformRequirements>os.win,bits.64</platformRequirements>
 	</test>
 	<test>
@@ -778,6 +843,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -808,6 +878,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -837,6 +912,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -867,6 +947,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_math_jre</testCaseName>
@@ -899,6 +984,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_other</testCaseName>
@@ -985,6 +1075,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_security1</testCaseName>
@@ -1178,6 +1273,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_swing</testCaseName>
@@ -1209,6 +1309,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_text</testCaseName>
@@ -1235,6 +1340,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_util</testCaseName>
@@ -1261,6 +1371,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_time</testCaseName>
@@ -1297,6 +1412,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_management</testCaseName>
@@ -1333,6 +1453,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_jmx</testCaseName>
@@ -1368,6 +1493,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_rmi</testCaseName>
@@ -1434,6 +1564,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_tools_openj9_DynamicLoadWarningTest</testCaseName>
@@ -1459,6 +1594,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -1501,6 +1641,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_jfr</testCaseName>
@@ -1574,6 +1719,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_instrument</testCaseName>
@@ -1614,6 +1764,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<!-- From jdk11 jdk_jdi is part of jdk_svc_sanity -->
 	<test>
@@ -1663,6 +1818,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_jdi</testCaseName>
@@ -1701,6 +1861,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<!-- ClassesByName2Test is a subtest of jdk_jdi. Once jdk_jdi is fully enabled in openj9/ibm, the classesByName2Test below can be removed  -->
 	<test>
@@ -1734,6 +1899,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<!-- JdwpAttachTest is a subtest of jdk_jdi. Once jdk_jdi is fully enabled in openj9/ibm, the JdwpAttachTest below can be removed  -->
 	<test>
@@ -1767,6 +1937,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_build</testCaseName>
@@ -1806,6 +1981,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_imageio</testCaseName>
@@ -1842,6 +2022,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_client_sanity</testCaseName>
@@ -1884,6 +2069,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_security_infra</testCaseName>
@@ -1947,6 +2137,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 
 	<test>
@@ -2019,6 +2214,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_jfc_demo</testCaseName>
@@ -2060,6 +2260,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk11_tier1_buffer</testCaseName>
@@ -2089,6 +2294,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk11_tier1_iso8859</testCaseName>
@@ -2118,6 +2328,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk11_tier1_pack200</testCaseName>
@@ -2188,6 +2403,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_vector_float128_j9</testCaseName>
@@ -2213,6 +2433,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -2242,6 +2467,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -2271,6 +2501,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -2300,6 +2535,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -2329,6 +2569,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -2358,6 +2603,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -2387,6 +2637,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -2707,5 +2962,10 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 </playlist>


### PR DESCRIPTION
- Added features to ibm/openj9 openjdk testcases to accommodate the following TESTFLAGS: FIPS140_2, FIPS140_3_OpenJCEPlusFIPS, FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.

related: https://github.ibm.com/runtimes/backlog/issues/1494