### PR TITLE
Revert "(v1.0.5) Exclude TestCipherMode for OpenJ9 jdk17, 21 (#5799)"

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -302,7 +302,6 @@ java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj
 
 # jdk_security2
 
-javax/crypto/Cipher/TestCipherMode.java https://github.com/eclipse-openj9/openj9/issues/19962 aix-all
 javax/xml/crypto/dsig/SecureValidation.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -372,12 +372,6 @@ java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj
 
 ############################################################################
 
-# jdk_security2
-
-javax/crypto/Cipher/TestCipherMode.java https://github.com/eclipse-openj9/openj9/issues/19962 aix-all
-
-############################################################################
-
 # jdk_security3
 
 javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all,aix-all


### PR DESCRIPTION
Reverts adoptium/aqa-tests#5804

The problem persists with the test excluded, the test wasn't the cause of the problem.