### PR TITLE
exclude JDK23+ and jdknext openj9 xmac testing on mac10

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -303,8 +303,11 @@ timestamps{
             }
 
             // JDK23+ isn't supported on machines prior to Mac 11 https://github.com/eclipse-openj9/openj9/issues/19694
-            if (params.JDK_IMPL == "openj9" && PLATFORM == "x86-64_mac" && params.JDK_VERSION && params.JDK_VERSION.toInteger() >= 23) {
-                LABEL += "&&!sw.os.mac.10"
+            // assume if JDK_VERSION is set to next, JDK_VERSION is 23+
+            if (params.JDK_IMPL == "openj9" && PLATFORM == "x86-64_mac" && params.JDK_VERSION) {
+                if (!params.JDK_VERSION.isInteger() || params.JDK_VERSION.toInteger() >= 23) {
+                    LABEL += "&&!sw.os.mac.10"
+                }
             }
 
             if (params.DOCKER_REQUIRED) {


### PR DESCRIPTION
related: https://github.com/adoptium/aqa-tests/pull/5686#discussion_r1801681881