### PR TITLE
Updated msft problemlist for October 2024 psu

### DIFF
--- a/openjdk/excludes/vendors/microsoft/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/vendors/microsoft/ProblemList_openjdk11.txt
@@ -96,6 +96,7 @@ java/lang/management/MemoryMXBean/LowMemoryTest2.sh https://github.com/adoptium/
 
 # jdk_tools
 tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 
 ############################################################################
 

--- a/openjdk/excludes/vendors/microsoft/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/vendors/microsoft/ProblemList_openjdk21.txt
@@ -97,7 +97,7 @@ java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/is
 
 # jdk_tools
 sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
-sun/tools/jhsdb/sun/tools/jhsdb/HeapDumpTestWithActiveProcess.jav.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 
 ############################################################################
 

--- a/openjdk/excludes/vendors/microsoft/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/vendors/microsoft/ProblemList_openjdk21.txt
@@ -97,6 +97,7 @@ java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/is
 
 # jdk_tools
 sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/sun/tools/jhsdb/HeapDumpTestWithActiveProcess.jav.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 
 ############################################################################
 


### PR DESCRIPTION
Added `sun/tools/jhsdb/JShellHeapDumpTest.java` to jdk11 msft problemlist for windows as it is already problemlisted for all other JDKs, as requested in issue:  https://github.com/adoptium/aqa-tests/issues/4155


Added `sun/tools/jhsdb/sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java` to jdk21 msft problemlist for windows, https://github.com/adoptium/aqa-tests/issues/4155