### PR TITLE
Exclude AIX tests which deliberately fails on AIX

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -451,3 +451,4 @@ jdk/jfr/event/compiler/TestCompilerInlining.java https://github.com/adoptium/aqa
 # langtools_all
 
 tools/javac/defaultMethods/Assertions.java https://bugs.openjdk.org/browse/JDK-8047675 generic-all
+tools/javah/ReadOldClass.sh https://github.com/adoptium/aqa-tests/issues/5854 aix-all

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -12,6 +12,12 @@
 # limitations under the License.
 #############################################################################
 
+# hotspot_jdk
+
+serviceability/dcmd/DynLibDcmdTest.java 
+
+############################################################################
+
 # hotspot_all
 
 # compiler/7184394/TestAESMain.java https://github.com/adoptium/infrastructure/issues/2893

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -14,7 +14,7 @@
 
 # hotspot_jdk
 
-serviceability/dcmd/DynLibDcmdTest.java 
+serviceability/dcmd/DynLibDcmdTest.java https://github.com/adoptium/aqa-tests/issues/5854 aix-all
 
 ############################################################################
 


### PR DESCRIPTION
ref https://github.com/adoptium/aqa-tests/issues/5854

Looks like this is a test which deliberately fails on AIX

Testcode https://github.com/adoptium/jdk8u/blob/release/langtools/test/tools/javah/ReadOldClass.sh

```
# set platform-dependent variables
OS=`uname -s`
case "$OS" in
  SunOS | Linux | Darwin | CYGWIN* )
    PS=":"
    FS="/"
    ;;
  Windows* )
    PS=";"
    FS="\\"
    ;;
  * )
    echo "Unrecognized system!"
    exit 1;
    ;;
esac
```

`uname -s` on AIX machines returns AIX