### PR TITLE
Temporarily exclude plinux dev.external for release

### DIFF
--- a/buildenv/jenkins/config/openj9/default.json
+++ b/buildenv/jenkins/config/openj9/default.json
@@ -5,7 +5,7 @@
             { "aarch64_linux" : "defaultTestTargets,dev.external" },
             { "aarch64_mac" : "defaultTestTargets" },
             { "ppc64_aix" : "defaultTestTargets" },
-            { "ppc64le_linux" : "defaultTestTargets,dev.external" },
+            { "ppc64le_linux" : "defaultTestTargets" },
             { "s390x_linux" : "defaultTestTargets,dev.external" },
             { "x86-64_linux" : "defaultTestTargets,dev.external" },
             { "x86-64_mac" : "defaultTestTargets" },


### PR DESCRIPTION
Temporarily exclude plinux dev.external for release

Issue: https://github.com/eclipse-openj9/openj9/issues/18468