### PR TITLE
openjdk: update bug link for Test8009761.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -45,7 +45,7 @@ compiler/floatingpoint/8165673/TestFloatJNIArgs.sh https://github.com/adoptium/a
 compiler/intrinsics/mathexact/LongMulOverflowTest.java https://bugs.openjdk.org/browse/JDK-8196568 solaris-x64
 compiler/gcbarriers/PreserveFPRegistersTest.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 compiler/6891750/Test6891750.java https://bugs.openjdk.org/browse/JDK-8209023 linux-arm
-compiler/8009761/Test8009761.java https://bugs.openjdk.org/browse/JDK-8252473 linux-arm,windows-x86
+compiler/8009761/Test8009761.java https://bugs.openjdk.org/browse/JDK-8048003 linux-arm,windows-x86
 compiler/8209951/TestCipherBlockChainingEncrypt.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
 gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all,linux-arm
 gc/whitebox/TestConcMarkCycleWB.java https://bugs.openjdk.java.net/browse/JDK-8067368 linux-arm


### PR DESCRIPTION
Updates bug link for `compiler/8009761/Test8009761.java`. Turns out this is already other bug and fix for this in newer jdks, see: https://github.com/adoptium/aqa-tests/pull/5659#issuecomment-2389462741

I'll later do backport of JDK-8048003 to jdk8.