### PR TITLE
Add VectorGatherMaskFoldingTest to excludes for jdk21

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -377,6 +377,7 @@ compiler/codecache/MHIntrinsicAllocFailureTest.java https://bugs.openjdk.org/bro
 compiler/whitebox/ForceNMethodSweepTest.java https://bugs.openjdk.org/browse/JDK-8265181 linux-arm
 compiler/codegen/aes/Test8292158.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
 compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
+compiler/vectorapi/VectorGatherMaskFoldingTest.java https://bugs.openjdk.org/browse/JDK-8333248 linux-riscv64
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -377,7 +377,7 @@ compiler/codecache/MHIntrinsicAllocFailureTest.java https://bugs.openjdk.org/bro
 compiler/whitebox/ForceNMethodSweepTest.java https://bugs.openjdk.org/browse/JDK-8265181 linux-arm
 compiler/codegen/aes/Test8292158.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
 compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/4470 linux-s390x
-compiler/vectorapi/VectorGatherMaskFoldingTest.java https://bugs.openjdk.org/browse/JDK-8333248 linux-riscv64
+compiler/vectorapi/VectorGatherMaskFoldingTest.java https://bugs.openjdk.org/browse/JDK-8333248 linux-s390x,linux-riscv64
 
 ############################################################################
 


### PR DESCRIPTION
Test material needs an update from JDK-8333248. Exclude until that is backported to 21.

Related: https://github.com/adoptium/aqa-tests/issues/5620