### PR TITLE
Exclude windows beans due to headless detection JDK-8336862

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -18,16 +18,16 @@
 
 # jdk_beans
 
-# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/XMLEncoder/java_awt_ScrollPane.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
 java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
 java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
@@ -420,7 +420,7 @@ javax/management/remote/mandatory/util/MapNullValuesTest.java https://github.com
 # jdk_imageio
 
 javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -51,6 +51,16 @@ java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/iss
 java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
 
 ############################################################################
 
@@ -409,6 +419,7 @@ javax/management/remote/mandatory/util/MapNullValuesTest.java https://github.com
 # jdk_imageio
 
 javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -18,21 +18,32 @@
 
 # jdk_beans
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
 # java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
 # java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 # java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
@@ -51,16 +62,6 @@ java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/iss
 java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -18,16 +18,16 @@
 
 # jdk_beans
 
-# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
+# java/beans/XMLEncoder/java_awt_ScrollPane.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
 java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
 java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
@@ -420,7 +420,7 @@ javax/management/remote/mandatory/util/MapNullValuesTest.java https://github.com
 # jdk_imageio
 
 javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -51,6 +51,16 @@ java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/iss
 java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
 
 ############################################################################
 
@@ -409,6 +419,7 @@ javax/management/remote/mandatory/util/MapNullValuesTest.java https://github.com
 # jdk_imageio
 
 javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -18,21 +18,32 @@
 
 # jdk_beans
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
+
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
 # java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
 # java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 # java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
@@ -51,16 +62,6 @@ java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/iss
 java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/5616 windows-all
 
 ############################################################################
 


### PR DESCRIPTION
Exclude Windows beans tests that fail with headless detection issue "application does not have desktop access"
ref: https://bugs.openjdk.org/browse/JDK-8336862
