### PR TITLE
problemList: add missing windows-aarch64 exclusions

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -273,6 +273,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 
 # jdk_tools
 
+sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
@@ -311,6 +313,7 @@ tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/infrastructur
 tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
 tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
 tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-ppc64
+tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
@@ -381,6 +384,10 @@ compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issu
 ############################################################################
 
 # jdk_jfr
+
+jdk/jfr/event/runtime/TestDumpReason.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+jdk/jfr/jvm/TestDumpOnCrash.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 
 ###########################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -283,6 +283,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 
 # jdk_tools
 
+sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
@@ -321,6 +323,7 @@ tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/infrastructur
 tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
 tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
 tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-ppc64
+tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
@@ -392,6 +395,10 @@ compiler/vectorapi/VectorGatherMaskFoldingTest.java https://bugs.openjdk.org/bro
 ############################################################################
 
 # jdk_jfr
+
+jdk/jfr/event/runtime/TestDumpReason.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+jdk/jfr/jvm/TestDumpOnCrash.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 
 ###########################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -283,6 +283,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 
 # jdk_tools
 
+sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
@@ -321,6 +323,7 @@ tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/infrastructur
 tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
 tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
 tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-ppc64
+tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
@@ -391,6 +394,10 @@ compiler/codegen/aes/TestAESMain.java https://github.com/adoptium/aqa-tests/issu
 ############################################################################
 
 # jdk_jfr
+
+jdk/jfr/event/runtime/TestDumpReason.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+jdk/jfr/jvm/TestDumpOnCrash.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 
 ###########################################################################
 

--- a/openjdk/excludes/vendors/microsoft/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/vendors/microsoft/ProblemList_openjdk21.txt
@@ -97,9 +97,6 @@ java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/is
 
 # jdk_tools
 sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
-sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 
 ############################################################################
 
@@ -117,7 +114,6 @@ tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-t
 
 # jdk_other
 
-
 ############################################################################
 
 # jdk_imageio
@@ -125,6 +121,3 @@ tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-t
 ############################################################################
 
 # jdk_jfr
-jdk/jfr/event/runtime/TestDumpReason.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-jdk/jfr/jvm/TestDumpOnCrash.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64


### PR DESCRIPTION
most of these are defined in https://github.com/adoptium/aqa-tests/issues/4155#issuecomment-1920132183

Grinder: https://ci.adoptium.net/job/Grinder/11258/