### PR TITLE
Add new test for off-heap

### DIFF
--- a/functional/SyntheticGCWorkload/playlist.xml
+++ b/functional/SyntheticGCWorkload/playlist.xml
@@ -164,19 +164,13 @@
 		</groups>
 	</test>
 	<test>
-		<testCaseName>SyntheticGCWorkload_DoubleMap_J9</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/8034</comment>
-				<platform>.*aarch64.*</platform>
-			</disable>
-		</disables>
+		<testCaseName>SyntheticGCWorkload_OffHeap_J9</testCaseName>
 		<variations>
-			<variation>-Xmx2g -Xdump:none -Xgcpolicy:balanced -Xgc:enableArrayletDoubleMapping -verbose:gc</variation>
+			<variation>-Xmx2g -Xdump:none -Xgcpolicy:balanced -XXgc:enableVirtualLargeObjectHeap -verbose:gc</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(TEST_RESROOT)$(D)SyntheticGCWorkload.jar$(Q) net.adoptopenjdk.casa.workload_sessions.Main $(TEST_RESROOT)/config/config_doubleMapStress.xml -n; \
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(TEST_RESROOT)$(D)SyntheticGCWorkload.jar$(Q) net.adoptopenjdk.casa.workload_sessions.Main $(TEST_RESROOT)/config/config_offHeapStress.xml -n; \
 	${TEST_STATUS}</command>
-		<platformRequirements>bits.64,^os.aix,^os.win,^os.zos</platformRequirements>
+		<platformRequirements>bits.64</platformRequirements>
 		<levels>
 			<level>extended</level>
 		</levels>


### PR DESCRIPTION
Arraylet doubleMapping has been replaced with new off-heap feature, update test SyntheticGCWorkload_DoubleMap_J9 to test SyntheticGCWorkload_OffHeap_J9 for testing offheap.
 - the change in playlist.xml
 - new config_offHeapStress.xml file

On Hold until off heap changes are merged