### PR TITLE
Silence podman detection

### DIFF
--- a/external/provider.sh
+++ b/external/provider.sh
@@ -27,7 +27,7 @@
 ###################################################################
 
 if [ -z "${EXTERNAL_AQA_RUNNER}" ]; then
-  if which podman > /dev/null; then
+  if which podman > /dev/null 2>&1; then
      EXTERNAL_AQA_RUNNER=podman
   else
      EXTERNAL_AQA_RUNNER=docker


### PR DESCRIPTION
Closes #5768

When I introduced podman support, I have forget to silence its error stream, and thus a lot of unnecessary like:

```
15:44:51       [exec] /usr/bin/which: no podman in (/home/jenkins/.local/bin:/home/jenkins/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin)
```

messages are printed. This PR is removing them