### PR TITLE
Revert changes to upload perf logs from jvmtest folder to artifactory

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -904,7 +904,6 @@ def post(output_name) {
 				def pattern = "${env.WORKSPACE}/*_output.*"
 				uploadToArtifactory(pattern)
 			}
-			archiveFile("jvmtest/perf/**/leftoverResults/", false)
 		} else if ((currentBuild.result == 'UNSTABLE' || currentBuild.result == 'FAILURE' || currentBuild.result == 'ABORTED') || params.ARCHIVE_TEST_RESULTS) {
 			def test_output_tar_name = "${output_name}_test_output${suffix}"
 			if (tar_cmd.startsWith('tar')) {


### PR DESCRIPTION
Update this change as perf logs have been using reportDir for now

Fixes: https://github.ibm.com/runtimes/automation/issues/80