### PR TITLE
Extra doc for EXTRA_OPTIONS

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -361,8 +361,8 @@ ARCH_OS_LIST.each { ARCH_OS ->
                                                                        individual test in playlist.xml: floatSanityTests|MiniMix_5m|jdk_math|jdk_beans_0|jdk_custom<br/>
                                                                        a list of tests: testList TESTLIST=jit_jitt,jit_recognizedMethod_1,testSCCMLTests2_1<br/>
                                                                        Note: please do not use level, group or type (i.e., functional, sanity, etc) in the TESTLIST<br/>''')
-							stringParam('CUSTOM_TARGET', "", '''
-								Only used when the custom target is specified in TARGET , e.g. jdk_custom, langtools_custom, system_custom, etc., CUSTOM_TARGET=path to the test class to execute<br>
+							stringParam('CUSTOM_TARGET', "",
+								'''Only used when the custom target is specified in TARGET , e.g. jdk_custom, langtools_custom, system_custom, etc., CUSTOM_TARGET=path to the test class to execute (typically ending in .java or .sh)<br>
 								Example 1:<br>
 								TARGET=system_custom<br>
 								CUSTOM_TARGET=-test=MathLoadTest -test-args="workload=math,timeLimit=5m"<br>
@@ -386,7 +386,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							}
 							choiceParam('TEST_FLAG', ['', 'JITAAS', 'AOT', 'FIPS', 'FIPS140_2', 'FIPS140_3_OpenJCEPlusFIPS', 'FIPS140_3_OpenJCEPlusFIPS.FIPS140-3'], "Optional. Only set for feature testing. (i.e.,  JITAAS, AOT, FIPS140_2, etc)")
 							stringParam('EXTRA_OPTIONS', "", "Use this to append options to the test command e.g. to add extra JVM flags")
-							stringParam('JVM_OPTIONS', "", "Use this to replace the test original command line options")
+							stringParam('JVM_OPTIONS', "", "Use this to replace the original options to the test command e.g. to override JVM flags")
 							stringParam('APPLICATION_OPTIONS', "", "Use this to append options to the test application")
 							stringParam('BUILD_IDENTIFIER', "", "build identifier")
 							stringParam('ITERATIONS',"1", '''Optional. Number of times to repeat execution of make target. <br/>

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -385,7 +385,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
 							choiceParam('TEST_FLAG', ['', 'JITAAS', 'AOT', 'FIPS', 'FIPS140_2', 'FIPS140_3_OpenJCEPlusFIPS', 'FIPS140_3_OpenJCEPlusFIPS.FIPS140-3'], "Optional. Only set for feature testing. (i.e.,  JITAAS, AOT, FIPS140_2, etc)")
-							stringParam('EXTRA_OPTIONS', "", "Use this to append options to the test command")
+							stringParam('EXTRA_OPTIONS', "", "Use this to append options to the test command e.g. to add extra JVM flags")
 							stringParam('JVM_OPTIONS', "", "Use this to replace the test original command line options")
 							stringParam('APPLICATION_OPTIONS', "", "Use this to append options to the test application")
 							stringParam('BUILD_IDENTIFIER', "", "build identifier")


### PR DESCRIPTION
Adding an example of what you might use this for. With the replace parameter being `JVM_OPTIONS` it's not entirely clear that `EXTRA_OPTIONS` (without `JVM` in the name) can be used for extra VM options as opposed to just parameters for the test harness - this should remove any ambiguity from me or others in the future.

Ref https://github.com/adoptium/infrastructure/issues/3065#issuecomment-2489009147