### PR TITLE
(v1.0.4-release) exclude JDK23+ openj9 xmac testing on mac10

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -302,6 +302,11 @@ timestamps{
                 LABEL += "&&!sw.os.cent.7"
             }
 
+            // JDK23+ isn't supported on machines prior to Mac 11 https://github.com/eclipse-openj9/openj9/issues/19694
+            if (params.JDK_IMPL == "openj9" && PLATFORM == "x86-64_mac" && params.JDK_VERSION && params.JDK_VERSION.toInteger() >= 23) {
+                LABEL += "&&!sw.os.mac.10"
+            }
+
             if (params.DOCKER_REQUIRED) {
                 LABEL += "&&sw.tool.docker"
             }


### PR DESCRIPTION
related: https://github.com/eclipse-openj9/openj9/issues/19694 and infrastructure/issues/9756

cherry-pick: https://github.com/adoptium/aqa-tests/pull/5686