### PR TITLE
(v1.0.4-release) Mark node offline if cannot delete workspace (#5636)

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -499,6 +499,7 @@ def runTest() {
                     errorList.add(".*java.io.IOException: Cannot run program \"nohup\".*");
                     errorList.add(".*unzip: command not found.*");
                     errorList.add(".*ant: command not found.*");
+                    errorList.add(".*ERROR: Cannot delete workspace.*");
 
                     // nightly/weekly builds should not have git clone issue
                     if (!env.JOB_NAME.contains("Grinder") && !env.JOB_NAME.contains("_Personal")) {


### PR DESCRIPTION
related: https://github.com/adoptium/aqa-tests/issues/5358 and infrastructure/issues/9874

cherry-pick: https://github.com/adoptium/aqa-tests/pull/5636