### PR TITLE
Exclude jdk_bean subtest Test6397609 and Test5102804

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -19,6 +19,8 @@
 # jdk_beans
 
 java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/Introspector/Test5102804.java https://github.com/eclipse-openj9/openj9/issues/20531 linux-x64
+java/beans/PropertyEditor/Test6397609.java https://github.com/eclipse-openj9/openj9/issues/20531 linux-x64
 
 ############################################################################
 


### PR DESCRIPTION
- Exclude jdk_bean subtest -`Test6397609` and `Test5102804` on xlinux JDK8.

related: eclipse-openj9/openj9#20531