### PR TITLE
Sfr test solaris

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -13,3 +13,9 @@ source ./scripts/testenv/testenvSettings.sh
 
 cd ./TKG
 $MAKE compile
+
+if [ $(uname) = SunOS ]; then
+    pwd
+    ls -ltr
+    chmod -R 744 ../openjdk/openjdk-jdk/jdk/test/sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.sh*
+fi

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -14,7 +14,7 @@
 
 # hotspot_all
 
-# compiler/7184394/TestAESMain.java https://github.com/adoptium/infrastructure/issues/2893 
+# compiler/7184394/TestAESMain.java https://github.com/adoptium/infrastructure/issues/2893
 compiler/7184394/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,solaris-sparcv9
 compiler/intrinsics/sha/TestSHA.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 
@@ -245,6 +245,7 @@ sun/security/pkcs11/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/i
 sun/security/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/issues/68 generic-all
 com/sun/crypto/provider/Mac/MacClone.java https://bugs.openjdk.java.net/browse/JDK-7087021 solaris-all
 javax/net/ssl/ServerName/BestEffortOnLazyConnected.java https://bugs.openjdk.org/browse/JDK-8155049 solaris-x64
+javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java https://bugs.openjdk.org/browse/JDK-8212096 solaris-x64
 javax/net/ssl/Stapling/HttpsUrlConnClient.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
 javax/net/ssl/Stapling/SSLSocketWithStapling.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
 javax/net/ssl/TLSCommon/ConcurrentClientAccessTest.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/3684

Exclude javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java test for JDK8/Solaris x64, as it is a known upstream issue with a PR awaiting merge for jdk8u ( see : https://bugs.openjdk.org/browse/JDK-8212096 )

Amend permissions of sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.sh on Solaris x64, so that it can be executed, successful test run : https://ci.adoptium.net/job/Grinder/11517/