### PR TITLE
[v1.0.5-release] Exclude AIX tests which deliberately fails on AIX (#5855)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -12,6 +12,12 @@
 # limitations under the License.
 #############################################################################
 
+# hotspot_jdk
+
+serviceability/dcmd/DynLibDcmdTest.java https://github.com/adoptium/aqa-tests/issues/5854 aix-all
+
+############################################################################
+
 # hotspot_all
 
 # compiler/7184394/TestAESMain.java https://github.com/adoptium/infrastructure/issues/2893
@@ -450,3 +456,4 @@ jdk/jfr/event/compiler/TestCompilerInlining.java https://github.com/adoptium/aqa
 # langtools_all
 
 tools/javac/defaultMethods/Assertions.java https://bugs.openjdk.org/browse/JDK-8047675 generic-all
+tools/javah/ReadOldClass.sh https://github.com/adoptium/aqa-tests/issues/5854 aix-all


### PR DESCRIPTION
Cherry pick of https://github.com/adoptium/aqa-tests/pull/5855