### PR TITLE
 Add new template to enable auto generate parent level job in perf test

### DIFF
--- a/buildenv/jenkins/testJobTemplatePerf
+++ b/buildenv/jenkins/testJobTemplatePerf
@@ -1,0 +1,165 @@
+#!groovy
+
+/*
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/**
+ * A template that defines a perf test job.
+ */
+
+def getBaseJDKImpl(JDK_IMPL) {
+	if (JDK_IMPL != "openj9" && JDK_IMPL != "ibm" ) {
+		return "hotspot"
+	}
+	return JDK_IMPL
+}
+
+if (!binding.hasVariable('JDK_IMPL')) JDK_IMPL = "openj9"
+if (!binding.hasVariable('TIME_LIMIT')) TIME_LIMIT = "10"
+if (!binding.hasVariable('KEEP_REPORTDIR')) KEEP_REPORTDIR = true
+if (!binding.hasVariable('SDK_RESOURCE')) SDK_RESOURCE = "upstream"
+if (!binding.hasVariable('JDK_VERSION')) JDK_VERSION = ""
+if (!binding.hasVariable('CUSTOMIZED_SDK_URL_CREDENTIAL_ID')) CUSTOMIZED_SDK_URL_CREDENTIAL_ID = ""
+if (!binding.hasVariable('VENDOR_TEST_REPOS')) VENDOR_TEST_REPOS = ""
+if (!binding.hasVariable('VENDOR_TEST_BRANCHES')) VENDOR_TEST_BRANCHES = ""
+if (!binding.hasVariable('VENDOR_TEST_DIRS')) VENDOR_TEST_DIRS = "perf"
+if (!binding.hasVariable('VENDOR_TEST_SHAS')) VENDOR_TEST_SHAS = ""
+
+
+if (binding.hasVariable('ARCH_OS_LIST')) {
+	ARCH_OS_LIST = ARCH_OS_LIST.split(',')*.trim()
+} else {
+	ARCH_OS_LIST = [
+		'arm_linux',
+		'aarch64_linux',
+		'ppc64_aix',
+		'ppc64le_linux',
+		's390x_linux',
+		's390x_zos',
+		'x86-32_windows',
+		'x86-64_linux',
+		'x86-64_linux_xl',
+		'x86-64_mac',
+		'x86-64_mac_xl',
+		'x86-64_windows'
+	]
+}
+
+JDK_IMPL_BASE = getBaseJDKImpl(JDK_IMPL)
+
+def ADOPTOPENJDK_REPO = "https://github.com/adoptium/aqa-tests.git"
+def ADOPTOPENJDK_BRANCH = "master"
+def PERFORMANCE_REPO = "https://github.ibm.com/runtimes/rt-performance.git"
+def PERFORMANCE_BRANCH = "main"
+def PERFORMANCE_REPO_CREDENTIAL = "83181e25-eea4-4f55-8b3e-e79615733226"
+
+// https://issues.jenkins.io/browse/JENKINS-42971 is resolved, but it seems to be a partial fix for Branch Specifier parameter.
+// Repository URL still has problem with lightweight checkout
+// Set Repository URL and Branch Specifier as build parameters by default
+// If LIGHT_WEIGHT_CHECKOUT is set to true, set Repository URL to its explicit value and keep Branch Specifier as parameter
+def ADOPTOPENJDK_REPO_BUILD_PARAM = '${ADOPTOPENJDK_REPO}'
+def ADOPTOPENJDK_BRANCH_BUILD_PARAM = '${ADOPTOPENJDK_BRANCH}'
+def PERFORMANCE_REPO_BUILD_PARAM = '${PERFORMANCE_REPO}'
+def PERFORMANCE_BRANCH_BUILD_PARAM = '${PERFORMANCE_BRANCH}'
+def SCRIPT_PATH = "rt-performance/jenkins/perfPipeline.groovy"
+def LIGHT_WEIGHT_CHECKOUT = true
+
+if (LIGHT_WEIGHT_CHECKOUT) {
+	PERFORMANCE_REPO_BUILD_PARAM = PERFORMANCE_REPO
+	SCRIPT_PATH = "jenkins/perfPipeline.groovy"
+}
+
+ARCH_OS_LIST.each { ARCH_OS ->
+	def ACTUAL_TEST_JOB_NAME = TEST_JOB_NAME
+				
+	pipelineJob("$ACTUAL_TEST_JOB_NAME") {
+ 		description('<h1>THIS IS AN AUTOMATICALLY GENERATED JOB. PLEASE DO NOT MODIFY, IT WILL BE OVERWRITTEN.</h1><br><p>This job is defined in <a href="https://github.com/adoptium/aqa-tests/blob/master/buildenv/jenkins/" target="_blank">testJobTemplatePerf</a> in the https://github.com/adoptium/aqa-tests repo. If you wish to change the job, please modify testJobTemplatePerf script. </p><p>For more information about job parameters, please refer <a href="https://github.com/adoptium/aqa-tests/wiki/How-to-Run-a-Grinder-Build-on-Jenkins" target="_blank">How to Run a Grinder Build on Jenkins</a></p>wiki:<p><a href="https://github.com/eclipse-openj9/openj9/wiki/AQA-Lightning-Talk-Series" target="_blank">AQA Lightning Talk Series</a></p><p><a href="https://github.com/eclipse-openj9/openj9/wiki/Reproducing-Test-Failures-Locally" target="_blank">Reproducing Test Failures Locally</a></p>')
+
+		properties {
+			copyArtifactPermission {
+				projectNames('*')
+			}
+		}
+
+		definition {
+			parameters {
+				stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos.")
+				stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch")
+				stringParam('PERFORMANCE_REPO', PERFORMANCE_REPO, "PERF git repo. For PERF test only")
+				stringParam('PERFORMANCE_BRANCH', PERFORMANCE_BRANCH, "PERF branch. For PERF test only")
+							
+				stringParam('PLATFORM', "${ARCH_OS}", '''Platform to be tested:
+                    <br/>arm_linux
+                    <br/>aarch64_linux
+                    <br/>ppc64_aix
+                    <br/>ppc64le_linux
+                    <br/>s390x_linux
+                    <br/>s390x_zos
+                    <br/>x86-64_linux
+                    <br/>x86-64_mac
+                    <br/>x86-64_windows
+                    <br/>x86-32_windows
+                    <br/>sparcv9_solaris
+                    <br/>riscv64_linux
+                    <br/>multiple platforms (comma separated values): x86-64_linux,x86-64_mac
+                    <br/>all platforms: all (this set actually excludes some secondary platforms and varies based on JDK_VERSION/JDK_IMPL selected)
+                    <br/>all OS-constrained platforms (only platforms already supported by "all" can be executed):
+                    <br/>all_linux
+                    <br/>all_mac
+                    <br/>all_windows
+                    <br/>all_aix
+                    <br/>Please refer to PLATFORM_MAP in https://github.com/adoptium/aqa-tests/blob/master/buildenv/jenkins/openjdk_tests<br/>''')
+
+				stringParam('SDK_RESOURCE', SDK_RESOURCE, '''Where to get sdk? nightly|releases|customized|upstream<br/>
+				nightly & releases pull the lastest from https://api.adoptium.net/ <br/>
+				If nightly / releases is selected, please provide JDK_VERSION and JDK_IMPL <br/>
+				If customized is selected, please provide CUSTOMIZED_SDK_URL (and CUSTOMIZED_SDK_URL_CREDENTIAL_ID if the URL has restricted access)<br/>
+				If upstream is selected, please provide UPSTREAM_JOB_NAME and UPSTREAM_JOB_NUMBER <br/>''')
+				stringParam('JDK_VERSION', "${JDK_VERSION}", "JDK version. i.e., 8, 11, 17, 21")
+				stringParam('JDK_IMPL', JDK_IMPL_BASE, "JDK Base implementation, e.g. hotspot, openj9")
+				stringParam('BASELINE_SDK_URL', "", "Customized SDK url, need to set when SDK_RESOURCE=customized")
+				stringParam('TEST_SDK_URL', "", "Customized SDK url, need to set when SDK_RESOURCE=customized")
+				stringParam('CUSTOMIZED_SDK_URL_CREDENTIAL_ID', CUSTOMIZED_SDK_URL_CREDENTIAL_ID, "Only use this if you are pulling an JDK from a site that needs credential")
+				stringParam('VENDOR_TEST_REPOS', VENDOR_TEST_REPOS, "Additional test material. If it is private/internal repo, please provide USER_CREDENTIALS_ID git@github.ibm.com:runtimes/test.git git@github.ibm.com:runtimes/jck.git git@github.ibm.com:runtimes/rt-performance.git")
+				stringParam('VENDOR_TEST_BRANCHES', VENDOR_TEST_BRANCHES, "main")
+                stringParam('VENDOR_TEST_DIRS', VENDOR_TEST_DIRS, "functional jck perf")
+				stringParam('VENDOR_TEST_SHAS', VENDOR_TEST_SHAS, "")
+                stringParam('TIME_LIMIT', TIME_LIMIT, "time limit")
+				stringParam('ITERATIONS',"1", "")
+				booleanParam('KEEP_REPORTDIR', KEEP_REPORTDIR.toBoolean(), "TKG will keep the test report dir if the test passes. Set true for OpenJDK junit results")
+			}
+			cpsScm {
+				scm {
+					git {
+						remote {
+							url(PERFORMANCE_REPO_BUILD_PARAM)
+                            credentials(PERFORMANCE_REPO_CREDENTIAL)
+						}
+						branch(PERFORMANCE_BRANCH_BUILD_PARAM)
+						extensions {
+							relativeTargetDirectory('rt-performance')
+							cleanBeforeCheckout()
+							wipeOutWorkspace()
+							cloneOptions {
+								timeout(60)
+							}
+						}
+					}
+					scriptPath(SCRIPT_PATH)
+					lightweight(LIGHT_WEIGHT_CHECKOUT)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This change is to create a new scm script to for auto generate job usage

Fixes: https://github.ibm.com/runtimes/automation/issues/69