### PR TITLE
openjdk: Move langtools_all to sanity

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2967,7 +2967,7 @@
 	$(Q)$(JTREG_LANGTOOLS_TEST_DIR)$(Q); \
 	$(TEST_STATUS)</command>
 		<levels>
-			<level>dev</level>
+			<level>sanity</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>


### PR DESCRIPTION
This moves langtools_all openjdk target from dev level to sanity level. See: https://github.com/adoptium/aqa-tests/issues/5424

Testing:
x86_64
21: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10816/)
17: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10815/)
11: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10814/)
8: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10813/)

aarch64:
21: [OK](https://ci.adoptium.net/view/Test_grinder/job/Grinder/10817/)