### PR TITLE
[v1.0.5-release] Update jdk8u arm32 dryrun tags

### DIFF
--- a/testenv/testenv_arm32.properties
+++ b/testenv/testenv_arm32.properties
@@ -9,6 +9,6 @@ OPENJ9_SYSTEMTEST_BRANCH=v1.0.5
 ADOPTOPENJDK_SYSTEMTEST_REPO=https://github.com/adoptium/aqa-systemtest.git
 ADOPTOPENJDK_SYSTEMTEST_BRANCH=v1.0.5
 JDK8_REPO=https://github.com/adoptium/aarch32-jdk8u.git
-JDK8_BRANCH=dev
+JDK8_BRANCH=jdk8u442-b05-aarch32-20250107
 AQA_REQUIRED_TARGETS=sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,extended.perf
 


### PR DESCRIPTION
Going to use jdk8u442-b05-aarch32-20250107 for the arm32 jdk8 dryrun