### PR TITLE
JDK 24+ don't enable security manager and disable failing tests

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -195,6 +195,12 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_all_CS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -20,6 +20,12 @@
 	<!--  The following tests are specific to openj9 only -->
 	<test>
 		<testCaseName>DaaLoadTest_daa1_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -39,6 +45,12 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa2_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -58,6 +70,12 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa3_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -77,6 +95,12 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_all_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -96,6 +120,12 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa1_CS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -115,6 +145,12 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa2_CS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -134,6 +170,12 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa3_CS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -49,6 +49,12 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteClassAuth</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -72,6 +78,10 @@
 				<version>8</version>
 				<impl>hotspot</impl>
 				<platform>arm_linux</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
 			</disable>
 		</disables>
 		<variations>
@@ -103,6 +113,10 @@
 				<version>11+</version>
 				<impl>hotspot</impl>
 				<platform>arm_linux|ppc64le_linux</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
 			</disable>
 		</disables>
 		<variations>
@@ -137,6 +151,10 @@
 				<impl>hotspot</impl>
 				<platform>arm_linux</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -156,6 +174,12 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteNotifierProxyAuth</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -175,6 +199,12 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteThreadAuth</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -192,6 +222,12 @@
 	</test>
 	<test>
 		<testCaseName>TestJlmRemoteThreadNoAuth</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -231,6 +267,12 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -303,6 +345,12 @@
 	<!--Exclude TestIBMJlmRemoteClassNoAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: adoptium/aqa-systemtest/issues/145-->
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassNoAuth</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -374,6 +422,12 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -446,6 +500,12 @@
 	<!--Exclude TestIBMJlmRemoteMemoryNoAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: adoptium/aqa-systemtest/issues/145-->
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryNoAuth</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -38,6 +38,12 @@
 	</test>
 	<test>
 		<testCaseName>LambdaLoadTest_J9_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -57,6 +63,12 @@
 	</test>
 	<test>
 		<testCaseName>LambdaLoadTest_CS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -143,6 +155,12 @@
 	</test>
 	<test>
 		<testCaseName>ParallelStreamsLoadTest_J9</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -162,6 +180,12 @@
 	</test>
 	<test>
 		<testCaseName>ParallelStreamsLoadTest_CS</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -19,6 +19,12 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_all_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -79,6 +85,12 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_all_CS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -35,6 +35,12 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_autosimd_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -51,6 +57,12 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_bigdecimal_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -86,6 +98,12 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_autosimd_CS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -105,6 +123,12 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_bigdecimal_CS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -20,6 +20,12 @@
 	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse-openj9/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleThrdLoad_J9_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -73,6 +79,12 @@
 	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse-openj9/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleInvocLoad_J9_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -131,12 +143,16 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
-                        <disable>
-                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
-                                <version>8</version>
-                                <impl>hotspot</impl>
-                                <platform>.*windows.*</platform>
-                        </disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+				<version>8</version>
+				<impl>hotspot</impl>
+				<platform>.*windows.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -709,6 +709,12 @@
 	</test>
 	<test>
 		<testCaseName>CLLoad</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -157,6 +157,12 @@
 	</test>
 	<test>
 		<testCaseName>ClassLoadingTest_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -302,6 +308,12 @@
 	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/342-->
 	<test>
 		<testCaseName>NioLoadTest_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -450,6 +462,12 @@
 	<!-- The tests below are added to test concurrent scavenge on z/OS, z/Linux, x/Linux and x/Windows using 64-bit OpenJ9 SDK -->
 	<test>
 		<testCaseName>ClassLoadingTest_CS_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -45,12 +45,16 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
-                        <disable>
-                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
-                                <version>8</version>
-                                <impl>hotspot</impl>
-                                <platform>.*windows.*</platform>
-                        </disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+				<version>8</version>
+				<impl>hotspot</impl>
+				<platform>.*windows.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -80,12 +84,16 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
-                        <disable>
-                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
-                                <version>8</version>
-                                <impl>hotspot</impl>
-                                <platform>.*windows.*</platform>
-                        </disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+				<version>8</version>
+				<impl>hotspot</impl>
+				<platform>.*windows.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -119,12 +127,16 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
-                        <disable>
-                                <comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
-                                <version>8</version>
-                                <impl>hotspot</impl>
-                                <platform>.*windows.*</platform>
-                        </disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/5673</comment>
+				<version>8</version>
+				<impl>hotspot</impl>
+				<platform>.*windows.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
 		</disables>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -debug-generation -java-debug-args=$(Q)-Xmx3g -Xms3g$(Q) -test-args=$(Q)timeLimit=5m$(Q) -java-args-execute-initial=$(Q)$(ADD_OPENS_CMD) -Xmx3g -Xms3g$(Q); \
 	$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -test-args=$(Q)timeLimit=5m$(Q) -java-args-execute-initial=$(Q)$(ADD_OPENS_CMD) -Xmx2g -Xms2g$(Q); \
@@ -239,6 +251,10 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -257,6 +273,12 @@
 	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/571-->
 	<test>
 		<testCaseName>DBBLoadTest_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -274,6 +296,12 @@
 	</test>
 	<test>
 		<testCaseName>LangLoadTest_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -290,6 +318,12 @@
 	</test>
 	<test>
 		<testCaseName>LockingLoadTest</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -331,6 +365,12 @@
 	</test>
 	<test>
 		<testCaseName>UtilLoadTest_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -423,6 +463,12 @@
 	</test>
 	<test>
 		<testCaseName>HeapHogLoadTest_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -442,6 +488,12 @@
 	</test>
 	<test>
 		<testCaseName>ObjectTreeLoadTest_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>

--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -24,6 +24,12 @@
 	</test>
 	<test>
 		<testCaseName>SharedClassesAPI</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -44,6 +50,12 @@
 	</test>
 	<test>
 		<testCaseName>SharedClassesWorkload</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/STF/issues/142</comment>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>

--- a/system/system.mk
+++ b/system/system.mk
@@ -47,14 +47,15 @@ else
   OPENJ9_PRAM=""
 endif
 
+# In JDK 24+ any attempts to enable the security manager will result in an error.
 # In JDK18+, java.security.manager == null behaves as -Djava.security.manager=disallow.
 # In JDK17-, java.security.manager == null behaves as -Djava.security.manager=allow.
 # In case of system tests, the base infra (STF) which is used to launch tests utilizes
 # the security manager in net.adoptopenjdk.loadTest.LoadTest.overrideSecurityManager.
 # For system tests to work as expected, -Djava.security.manager=allow behaviour is
-# needed in JDK18+.
+# needed in JDK18-23.
 # Related: https://github.com/eclipse-openj9/openj9/issues/14412
-ifeq ($(filter 8 9 10 11 12 13 14 15 16 17, $(JDK_VERSION)),)
+ifneq ($(filter 18 19 20 21 22 23, $(JDK_VERSION)),)
   export JAVA_TOOL_OPTIONS:=-Djava.security.manager=allow
   $(warning Environment variable JAVA_TOOL_OPTIONS is set to '$(JAVA_TOOL_OPTIONS)')
 endif


### PR DESCRIPTION
In [JEP 486](https://openjdk.org/jeps/486) for Java 24 any attempt to enable a security manager (such as -Djava.security.manager=allow) will result in an error. This change removes the use of java.security.manager=allow from JDK 24+.

The system test framework also has uses the security manager for load tests that needs to be removed. In the meantime this change disables tests that are failing because of it. See https://github.com/adoptium/STF/issues/142