### PR TITLE
openjdk: switch from hotspot_jre to hotspot_jdk

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -537,7 +537,7 @@
 		</impls>
 	</test>
 	<test>
-		<testCaseName>hotspot_jre</testCaseName>
+		<testCaseName>hotspot_jdk</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -552,7 +552,7 @@
 	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
 	${FEATURE_PROBLEM_LIST_FILE} \
 	${VENDOR_PROBLEM_LIST_FILE} \
-	$(Q)$(JTREG_HOTSPOT_TEST_DIR):jre$(Q); \
+	$(Q)$(JTREG_HOTSPOT_TEST_DIR):jdk$(Q); \
 	$(TEST_STATUS)</command>
 		<versions>
 			<version>8</version>


### PR DESCRIPTION
Aqa-tests currently has hotspot jre test group. There are few more test in [hotspot jdk test group](https://github.com/openjdk/jdk8u-dev/blob/ec2bb45e246f6c223a3e44b74a51128fe1563e74/hotspot/test/TEST.groups#L55).

**Testing:**
x86-64_linux: [OK](https://ci.adoptium.net/job/Grinder/10950/)