### PR TITLE
Exclude JDK8 javax/management/MBeanServer/OldMBeanServerTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -130,6 +130,8 @@ sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/ad
 
 # jdk_jmx
 
+javax/management/MBeanServer/OldMBeanServerTest.java https://github.com/eclipse-openj9/openj9/issues/20777 generic-all
+
 ############################################################################
 
 # jdk_math


### PR DESCRIPTION
Exclude JDK8 `javax/management/MBeanServer/OldMBeanServerTest.java`

Related to
* https://github.com/eclipse-openj9/openj9/issues/20777

Signed-off-by: Jason Feng <fengj@ca.ibm.com>