### PR TITLE
(v1.0.4-release) Skipped FIPS test for jdk11_tier1_pack200 and jdk_native_sanity testcase. (#5543)

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -89,15 +89,15 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
-		<impls>
-			<impl>openj9</impl>
-			<impl>ibm</impl>
-		</impls>
 		<features>
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
 		</features>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
 	</test>
 	<test>
 		<testCaseName>hotspot_custom</testCaseName>
@@ -2172,6 +2172,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_2d</testCaseName>
@@ -2362,6 +2367,11 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_vector</testCaseName>


### PR DESCRIPTION
- Added features to OpenJDK test cases - `jdk11_tier1_pack200` and `jdk_native_sanity`` to accommodate the following TESTFLAGS: FIPS140_2, FIPS140_3_OpenJCEPlusFIPS, FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.

related: https://github.ibm.com/runtimes/backlog/issues/1494