### PR TITLE
Limit OpenJcePlusTests to run with FIPS140-3 profile only

### DIFF
--- a/functional/OpenJcePlusTests/build.xml
+++ b/functional/OpenJcePlusTests/build.xml
@@ -120,29 +120,27 @@
 		<delete dir="${build}" />
 	</target>
 
-	<target name="build" >
+	<target name="build">
 		<if>
-			<or>
+			<and>
 				<contains string="${TEST_FLAG}" substring="FIPS140_3_OpenJCEPlusFIPS"/>
-				<and>
-					<equals arg1="${JDK_VENDOR}" arg2="ibm" />
-					<equals arg1="${JDK_IMPL}" arg2="openj9" />
-					<not>
-						<matches string="${JDK_VERSION}" pattern="^(8)$$" />
-					</not>
-					<or>
-						<contains string="${SPEC}" substring="aix_ppc-64"/>
-						<contains string="${SPEC}" substring="linux_ppc-64_le"/>
-						<contains string="${SPEC}" substring="linux_x86-64"/>
-						<contains string="${SPEC}" substring="win_x86-64"/>
-						<contains string="${SPEC}" substring="linux_390-64"/>
-					</or>
-				</and>
-			</or>
+				<equals arg1="${JDK_VENDOR}" arg2="ibm" />
+				<equals arg1="${JDK_IMPL}" arg2="openj9" />
+				<not>
+					<matches string="${JDK_VERSION}" pattern="^(8)$" />
+				</not>
+				<or>
+					<contains string="${SPEC}" substring="aix_ppc-64"/>
+					<contains string="${SPEC}" substring="linux_ppc-64_le"/>
+					<contains string="${SPEC}" substring="linux_x86-64"/>
+					<contains string="${SPEC}" substring="win_x86-64"/>
+					<contains string="${SPEC}" substring="linux_390-64"/>
+				</or>
+			</and>
 			<then>
 				<antcall target="clean" inheritall="true" />
 			</then>
 		</if>
-		
 	</target>
+
 </project>

--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -43,7 +43,8 @@
 		cp -r ${REPORTDIR}/target/surefire-reports/* junitreports
 		</command>
 		<features>
-			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:required</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:required</feature>
 		</features>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
- Enable if the check for TEST_FLAG contains FIPS140_3_OpenJCEPlusFIPS.
- Added feature tags into playlist as required feature.

related:https://github.ibm.com/runtimes/backlog/issues/1525