### PR TITLE
Enable javax_net_ssl_fips with FIPS_VARIATION_PROBLEM_LIST_FILE

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1217,7 +1217,19 @@
 			<disable>
 				<comment>placeholder for now until the tests in javax/net/ssl are updated for FIPS</comment>
 			</disable>
+			<disable>
+				<comment>only applicable for Semeru atm</comment>
+				<vendor>eclipse</vendor>
+			</disable>
+			<disable>
+				<comment>Only applicable on aix, pliunx, xlinux, wins64 and zlinux atm</comment>
+				<platform>^((?!(ppc64_aix|ppc64le_linux|x86-64_linux|x86-64_windows|s390x_linux)).)*$</platform>
+			</disable>
 		</disables>
+		<variations>
+			<variation>-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Test-TLS-PKCS12 -Djava.security.properties=$(JTREG_JDK_TEST_DIR)/javax/net/ssl/TLSTest_java.security</variation>
+			<variation>-Dsemeru.fips=true -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Test-TLS-JKS -Djava.security.properties=$(JTREG_JDK_TEST_DIR)/javax/net/ssl/TLSTest_java.security</variation>
+		</variations>
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q) $(JVM_OPTIONS) -Xmx512m $(VMOPTION_HEADLESS)$(Q) \
 	$(TIMEOUT_HANDLER) \
@@ -1227,9 +1239,13 @@
 	-exclude:$(Q)$(JTREG_JDK_TEST_DIR)$(D)ProblemList.txt$(Q) \
 	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
 	${FEATURE_PROBLEM_LIST_FILE} \
+	${FIPS_VARIATION_PROBLEM_LIST_FILE} \
 	${VENDOR_PROBLEM_LIST_FILE} \
 	$(Q)$(JTREG_JDK_TEST_DIR)/javax/net/ssl/$(Q); \
 	$(TEST_STATUS)</command>
+		<versions>
+			<version>11+</version>
+		</versions>
 		<levels>
 			<level>extended</level>
 		</levels>
@@ -1237,7 +1253,9 @@
 			<group>openjdk</group>
 		</groups>
 		<features>
-			<feature>FIPS140_3_OpenJCEPlusFIPS:required</feature>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
 		</features>
 		<impls>
 			<impl>ibm</impl>


### PR DESCRIPTION
javax_net_ssl_fips will remain disabled until openjdk javax/net/ssl is updated

related: backlog/issues/1529

depends on: https://github.com/adoptium/TKG/pull/620 and https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/816