### PR TITLE
Problemlist sun/jvmstat/monitor/MonitoredVm/CR6672135.java in jdk8u

### DIFF
--- a/openjdk/excludes/vendors/alibaba/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/vendors/alibaba/ProblemList_openjdk8.txt
@@ -115,7 +115,7 @@ com/sun/jdi/StepTest.java https://github.com/adoptium/aqa-tests/issues/3763 gene
 ############################################################################
 
 # jdk_other
-
+sun/jvmstat/monitor/MonitoredVm/CR6672135.java https://bugs.openjdk.org/browse/JDK-8062938 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Problemlist jtreg sun/jvmstat/monitor/MonitoredVm/CR6672135.java in jdk8u, which run intermittent fails

The intermittent failure was recorded by [JDK-8062938](https://bugs.openjdk.org/browse/JDK-8062938), before the upstream test bug has been backported to jdk8u, should we Problemlist this test.

Fixes: #5741