### PR TITLE
Exclude FIPS104_2 for OpenJcePlusTests (#5599)

### DIFF
--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -42,6 +42,9 @@
 		mkdir junitreports; \
 		cp -r ${REPORTDIR}/target/surefire-reports/* junitreports
 		</command>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+		</features>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
- Added feature tag to disable FIPS140_2 for OpenJcePlusTests.

related:https://github.ibm.com/runtimes/backlog/issues/1523