### PR TITLE
Enable jdk_restricted_security for JDK11 all platforms

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1656,12 +1656,6 @@
 	</test>
 	<test>
 		<testCaseName>jdk_restricted_security</testCaseName>
-		<disables>
-			<disable>
-				<comment>github_ibm/runtimes/automation/issues/151</comment>
-				<platform>.*(mac|windows|aix).*</platform>
-			</disable>
-		</disables>	
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
 	$(TIMEOUT_HANDLER) \


### PR DESCRIPTION
Depends on PR https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/854
Enable jdk_restricted_security for JDK11 all platforms

Issue: github_ibm/runtimes/automation/issues/151