### PR TITLE
Temporarily exclude alinux ubu22 image pull

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -209,7 +209,7 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
                     ],
             'aarch64_linux' : [
-                        ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22"],
+                        // no machine available, ibm_git/infrastructure/issues/9721 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8"],
                         ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
                     ],


### PR DESCRIPTION
The machine is not available so far