### PR TITLE
Enable MockitoMockTest for 23+

### DIFF
--- a/functional/MockitoTests/playlist.xml
+++ b/functional/MockitoTests/playlist.xml
@@ -21,10 +21,6 @@
 				<comment>https://github.com/eclipse-openj9/openj9/issues/19331</comment>
 				<platform>.*zos.*</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/19354</comment>
-				<version>23+</version>
-			</disable>
 		</disables>
 		<command>
 			$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(RESOURCES_DIR)$(P)$(TEST_RESROOT)$(D)MockitoTests.jar$(P)$(LIB_DIR)$(D)mockito-core.jar$(P)$(LIB_DIR)$(D)byte-buddy.jar$(P)$(LIB_DIR)$(D)byte-buddy-agent.jar$(P)$(LIB_DIR)$(D)objenesis.jar$(Q) test.java.MockitoMockTest ; \


### PR DESCRIPTION
Failure is solved by updating ByteBuddy to include Java 23 and 24 support.

Depends on: https://github.com/adoptium/TKG/pull/629
Fixes: https://github.com/eclipse-openj9/openj9/issues/19354