### PR TITLE
Revert "Update aqa-tests to use JDK 17 for building system test-related jars"

### DIFF
--- a/buildenv/jenkins/getDependency
+++ b/buildenv/jenkins/getDependency
@@ -17,14 +17,14 @@ def testBuild() {
 	timeout(time: time_limit, unit: 'HOURS') {
 		try {
 			if( params.BUILD_TYPE == "systemtest" ){
-				sh 'curl -OLJks "https://api.adoptopenjdk.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk"'
+				sh 'curl -OLJks "https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk"'
 				sh 'mkdir ${WORKSPACE}/j2sdk-image'
-				sh 'tar -xzf OpenJDK17U-jdk_x64_linux_hotspot*.gz -C ${WORKSPACE}/j2sdk-image --strip-components 1'
-				sh '${WORKSPACE}/j2sdk-image/bin/java -version'
+				sh 'tar -xzf OpenJDK8U-jdk_x64_linux_hotspot*.gz -C ${WORKSPACE}/j2sdk-image --strip-components 1'
+				sh '${WORKSPACE}/j2sdk-image/jre/bin/java -version'
 				sh 'git clone https://github.com/adoptium/aqa-systemtest'
 				sh 'git clone https://github.com/adoptium/STF'
-				sh 'ant -f ./aqa-systemtest/openjdk.build/build.xml -Djava.home=${WORKSPACE}/j2sdk-image -Dprereqs_root=${WORKSPACE}/systemtest_prereqs configure'
-				sh 'ant -f ./aqa-systemtest/openjdk.test.mauve/build.xml -Djava.home=${WORKSPACE}/j2sdk-image -Dprereqs_root=${WORKSPACE}/systemtest_prereqs configure'
+				sh 'ant -f ./aqa-systemtest/openjdk.build/build.xml -Djava.home=${WORKSPACE}/j2sdk-image/jre -Dprereqs_root=${WORKSPACE}/systemtest_prereqs configure'
+				sh 'ant -f ./aqa-systemtest/openjdk.test.mauve/build.xml -Djava.home=${WORKSPACE}/j2sdk-image/jre -Dprereqs_root=${WORKSPACE}/systemtest_prereqs configure'
 				archiveArtifacts '**/systemtest_prereqs/cvsclient/org-netbeans-lib-cvsclient.jar'
 				archiveArtifacts '**/systemtest_prereqs/mauve/mauve.jar'
 				archiveArtifacts '**/systemtest_prereqs/junit/junit.jar'


### PR DESCRIPTION
Reverts adoptium/aqa-tests#5711

related: https://github.com/adoptium/aqa-tests/issues/5760#issuecomment-2491232607