### PR TITLE
Enable jdk_restricted_security test on JDK8

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1674,9 +1674,6 @@
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
 		</features>
-		<versions>
-			<version>11+</version>
-		</versions>
 		<levels>
 			<level>special</level>
 		</levels>


### PR DESCRIPTION
Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/786
Enable jdk_restricted_security test on JDK8

Issue: github_ibm/runtimes/automation/issues/119


