### PR TITLE
Adjust Grinder link to properly rerun with 0 iterations and always rerun with parallel=none

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1189,43 +1189,40 @@ def addGrinderLink() {
 	def labelValue = ""
 	def targetValue = ""
 	def customTargetKeyValue = ""
-	def rerunIterations = ""
 	def urlParams = params.findAll {
 		// Exclude separator and help text parameters from url
 		!(it.key.endsWith('_PARAMS') || it.key.endsWith('_HELP_TEXT'))
 	}
 	urlParams.each { key, value ->
 		value = URLEncoder.encode(value.toString(), "UTF-8")
+		if (key == "LABEL") {
+			labelValue = "LABEL=${value}"
+		}
+		if (key == "TARGET") {
+			targetValue = "TARGET=${value}"
+		}
+		if (key == "CUSTOM_TARGET") {
+			customTargetKeyValue = "CUSTOM_TARGET=${value}"
+		}
+		// Always set RERUN_ITERATIONS to 0 for Grinder link
+		if (key == "RERUN_ITERATIONS") {
+			value = "0"
+		}
+		// Always set LightWeightCheckout to false for Grinder link
+		if (key == "LIGHT_WEIGHT_CHECKOUT") {
+			value = "false"
+		}
+		// Always set Parallel to None for Grinder link
+		if (key == "PARALLEL") {
+			value = "NONE"
+		}
+
 		url += "${key}=${value}"
 		if (i != urlParams.size()) {
 			url += "&amp;"
 		}
 		i++;
-		if ( key == "LABEL" ) {
-			labelValue = "LABEL=${value}"
-		}
-		if ( key == "TARGET" ) {
-			targetValue = "TARGET=${value}"
-		}
-		if ( key == "CUSTOM_TARGET") {
-			customTargetKeyValue = "CUSTOM_TARGET=${value}"
-		}
-		if ( key == "RERUN_ITERATIONS") {
-			rerunIterations = "RERUN_ITERATIONS=${value}"
-		}
-
 	}
-	env.RERUN_LINK = url
-	env.FAILED_TEST_TARGET = targetValue
-	env.CUSTOM_TARGET_KEY_VALUE = customTargetKeyValue
-
-	// reset RERUN_ITERATIONS to 0 in Rerun in Grinder link
-	if (rerunIterations) {
-		url = url.replace(rerunIterations,"RERUN_ITERATIONS=0")
-	}
-
-	// reset LIGHT_WEIGHT_CHECKOUT to false in Rerun in Grinder link
-	url = url.replace("LIGHT_WEIGHT_CHECKOUT=true", "LIGHT_WEIGHT_CHECKOUT=false")
 
 	currentBuild.description += "<br><a href=\"https://github.com/adoptium/aqa-tests/wiki/How-to-Run-a-Grinder-Build-on-Jenkins\">Grinder Wiki</a>"
 	echo "Rerun in Grinder: ${url}"
@@ -1233,6 +1230,10 @@ def addGrinderLink() {
 	def sameMachineUrl = url.replace(labelValue,"LABEL=${NODE_NAME}")
 	echo "Rerun in Grinder on same machine: ${sameMachineUrl}"
 	currentBuild.description += "<br><a href=${sameMachineUrl}>Rerun in Grinder on same machine</a> Change TARGET to run only the failed test targets. For dynamic vm agents as they are created at runtime and quickly recycled, it may not be possible to rerun on the same agent."
+
+	env.RERUN_LINK = url
+	env.FAILED_TEST_TARGET = targetValue
+	env.CUSTOM_TARGET_KEY_VALUE = customTargetKeyValue
 }
 
 def addFailedTestsGrinderLink(paths=""){

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1214,7 +1214,7 @@ def addGrinderLink() {
 		}
 		// Always set Parallel to None for Grinder link
 		if (key == "PARALLEL") {
-			value = "NONE"
+			value = "None"
 		}
 
 		url += "${key}=${value}"
@@ -1224,16 +1224,16 @@ def addGrinderLink() {
 		i++;
 	}
 
+	env.RERUN_LINK = url
+	env.FAILED_TEST_TARGET = targetValue
+	env.CUSTOM_TARGET_KEY_VALUE = customTargetKeyValue
+
 	currentBuild.description += "<br><a href=\"https://github.com/adoptium/aqa-tests/wiki/How-to-Run-a-Grinder-Build-on-Jenkins\">Grinder Wiki</a>"
 	echo "Rerun in Grinder: ${url}"
 	currentBuild.description += "<br><a href=${url}>Rerun in Grinder</a> Change TARGET to run only the failed test targets."
 	def sameMachineUrl = url.replace(labelValue,"LABEL=${NODE_NAME}")
 	echo "Rerun in Grinder on same machine: ${sameMachineUrl}"
 	currentBuild.description += "<br><a href=${sameMachineUrl}>Rerun in Grinder on same machine</a> Change TARGET to run only the failed test targets. For dynamic vm agents as they are created at runtime and quickly recycled, it may not be possible to rerun on the same agent."
-
-	env.RERUN_LINK = url
-	env.FAILED_TEST_TARGET = targetValue
-	env.CUSTOM_TARGET_KEY_VALUE = customTargetKeyValue
 }
 
 def addFailedTestsGrinderLink(paths=""){


### PR DESCRIPTION
Fixes: #4830 

This adjusts the code when generating grinder link parameters to:
- always rerun with 0 iterations
- never use lightweight checkouts
- always use no parallelization

with slightly refactored code that should be easier to read.