### PR TITLE
Enable jdk_beans on xlinux

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -755,8 +755,9 @@
 		<testCaseName>jdk_beans</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/20531</comment>
 				<impl>openj9</impl>
+				<platform>^((?!(x86-64_linux)).)*$</platform>
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>


### PR DESCRIPTION
- Enable jdk_beans on xlinux except for java version 8 and 11

related: eclipse-openj9/openj9#20531