### PR TITLE
Exclude java/nio/channels/DatagramChannel/Disconnect.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -242,6 +242,7 @@ java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/BasicMulticastTests.java https://github.ibm.com/runtimes/backlog/issues/966 macosx-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
+java/nio/channels/DatagramChannel/Disconnect.java https://github.com/eclipse-openj9/openj9/issues/20115 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all,linux-s390x
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
 #java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x


### PR DESCRIPTION
Exclude `java/nio/channels/DatagramChannel/Disconnect.java`

There is a compilation error: cannot find symbol `InetAddress.ofLiteral()`.

Related to
* https://github.com/eclipse-openj9/openj9/issues/20115

Signed-off-by: Jason Feng <fengj@ca.ibm.com>