### PR TITLE
(v1.0.5-release) Set RERUN_FAILURE in testJobTemplate (#5837)

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -62,6 +62,7 @@ if (!binding.hasVariable('VENDOR_TEST_DIRS')) VENDOR_TEST_DIRS = ""
 if (!binding.hasVariable('USER_CREDENTIALS_ID')) USER_CREDENTIALS_ID = ""
 if (!binding.hasVariable('GENERATE_JOBS')) GENERATE_JOBS = false
 if (!binding.hasVariable('CLOUD_PROVIDER')) CLOUD_PROVIDER = ""
+if (!binding.hasVariable('RERUN_FAILURE')) RERUN_FAILURE = false
 if (!binding.hasVariable('RERUN_ITERATIONS')) RERUN_ITERATIONS = "0"
 if (!binding.hasVariable('JENKINS_KEY')) JENKINS_KEY = ""
 if (!binding.hasVariable('RELATED_NODES')) RELATED_NODES = ""
@@ -449,6 +450,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							stringParam('SLACK_CHANNEL', SLACK_CHANNEL, "Slack channel. e.g., #rt-jenkins")
 							booleanParam('PERSONAL_BUILD', false, "Is this a personal build?")
 							booleanParam('USE_TESTENV_PROPERTIES', USE_TESTENV_PROPERTIES.toBoolean(), "use properties defined in the testenv.properties")
+							booleanParam('RERUN_FAILURE', RERUN_FAILURE.toBoolean(), "If set to true, auto rerun test child builds in FAILURE status.")
 							stringParam('RERUN_ITERATIONS', RERUN_ITERATIONS, "Optional. Number of times to repeat execution of failed test target(s).")
 							booleanParam('SETUP_JCK_RUN', SETUP_JCK_RUN.toBoolean(), "setup jdk during release for jck interactive run")
 							stringParam('JENKINS_KEY', JENKINS_KEY, "Optional. Only use this for Multi-node Compiler TCK tests")


### PR DESCRIPTION
cherry-pick: https://github.com/adoptium/aqa-tests/pull/5837

related: https://github.com/adoptium/ci-jenkins-pipelines/issues/1177