### PR TITLE
Release branch cherry pick for excludes hotspot_runtime and hotspot_serviceability

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -338,7 +338,12 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 
 # hotspot_runtime
 
+runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
@@ -351,6 +356,7 @@ runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjd
 serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 serviceability/dtrace/DTraceOptionsTest.java#enabled https://github.com/adoptium/aqa-tests/issues/5397 linux-s390x
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -348,6 +348,7 @@ runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tes
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all
+runtime/CDSCompressedKPtrs/XShareAuto.java https://github.com/adoptium/aqa-tests/issues/5671 windows-x86
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -352,6 +352,7 @@ serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java https://github.com
 serviceability/dtrace/DTraceOptionsTest.java#enabled https://github.com/adoptium/aqa-tests/issues/5397 linux-s390x
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -464,7 +464,8 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 # hotspot_runtime
 
 runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-x86
+runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-x86
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -482,6 +482,7 @@ serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java https://github.com
 serviceability/dtrace/DTraceOptionsTest.java#enabled https://github.com/adoptium/aqa-tests/issues/5397 linux-s390x
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -463,7 +463,12 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 
 # hotspot_runtime
 
+runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
@@ -481,6 +486,7 @@ runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/bro
 serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 serviceability/dtrace/DTraceOptionsTest.java#enabled https://github.com/adoptium/aqa-tests/issues/5397 linux-s390x
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -443,7 +443,12 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 
 # hotspot_runtime
 
+runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
@@ -463,6 +468,7 @@ serviceability/dtrace/DTraceOptionsTest.java#enabled https://github.com/adoptium
 serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfoWithEATest.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -67,6 +67,8 @@ java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjd
 java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
 java/lang/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8313260 linux-arm
+java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
+java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 
 ############################################################################
 
@@ -443,8 +445,11 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 
 # hotspot_runtime
 
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
@@ -476,3 +481,20 @@ serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/is
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJstack.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-process https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbFindPC.java#xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbCDSJstackPrintAll.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbJdis.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbJstack.java#id1 https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbPmap.java#core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbPrintAs.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbPstack.java#core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbSource.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbThreadContext.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbWhere.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/TestJhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/TestClhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/jvmti/RedefineClasses/RedefineSharedClass.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -464,6 +464,7 @@ serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfo
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -77,6 +77,8 @@ java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjd
 # java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
 java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
+java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 
 ############################################################################
 
@@ -455,13 +457,19 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 
 # hotspot_runtime
 
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/memory/ReadFromNoaccessArea.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
+#runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,windows-aarch64
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
@@ -488,3 +496,20 @@ serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/is
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJstack.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-process https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbFindPC.java#xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbCDSJstackPrintAll.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbJdis.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbJstack.java#id1 https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbPmap.java#core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbPrintAs.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbPstack.java#core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbSource.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbThreadContext.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbWhere.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/TestJhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/TestClhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/jvmti/RedefineClasses/RedefineSharedClass.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -455,7 +455,12 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 
 # hotspot_runtime
 
+runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
@@ -475,6 +480,7 @@ serviceability/dtrace/DTraceOptionsTest.java#enabled https://github.com/adoptium
 serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfoWithEATest.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -476,6 +476,7 @@ serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfo
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -77,6 +77,8 @@ java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjd
 # java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
 java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
+java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 
 ############################################################################
 
@@ -454,13 +456,19 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 
 # hotspot_runtime
 
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/memory/ReadFromNoaccessArea.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
+#runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,windows-aarch64
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
@@ -487,3 +495,20 @@ serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/is
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJstack.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-process https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbFindPC.java#xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbCDSJstackPrintAll.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbJdis.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbJstack.java#id1 https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbPmap.java#core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbPrintAs.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbPstack.java#core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbSource.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbThreadContext.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/ClhsdbWhere.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/TestJhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/sa/TestClhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/jvmti/RedefineClasses/RedefineSharedClass.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -475,6 +475,7 @@ serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfo
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -454,7 +454,12 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 
 # hotspot_runtime
 
+runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
@@ -474,6 +479,7 @@ serviceability/dtrace/DTraceOptionsTest.java#enabled https://github.com/adoptium
 serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfoWithEATest.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -46,6 +46,12 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
+                        <disable>
+                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+                                <version>8</version>
+                                <impl>hotspot</impl>
+                                <platform>.*windows.*</platform>
+                        </disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -93,6 +99,12 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
+                        <disable>
+                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+                                <version>8</version>
+                                <impl>hotspot</impl>
+                                <platform>.*windows.*</platform>
+                        </disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -119,6 +131,12 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
+                        <disable>
+                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+                                <version>8</version>
+                                <impl>hotspot</impl>
+                                <platform>.*windows.*</platform>
+                        </disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -45,6 +45,12 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
+                        <disable>
+                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+                                <version>8</version>
+                                <impl>hotspot</impl>
+                                <platform>.*windows.*</platform>
+                        </disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -74,6 +80,12 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
+                        <disable>
+                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+                                <version>8</version>
+                                <impl>hotspot</impl>
+                                <platform>.*windows.*</platform>
+                        </disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -107,6 +119,12 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
+                        <disable>
+                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+                                <version>8</version>
+                                <impl>hotspot</impl>
+                                <platform>.*windows.*</platform>
+                        </disable>
 		</disables>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -debug-generation -java-debug-args=$(Q)-Xmx3g -Xms3g$(Q) -test-args=$(Q)timeLimit=5m$(Q) -java-args-execute-initial=$(Q)$(ADD_OPENS_CMD) -Xmx3g -Xms3g$(Q); \
 	$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -test-args=$(Q)timeLimit=5m$(Q) -java-args-execute-initial=$(Q)$(ADD_OPENS_CMD) -Xmx2g -Xms2g$(Q); \


### PR DESCRIPTION
Cherry pick for:
[openjdk: exclude serviceability/sa/ClhsdbCDSCore.java test ](https://github.com/adoptium/aqa-tests/pull/5623)https://github.com/adoptium/aqa-tests/commit/88da0755d0c7ae0df9c21a5086c1fa75469350a5
[openjdk: exclude macosx hotspot failures](https://github.com/adoptium/aqa-tests/pull/5647) https://github.com/adoptium/aqa-tests/commit/19e8cfbf6de11e69ed7e09162c07565bccc93b26
[Add openjdk & system excludes for Windows failures](https://github.com/adoptium/aqa-tests/pull/5678) https://github.com/adoptium/aqa-tests/commit/5632b5c6646b22689621d6f835caa5bfbbd07957