### PR TITLE
add quote around .zip

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -310,7 +310,7 @@ getBinaryOpenjdk()
 	jdk_file_array=(${jdk_files//\\n/ })
 	last_index=$(( ${#jdk_file_array[@]} - 1 ))
 	if [[ $last_index == 0 ]]; then
-		if [[ $download_url =~ '*.tar.gz' ]] || [[ $download_url =~ '*.zip' ]] || [[ $jdk_files == *.zip ]]; then
+		if [[ $download_url =~ '*.tar.gz' ]] || [[ $download_url =~ '*.zip' ]] || [[ $jdk_files == '*.zip' ]]; then
 			nested_zip="${jdk_file_array[0]}"
 			echo "${nested_zip} is a nested zip"
 			unzip -q $nested_zip -d .


### PR DESCRIPTION
Having build unzip issues due to nested zip in jenkins submission on windows platforms.

Fixes is given here by **adding quote around *.zip**:- https://github.com/prodroy89/aqa-tests/blob/8af20858dcfa4480057f6075b3c7abd743098db3/get.sh#L313

Signed-off-by: Prodip Roy [prodroy89@in.ibm.com](mailto:prodroy89@in.ibm.com)