### PR TITLE
Add support for decompression of tar.xz in get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -379,10 +379,15 @@ getBinaryOpenjdk()
 					unzip -q $file_name -d $extract_dir
 				else
 					# some debug-image tar has parent folder ... strip it
-					if tar --version 2>&1 | grep GNU 2>&1; then
-						gzip -cd $file_name | tar xof - -C $extract_dir --strip 1
+					if [[ $file_name == *xz ]]; then
+						DECOMPRESS_TOOL=xz
 					else
-						mkdir dir.$$ && cd dir.$$ && gzip -cd ../$file_name | tar xof - && cd * && tar cf - . | (cd ../../$extract_dir && tar xpf -) && cd ../.. && rm -rf dir.$$
+						DECOMPRESS_TOOL=gzip
+					fi
+					if tar --version 2>&1 | grep GNU 2>&1; then
+						$DECOMPRESS_TOOL -cd $file_name | tar xof - -C $extract_dir --strip 1
+					else
+						mkdir dir.$$ && cd dir.$$ && $DECOMPRESS_TOOL -cd ../$file_name | tar xof - && cd * && tar cf - . | (cd ../../$extract_dir && tar xpf -) && cd ../.. && rm -rf dir.$$
 					fi
 				fi
 			else
@@ -398,7 +403,12 @@ getBinaryOpenjdk()
 					cd ./tmp
 					pax -p xam -rzf ../$file_name
 				else
-					gzip -cd $file_name | (cd tmp && tar xof -)
+					if [[ $file_name == *xz ]]; then
+						DECOMPRESS_TOOL=xz
+					else
+						DECOMPRESS_TOOL=gzip
+					fi
+					$DECOMPRESS_TOOL -cd $file_name | (cd tmp && tar xof -)
 				fi
 
 				cd $SDKDIR/jdkbinary/tmp

--- a/get.sh
+++ b/get.sh
@@ -367,6 +367,12 @@ getBinaryOpenjdk()
 	for file_name in "${jdk_file_array[@]}"
 	do
 		if [[ ! "$file_name" =~ "sbom" ]]; then
+			if [[ $file_name == *xz ]]; then
+				DECOMPRESS_TOOL=xz
+			else
+				# Noting that this will be set, but not used, for zip files
+				DECOMPRESS_TOOL=gzip
+			fi
 			if [[ "$file_name" =~ "debug-image" ]] || [[ "$file_name" =~ "debugimage" ]] || [[ "$file_name" =~ "symbols-" ]]; then
 				# if file_name contains debug-image, extract into j2sdk-image/jre or j2sdk-image dir
 				# Otherwise, files will be extracted under ./tmp
@@ -379,11 +385,6 @@ getBinaryOpenjdk()
 					unzip -q $file_name -d $extract_dir
 				else
 					# some debug-image tar has parent folder ... strip it
-					if [[ $file_name == *xz ]]; then
-						DECOMPRESS_TOOL=xz
-					else
-						DECOMPRESS_TOOL=gzip
-					fi
 					if tar --version 2>&1 | grep GNU 2>&1; then
 						$DECOMPRESS_TOOL -cd $file_name | tar xof - -C $extract_dir --strip 1
 					else
@@ -403,11 +404,6 @@ getBinaryOpenjdk()
 					cd ./tmp
 					pax -p xam -rzf ../$file_name
 				else
-					if [[ $file_name == *xz ]]; then
-						DECOMPRESS_TOOL=xz
-					else
-						DECOMPRESS_TOOL=gzip
-					fi
 					$DECOMPRESS_TOOL -cd $file_name | (cd tmp && tar xof -)
 				fi
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/4374

A couple of points:
- Do we have a requirement for this for the debugimage etc.? I've covered it in this PR regardless
- We do not guarantee that `xz` is on any given machine - maybe we should add it ... At the moment it'll just fail to extract with a message along the lines of`xz: not found` or similar.