### PR TITLE
(v1.0.2)Exclude tests for alinux machine (#5497)

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -179,8 +179,8 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.broadwell"]
                     ],
             'aarch64_linux' : [
-                        // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.20"],
-                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.aarch64.armv8"],
+                    	// no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.20"],
+                    	// https://github.ibm.com/runtimes/infrastructure/issues/9721 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.aarch64.armv8"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.aarch64.armv8"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.aarch64.armv8"]
                     ],

--- a/external/criuSettings.mk
+++ b/external/criuSettings.mk
@@ -21,8 +21,8 @@ export CRIU_COMBO_LIST_linux_390_64_z13=sw.os.ubuntu.22-hw.arch.s390x.z13 sw.os.
 export CRIU_COMBO_LIST_linux_390_64_z14=sw.os.ubuntu.22-hw.arch.s390x.z14 sw.os.rhel.8-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z14 sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
 export CRIU_COMBO_LIST_linux_390_64_z15=sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
 
-export CRIU_COMBO_LIST_linux_aarch64=sw.os.ubuntu.22-hw.arch.aarch64.armv8 sw.os.rhel.9-hw.arch.aarch64.armv8 sw.os.rhel.8-hw.arch.aarch64.armv8
-# not available: sw.os.ubuntu.20-hw.arch.aarch64.armv8
+export CRIU_COMBO_LIST_linux_aarch64=sw.os.rhel.9-hw.arch.aarch64.armv8 sw.os.rhel.8-hw.arch.aarch64.armv8
+# not available: sw.os.ubuntu.20-hw.arch.aarch64.armv8 sw.os.ubuntu.22-hw.arch.aarch64.armv8 
 
 export CRIU_COMBO_LIST_linux_ppc_64_p9=sw.os.rhel.9-hw.arch.ppc64le.p9
 export CRIU_COMBO_LIST_linux_ppc_64_p10=sw.os.rhel.8-hw.arch.ppc64le.p10


### PR DESCRIPTION
cherry-pick
- Exclude tests for the alinux machine temporarily, as the CRIU Docker-based testing requires an alinux machine, which is currently unavailable.

related: https://github.ibm.com/runtimes/backlog/issues/1487