### PR TITLE
Add riscv exclude for jdk23 VectorGatherMaskFoldingTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -385,7 +385,7 @@ compiler/codecache/MHIntrinsicAllocFailureTest.java https://bugs.openjdk.org/bro
 compiler/whitebox/ForceNMethodSweepTest.java https://bugs.openjdk.org/browse/JDK-8265181 linux-arm
 compiler/codegen/aes/Test8292158.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
 compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
-compiler/vectorapi/VectorGatherMaskFoldingTest.java https://bugs.openjdk.org/browse/JDK-8333248 linux-s390x
+compiler/vectorapi/VectorGatherMaskFoldingTest.java https://bugs.openjdk.org/browse/JDK-8333248 linux-s390x,linux-riscv64
 
 ############################################################################
 


### PR DESCRIPTION
The test also fails on riscv:

Test material needs an update from JDK-8333248. Exclude until that is backported to 23.

Related: #5620 #5628 