### PR TITLE
Revert "Exclude jdk_security4 test on jdk8 linux (#5220)"

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -280,7 +280,6 @@ sun/security/provider/DSA/TestAlgParameterGenerator.java https://github.com/adop
 
 sun/security/krb5/auto/ReplayCacheTestProc.java https://github.com/adoptium/aqa-tests/issues/2349 generic-all
 sun/security/krb5/auto/Unreachable.java https://github.com/adoptium/aqa-tests/issues/2353 aix-all,macosx-all
-sun/security/krb5/auto/rcache_usemd5.sh https://bugs.openjdk.org/browse/JDK-8258855 linux-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
This reverts commit 1ef8a6feb98bcb9f16832fe22aafe7eb0a59a604 and re-enables sun/security/krb5/auto/rcache_usemd5.sh specifically. I am speculating that this was only excluded on aarch64 as it was the only platform where we had the newer distributions at the time.

Fixes https://github.com/adoptium/infrastructure/issues/3521 (Believed to have been resolved upstream in https://bugs.openjdk.org/browse/JDK-8330546)