### PR TITLE
(v1.0.5 Release) Enable jdk_restricted_security for JDK11 all platforms (#5816)

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1659,12 +1659,6 @@
 	</test>
 	<test>
 		<testCaseName>jdk_restricted_security</testCaseName>
-		<disables>
-			<disable>
-				<comment>github_ibm/runtimes/automation/issues/151</comment>
-				<platform>.*(mac|windows|aix).*</platform>
-			</disable>
-		</disables>	
 		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
 	$(TIMEOUT_HANDLER) \


### PR DESCRIPTION
Cherry-pick https://github.com/adoptium/aqa-tests/pull/5816

Enable jdk_restricted_security for JDK11 all platforms