### PR TITLE
Use gmake instead of make on AIX to avoid aqa-tests issue 5542

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -332,7 +332,7 @@ def genParallelList(PARALLEL_OPTIONS) {
 	if (JDK_IMPL == 'hotspot' && PLATFORM.contains('alpine-linux')) {
 		unsetLLP = "unset LD_LIBRARY_PATH;"
 	}
-	sh "cd ./aqa-tests/TKG; ${unsetLLP} make genParallelList ${PARALLEL_OPTIONS}"
+	sh "cd ./aqa-tests/TKG; $RESOLVED_MAKE; ${unsetLLP} \$MAKE genParallelList ${PARALLEL_OPTIONS}"
 	def parallelList = "aqa-tests/TKG/parallelList.mk"
 	int NUM_LIST = -1
 	if (fileExists("${parallelList}")) {


### PR DESCRIPTION
...where make fails with this error:
make: Dependency line needs colon or double colon operator.

Resolves https://github.com/adoptium/aqa-tests/issues/5542