### PR TITLE
openjdk: promote hotspot test to extended level

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -335,7 +335,7 @@
 			<version>11+</version>
 		</versions>
 		<levels>
-			<level>dev</level>
+			<level>extended</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>
@@ -361,7 +361,7 @@
 			<version>11+</version>
 		</versions>
 		<levels>
-			<level>dev</level>
+			<level>extended</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>
@@ -387,7 +387,7 @@
 			<version>11+</version>
 		</versions>
 		<levels>
-			<level>dev</level>
+			<level>extended</level>
 		</levels>
 		<groups>
 			<group>openjdk</group>


### PR DESCRIPTION
Promote `hotspot_gc`, `hotspot_runtime`, `hotspot_serviceability` to extended level. See: https://github.com/adoptium/aqa-tests/issues/5424

Results of dev.openjdk ([jdk21](https://ci.adoptium.net/view/Test_openjdk/job/Test_openjdk21_hs_dev.openjdk_x86-64_linux/28/), [jdk11](https://ci.adoptium.net/view/Test_openjdk/job/Test_openjdk11_hs_dev.openjdk_x86-64_linux/23/)) show just 1 serviceability issue. I have done other [PR](https://github.com/adoptium/aqa-tests/pull/5623) to exclude it.
