### PR TITLE
Removed ages gone -t from system-test/test.sh's get.sh

### DIFF
--- a/external/system-test/test.sh
+++ b/external/system-test/test.sh
@@ -21,7 +21,7 @@ echo "TEST_JDK_HOME is : $TEST_JDK_HOME"
 export BUILD_LIST=system
 
 cd /aqa-tests
-./get.sh -t /aqa-tests
+./get.sh
 
 cd /aqa-tests/TKG
 


### PR DESCRIPTION
The -t/--testdir was made optional in favour ow CWD in February and removed in August