### PR TITLE
(v1.0.2) Temporarily move criu softmx test to special (#5394)

### DIFF
--- a/external/criu-functional/playlist.xml
+++ b/external/criu-functional/playlist.xml
@@ -51,7 +51,7 @@
 			<impl>openj9</impl>
 		</impls>
 		<levels>
-			<level>dev</level>
+			<level>special</level>
 		</levels>
 		<groups>
 			<group>external</group>


### PR DESCRIPTION
Cherry-pick
- Criu softmx test image got deleted before test in dev.external
- Temporarily move it to special, and move back once fixed