### PR TITLE
openjdk: additional jdk8 hotspot excludes for win32 and arm

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -44,6 +44,8 @@ compiler/floatingpoint/8207838/TestFloatSyncJNIArgs.sh https://github.com/adopti
 compiler/floatingpoint/8165673/TestFloatJNIArgs.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
 compiler/intrinsics/mathexact/LongMulOverflowTest.java https://bugs.openjdk.org/browse/JDK-8196568 solaris-x64
 compiler/gcbarriers/PreserveFPRegistersTest.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
+compiler/6891750/Test6891750.java https://bugs.openjdk.org/browse/JDK-8209023 linux-arm
+compiler/8009761/Test8009761.java https://bugs.openjdk.org/browse/JDK-8252473 linux-arm,windows-x86
 compiler/8209951/TestCipherBlockChainingEncrypt.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
 gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all,linux-arm
 gc/whitebox/TestConcMarkCycleWB.java https://bugs.openjdk.java.net/browse/JDK-8067368 linux-arm
@@ -90,6 +92,7 @@ gc/g1/TestStringDeduplicationTableRehash.java https://github.com/adoptium/aqa-te
 gc/g1/TestHumongousShrinkHeap.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/g1/TestShrinkAuxiliaryData20.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/g1/TestStringDeduplicationTableResize.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
+gc/g1/TestNoEagerReclaimOfHumongousRegions.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/concurrentMarkSweep/GuardShrinkWarning.java https://bugs.openjdk.java.net/browse/JDK-8023356 solaris-x64
 runtime/CDSCompressedKPtrs/CDSCompressedKPtrs.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/CDSCompressedKPtrs/CDSCompressedKPtrsError.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all


### PR DESCRIPTION
Excludes jdk8 failures showing up on linux-arm,windows-x86, see: https://github.com/adoptium/aqa-tests/pull/5646#issuecomment-2383237884

**Testing:**
arm_linux: [OK](https://ci.adoptium.net/job/Grinder/11014/)
x86-32_windows: [OK](https://ci.adoptium.net/job/Grinder/11015/)