### PR TITLE
Exclude riscv headless failure for tools/jpackage/linux/LinuxWeirdOutputDirTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -233,6 +233,7 @@ sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-824
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
 sun/tools/jstat/jstatLineCounts4.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+tools/jpackage/linux/LinuxWeirdOutputDirTest.java https://bugs.openjdk.org/browse/JDK-8324306 linux-riscv64
 tools/jpackage/linux/AppAboutUrlTest.java#id0 https://github.com/adoptium/aqa-tests/issues/4976 linux-riscv64
 tools/jpackage/linux/AppCategoryTest.java https://github.com/adoptium/aqa-tests/issues/4976 linux-riscv64
 tools/jpackage/linux/LinuxBundleNameTest.java https://github.com/adoptium/aqa-tests/issues/4976 linux-riscv64


### PR DESCRIPTION
Exclude for riscv headless jdk-17 failure tools/jpackage/linux/LinuxWeirdOutputDirTest.java
ref: https://github.com/adoptium/aqa-tests/issues/5867#issue-2792470996
