### PR TITLE
[v1.0.4-release] Add VectorGatherMaskFoldingTest to excludes for jdk23 s390x (#5628)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -385,6 +385,7 @@ compiler/codecache/MHIntrinsicAllocFailureTest.java https://bugs.openjdk.org/bro
 compiler/whitebox/ForceNMethodSweepTest.java https://bugs.openjdk.org/browse/JDK-8265181 linux-arm
 compiler/codegen/aes/Test8292158.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
 compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
+compiler/vectorapi/VectorGatherMaskFoldingTest.java https://bugs.openjdk.org/browse/JDK-8333248 linux-s390x
 
 ############################################################################
 


### PR DESCRIPTION
Cherry pick of #5628