### PR TITLE
Enable jdk_beans on all linux

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -19,8 +19,8 @@
 # jdk_beans
 
 java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
-java/beans/Introspector/Test5102804.java https://github.com/eclipse-openj9/openj9/issues/20531 linux-x64
-java/beans/PropertyEditor/Test6397609.java https://github.com/eclipse-openj9/openj9/issues/20531 linux-x64
+java/beans/Introspector/Test5102804.java https://github.com/eclipse-openj9/openj9/issues/20531 linux-all
+java/beans/PropertyEditor/Test6397609.java https://github.com/eclipse-openj9/openj9/issues/20531 linux-all
 
 ############################################################################
 

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -757,7 +757,7 @@
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/20531</comment>
 				<impl>openj9</impl>
-				<platform>^((?!(x86-64_linux)).)*$</platform>
+				<platform>^(?!.*linux).*$</platform>
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>


### PR DESCRIPTION
- Enable jdk_beans on alinux, plinux, zlinux for all java versions

related: eclipse-openj9/openj9#20531