### PR TITLE
Workaround for temurin-compliance getDependency url no authentication

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1070,7 +1070,10 @@ def getCustomUrl() {
 	def jenkinsDomain = getJenkinsDomain()
 	if (jenkinsDomain.contains("hyc-runtimes")) {
 		jenkinsDomain = "openj9-jenkins.osuosl.org"
-	}
+	} else if (jenkinsDomain.contains("temurin-compliance")) {
+                jenkinsDomain = "ci.adoptium.net"
+        }
+
 	def customUrl = "https://${jenkinsDomain}/job/test.getDependency/lastSuccessfulBuild/artifact/"
 	echo "Custom URL: ${customUrl}"
 	return customUrl


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/5589

Fix/workaround for temurin-compliance getDependency failure due to no authentication.
For temurin-compliance we can use ci.adoptium.net getDependencies.
