### PR TITLE
Download dependency libs for MBCS_Tests

### DIFF
--- a/functional/MBCS_Tests/datetime/build.xml
+++ b/functional/MBCS_Tests/datetime/build.xml
@@ -27,13 +27,15 @@ limitations under the License.
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
 	<property name="build" location="./bin" />
+	<property name="LIB" value="junit4,testng,jcommander"/>
+	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 	
 	<target name="init">
 		<mkdir dir="${DEST}" />
 		<mkdir dir="${build}" />
 	</target>
 
-	<target name="compile" depends="init" description="Using java${JDK_VERSION} to compile the source  ">
+	<target name="compile" depends="init,getDependentLibs" description="Using java${JDK_VERSION} to compile the source  ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:				yes</echo>

--- a/functional/MBCS_Tests/language_tag/build.xml
+++ b/functional/MBCS_Tests/language_tag/build.xml
@@ -27,13 +27,15 @@ limitations under the License.
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
 	<property name="build" location="./bin" />
+	<property name="LIB" value="junit4,testng,jcommander"/>
+	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 	
 	<target name="init">
 		<mkdir dir="${DEST}" />
 		<mkdir dir="${build}" />
 	</target>
 
-	<target name="compile" depends="init" description="Using ${JAVA_VERSION} java compile the source  ">
+	<target name="compile" depends="init,getDependentLibs" description="Using ${JAVA_VERSION} java compile the source  ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:				yes</echo>

--- a/functional/MBCS_Tests/property_utf8/build.xml
+++ b/functional/MBCS_Tests/property_utf8/build.xml
@@ -27,13 +27,15 @@ limitations under the License.
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
 	<property name="build" location="./bin" />
+	<property name="LIB" value="junit4,testng,jcommander"/>
+	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 	
 	<target name="init">
 		<mkdir dir="${DEST}" />
 		<mkdir dir="${build}" />
 	</target>
 
-	<target name="compile" depends="init" description="Using ${JAVA_VERSION} java compile the source  ">
+	<target name="compile" depends="init,getDependentLibs" description="Using ${JAVA_VERSION} java compile the source  ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:				yes</echo>


### PR DESCRIPTION
- Added junit, testng, jcommander libs to download for MBCS_Tests when prestage libs do not exist.

related: https://github.com/adoptium/aqa-tests/issues/5569