### PR TITLE
Update JDK 8 ProblemList with JBS link for java/nio/MappedByteBuffer/Truncate

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -199,7 +199,7 @@ java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/is
 
 # jdk_nio
 
-java/nio/MappedByteBuffer/Truncate.java https://github.com/adoptium/aqa-tests/issues/1052 linux-s390x
+java/nio/MappedByteBuffer/Truncate.java https://bugs.openjdk.org/browse/JDK-8345842 linux-s390x
 java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java https://bugs.openjdk.java.net/browse/JDK-8211851 aix-all
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x


### PR DESCRIPTION
Fixes: https://github.com/adoptium/aqa-tests/issues/1052

The test failure has a JBS now. This PR updates the link.
