### PR TITLE
Exclude jdk_beans tests for macOS versions 8,24,25

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -22,6 +22,16 @@
 
 # jdk_beans
 
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClass.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClassJava.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClassNull.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClassValue.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClass.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClassJava.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClassNull.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClassValue.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+
 ############################################################################
 
 # jdk_lang

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -22,6 +22,16 @@
 
 # jdk_beans
 
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClass.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClassJava.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClassNull.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClassValue.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClass.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClassJava.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClassNull.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClassValue.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+
 ############################################################################
 
 # jdk_lang

--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -19,8 +19,18 @@
 # jdk_beans
 
 java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
-java/beans/Introspector/Test5102804.java https://github.com/eclipse-openj9/openj9/issues/20531 linux-all
-java/beans/PropertyEditor/Test6397609.java https://github.com/eclipse-openj9/openj9/issues/20531 linux-all
+java/beans/Introspector/Test5102804.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all,linux-all
+java/beans/PropertyEditor/Test6397609.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all,linux-all
+java/beans/XMLEncoder/Test6570354.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClass.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClassJava.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClassNull.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestColorClassValue.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClass.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClassJava.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClassNull.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
+java/beans/PropertyEditor/TestFontClassValue.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
- Exclude jdk_beans subtests for amac/xmac for versions 8,24,25

related: eclipse-openj9/openj9#20531