### PR TITLE
Enable Aarch SyntheticGCWorkload_DoubleMap_J9 test

### DIFF
--- a/functional/SyntheticGCWorkload/playlist.xml
+++ b/functional/SyntheticGCWorkload/playlist.xml
@@ -165,12 +165,6 @@
 	</test>
 	<test>
 		<testCaseName>SyntheticGCWorkload_DoubleMap_J9</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/8034</comment>
-				<platform>.*aarch64.*</platform>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xmx2g -Xdump:none -Xgcpolicy:balanced -Xgc:enableArrayletDoubleMapping -verbose:gc</variation>
 		</variations>


### PR DESCRIPTION
Enable Aarch SyntheticGCWorkload_DoubleMap_J9 test since fixed already

Issue: https://github.com/eclipse-openj9/openj9/issues/8034