### PR TITLE
Update playlist of jdk_lang_j9 test

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -858,6 +858,7 @@
 		<testCaseName>jdk_lang_j9</testCaseName>
 		<variations>
 			<variation>$(TEST_VARIATION_DUMP) $(TEST_VARIATION_JIT_PREVIEW) Mode501</variation>
+			<variation>$(TEST_VARIATION_DUMP) $(TEST_VARIATION_JIT_PREVIEW) Mode501 -XXgc:fvtest_forceCopyForwardHybridMarkCompactRatio=10</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -Xmx768m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \


### PR DESCRIPTION
Update playlist of jdk_lang_j9 test for increasing test coverage.

there are no enough test cases for testing balanced sweep compaction code, so adding the variation for jdk_lang_j9 test with fvt option
-XXgc:fvtest_forceCopyForwardHybridMarkCompactRatio=10 (force random pick 10% collection set(regions) to be sweep/compact instead of copyforward during regular PGC).