### PR TITLE
Finish/fix SKIP_JCK_GIT_UPDATE variable in JCK

### DIFF
--- a/jck/README.md
+++ b/jck/README.md
@@ -27,6 +27,7 @@
 
 3. Export `JCK_ROOT=/jck/<test_material_folder>` as an environment variable or pass it in when run as a make command. For example `export JCK_ROOT=/jck/jck8d`.
 * Optional. The default value is `<openjdk-test>/../../../jck_root/JCK$(JDK_VERSION)-unzipped`.
+* if you export `SKIP_JCK_GIT_UPDATE=true`, then the `JCK_GIT_REPO` is not used at all, and `JCK_ROOT` is used directly, without needing to be a repo.
 
 4. Export `TEST_JDK_HOME=<your_JDK_root>` as an environment variable.
 

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -119,41 +119,47 @@
 		<if>
 			<available file="${JCK_ROOT_USED}" type="dir" />
 			<then>
-				<!--Obtain local and remote SHA to figure out if local materials are up-to-date--> 
-				<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false" outputproperty="localSHA" resultproperty="return.code">
-					<arg line="rev-parse"/>
-					<arg line="HEAD"/>
-				</exec>
 				<if>
-					<not>
-						<equals arg1="${return.code}" arg2="0"/>
-					</not>
+					<isset property="env.SKIP_JCK_GIT_UPDATE" />
 					<then>
-						<echo message="Error: Git command failed with return code ${return.code}. Delete the directory and continue." />
-						<delete dir="${JCK_ROOT_USED}" failonerror="true" />
+						<echo message="env.SKIP_JCK_GIT_UPDATE is set. Skip Running git checks at ${JCK_ROOT_USED}. Continue." />
 					</then>
 					<else>
-						<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true" outputproperty="remoteSHA">
-							<arg line="ls-remote"/>
-							<arg line="${JCK_GIT_REPO_USED}"/>
-							<arg line="${jck_branch}"/>
+						<!--Obtain local and remote SHA to figure out if local materials are up-to-date--> 
+						<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="false" outputproperty="localSHA" resultproperty="return.code">
+							<arg line="rev-parse"/>
+							<arg line="HEAD"/>
 						</exec>
-						<loadresource property="localSHATrimmed">
-							<propertyresource name="localSHA"/>
-							<filterchain>
-								<tokenfilter>
-									<trim/>
-								</tokenfilter>
-								<striplinebreaks/>
-							</filterchain>
-						</loadresource>
-							
-						<echo message="LocalSHA = --${localSHATrimmed}--"/>
-						<echo message="RemoteSHA= --${remoteSHA}--"/>
-
-						<condition property="local-material-uptodate">
-							<contains string="${remoteSHA}" substring="${localSHATrimmed}" />
-						</condition>
+						<if>
+							<not>
+								<equals arg1="${return.code}" arg2="0"/>
+							</not>
+							<then>
+								<echo message="Error: Git command failed with return code ${return.code}. Delete the directory and continue." />
+								<delete dir="${JCK_ROOT_USED}" failonerror="true" />
+							</then>
+							<else>
+								<exec executable="git" dir="${JCK_ROOT_USED}" failonerror="true" outputproperty="remoteSHA">
+									<arg line="ls-remote"/>
+									<arg line="${JCK_GIT_REPO_USED}"/>
+									<arg line="${jck_branch}"/>
+								</exec>
+								<loadresource property="localSHATrimmed">
+									<propertyresource name="localSHA"/>
+										<filterchain>
+										<tokenfilter>
+											<trim/>
+										</tokenfilter>
+										<striplinebreaks/>
+									</filterchain>
+								</loadresource>
+								<echo message="LocalSHA = --${localSHATrimmed}--"/>
+								<echo message="RemoteSHA= --${remoteSHA}--"/>
+								<condition property="local-material-uptodate">
+									<contains string="${remoteSHA}" substring="${localSHATrimmed}" />
+								</condition>
+							</else>
+						</if>
 					</else>
 				</if>
 			</then>

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -313,14 +313,23 @@
 	</target>
 
 	<target name="build">
-		<fail message="env.JCK_GIT_REPO: ${env.JCK_GIT_REPO} was not correctly set for running JCK tests. If you do not want to compile JCK tests,
+				<if>
+					<isset property="env.SKIP_JCK_GIT_UPDATE" />
+					<then>
+						<echo message="env.SKIP_JCK_GIT_UPDATE set, not enforcing existence of env.JCK_GIT_REPO" />
+					</then>
+					<else>
+						<fail message="env.JCK_GIT_REPO: ${env.JCK_GIT_REPO} was not correctly set for running JCK tests. If you do not want to compile JCK tests,
 						please use BUILD_LIST to include test folders you want to test.">
-			<condition>
-				<not>
-					<isset property="env.JCK_GIT_REPO"/>
-				</not>
-			</condition>
-		</fail>
+							<condition>
+								<not>
+									<isset property="env.JCK_GIT_REPO"/>
+								</not>
+							</condition>
+						</fail>
+
+					</else>
+				</if>
 		<propertyregex property="JCK_GIT_REPO_USED" input="${env.JCK_GIT_REPO}" regexp="JCKnext-unzipped.git" replace="JCK${JDK_VERSION}-unzipped.git" casesensitive="false" defaultValue="${env.JCK_GIT_REPO}"/>
 		<echo>=== JCK_GIT_REPO_USED is set to ${JCK_GIT_REPO_USED} ===</echo>
 

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -322,7 +322,7 @@
 				<if>
 					<isset property="env.SKIP_JCK_GIT_UPDATE" />
 					<then>
-						<echo message="env.SKIP_JCK_GIT_UPDATE set, not enforcing existence of env.JCK_GIT_REPO" />
+						<echo message="=== env.SKIP_JCK_GIT_UPDATE set, not enforcing existence of env.JCK_GIT_REPO ===" />
 					</then>
 					<else>
 						<fail message="env.JCK_GIT_REPO: ${env.JCK_GIT_REPO} was not correctly set for running JCK tests. If you do not want to compile JCK tests,

--- a/jck/build.xml
+++ b/jck/build.xml
@@ -120,9 +120,9 @@
 			<available file="${JCK_ROOT_USED}" type="dir" />
 			<then>
 				<if>
-					<isset property="env.SKIP_JCK_GIT_UPDATE" />
+					<equals arg1="${env.SKIP_JCK_GIT_UPDATE}" arg2="true"/>
 					<then>
-						<echo message="env.SKIP_JCK_GIT_UPDATE is set. Skip Running git checks at ${JCK_ROOT_USED}. Continue." />
+						<echo message="env.SKIP_JCK_GIT_UPDATE is set to true. Skip Running git checks at ${JCK_ROOT_USED}. Continue." />
 					</then>
 					<else>
 						<!--Obtain local and remote SHA to figure out if local materials are up-to-date--> 
@@ -185,10 +185,10 @@
 			<!-- jck materials exist, update jck materials if needed-->
 			<else>
 				<if>
-					<isset property="env.SKIP_JCK_GIT_UPDATE" />
+					<equals arg1="${env.SKIP_JCK_GIT_UPDATE}" arg2="true"/>
 					<!-- don't want to update local JCK materials -->
 					<then>
-						<echo message="env.SKIP_JCK_GIT_UPDATE is set. Skip Running git update at ${JCK_ROOT_USED}. Continue." />
+						<echo message="env.SKIP_JCK_GIT_UPDATE is set to true. Skip Running git update at ${JCK_ROOT_USED}. Continue." />
 					</then>
 					<else>
 						<if>
@@ -320,9 +320,9 @@
 
 	<target name="build">
 				<if>
-					<isset property="env.SKIP_JCK_GIT_UPDATE" />
+					<equals arg1="${env.SKIP_JCK_GIT_UPDATE}" arg2="true"/>
 					<then>
-						<echo message="=== env.SKIP_JCK_GIT_UPDATE set, not enforcing existence of env.JCK_GIT_REPO ===" />
+						<echo message="=== SKIP_JCK_GIT_UPDATE set to true, not enforcing existence of env.JCK_GIT_REPO ===" />
 					</then>
 					<else>
 						<fail message="env.JCK_GIT_REPO: ${env.JCK_GIT_REPO} was not correctly set for running JCK tests. If you do not want to compile JCK tests,


### PR DESCRIPTION
It seems the SKIP_JCK_GIT_UPDATE was not finished/was single usage targeted/or was broken in later commits.

Before this PR, the JCK_GIT_REPO was mandatory to exists even if the SKIP_JCK_GIT_UPDATE was on place. In addition, the JCK_ROOT (which was supposed to be not updated) was deleted if the checks failed.

This PR is extending the usage of SKIP_JCK_GIT_UPDATE so the JCK_GIT_REPO is nto used at all and JCK_ROOT do not need to pass the git checs ( so it do not need to be repo art all)

Small side note - to fake git repo, which contains unpacked compatibility jars, takes some 30 minutes and used pretty quite a lot of disk space. This PR is making this creation of fake repository redundant. 

https://github.com/adoptium/aqa-tests/issues/5745