### PR TITLE
Cherry pick openjdk exclude fixes

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -18,19 +18,19 @@
 
 # jdk_beans
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 # java/beans/XMLEncoder/java_awt_ScrollPane.java failure on mac is tracked by https://github.com/adoptium/aqa-tests/issues/2848
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
@@ -43,17 +43,7 @@ java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
-java/beans/PropertyEditor/TestColorClass.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86 
-java/beans/PropertyEditor/TestColorClassJava.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
-java/beans/PropertyEditor/TestColorClassNull.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
-java/beans/PropertyEditor/TestColorClassValue.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
-java/beans/PropertyEditor/TestFontClass.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
-java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
-java/beans/PropertyEditor/TestFontClassNull.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
-java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
-javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/adoptium/aqa-tests/issues/5689 windows-x86
+javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/adoptium/aqa-tests/issues/5689 windows-all
 ############################################################################
 
 # jdk_lang

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -206,7 +206,7 @@ javax/net/ssl/SSLEngine/LargePacket.java https://bugs.openjdk.org/browse/JDK-822
 sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-tests/issues/4808 generic-all
 sun/security/pkcs11/Secmod/AddTrustedCert.java https://github.com/adoptium/aqa-tests/issues/2123 linux-all
 sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java https://github.com/adoptium/aqa-tests/issues/2123 linux-all
-sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
+sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
 sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aqa-tests/issues/3811 windows-x86
 sun/security/util/Debug/DebugOptions.java https://bugs.openjdk.org/browse/JDK-8339713 linux-arm
 

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -18,21 +18,21 @@
 
 # jdk_beans
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
 # java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
 # java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 # java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -248,7 +248,7 @@ sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aq
 
 javax/net/ssl/SSLEngine/LargePacket.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
 sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-tests/issues/4808 generic-all
-sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
+sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 
 ###########################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -249,7 +249,7 @@ sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aq
 
 javax/net/ssl/SSLEngine/LargePacket.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
 sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-tests/issues/4808 generic-all
-sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
+sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 
 ###########################################################################
 


### PR DESCRIPTION
Cherry pick commits:
- [Symantec/Distrust exclude renamed for jdk-17+](https://github.com/adoptium/aqa-tests/commit/7f29c838228fc7eb6a7b80b31e1351a2cd007992)
- [Correct PropertyEditor exclusion mac+windows excludes under one entry](https://github.com/adoptium/aqa-tests/commit/4b7bd7d6b74761419b503cb4184a80529137d1b2)
- 