### PR TITLE
Exclude failing UTC test on MacOS on Eclipse only

### DIFF
--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk11.txt
@@ -98,7 +98,7 @@ java/nio/file/DirectoryStream/SecureDS.java https://github.com/adoptium/aqa-test
 
 # jdk_time
 
-java/time/test/java/time/format/TestUTCParse.java https://github.com/adoptium/infrastructure/issues/3658#issuecomment-2220728689 linux-all
+java/time/test/java/time/format/TestUTCParse.java https://github.com/adoptium/infrastructure/issues/3658#issuecomment-2220728689 linux-all,macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
An extension of https://github.com/adoptium/aqa-tests/pull/5447/files

ref https://github.com/adoptium/infrastructure/issues/3361