### PR TITLE
Add .gitattributes file to tag jar/war files in binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Binary files
+*.jar binary
+*.war binary


### PR DESCRIPTION
Due to JEP400 in JDK21 on z/OS, jar/war files needs to be tagged as binary to avoid auto-Conversion. This PR relates to https://github.com/adoptium/TKG/pull/608