### PR TITLE
Exclude CRIU combo with Ubu24 plinux machines

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -219,8 +219,9 @@ timestamps{
                         ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z15"]
                     ],
             'ppc64le_linux' : [
-                        ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.ppc64le.p10"],
-                        ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.ppc64le.p9"]
+                        // Temporarily exclude ubuntu 24 machines due to issue runtimes_backlog 1506
+                        ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.ppc64le.p10&&!sw.os.ubuntu.24"],
+                        ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.ppc64le.p9&&!sw.os.ubuntu.24"]
                     ]
         ]
         if (params.PLATFORM && imageUploadMap[params.PLATFORM] != null && imagePullMap[params.PLATFORM] != null) {


### PR DESCRIPTION
Currently ubu24 machines have issue to stop certain podman container

Issue: runtimes_backlog_1506