### PR TITLE
Increase aarch linux jtreg timeout option

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -112,14 +112,16 @@ JTREG_BASIC_OPTIONS += $(JTREG_IGNORE_OPTION)
 # riscv64 machines aren't very fast (yet!!)
 ifeq ($(ARCH), riscv64)
 	JTREG_TIMEOUT_OPTION = -timeoutFactor:16
-else
+# aarch64 linux requires extra time, set timeoutFactor to 12
+else ifneq ($(filter linux_aarch64, $(SPEC)),)
+	JTREG_TIMEOUT_OPTION =  -timeoutFactor:12
 # Multiple by 8 the timeout numbers, except on zOS use 2
-ifneq ($(OS),OS/390)
-	JTREG_TIMEOUT_OPTION =  -timeoutFactor:8
-else
+else ifeq ($(OS),OS/390)
 	JTREG_TIMEOUT_OPTION =  -timeoutFactor:2
+else
+	JTREG_TIMEOUT_OPTION =  -timeoutFactor:8
 endif
-endif
+
 JTREG_BASIC_OPTIONS += $(JTREG_TIMEOUT_OPTION)
 # Create junit xml
 JTREG_XML_OPTION = -xml:verify


### PR DESCRIPTION
Increase aarch linux jtreg timeout option.

Issue: https://github.com/eclipse-openj9/openj9/issues/20463