### PR TITLE
New testcase JavacBench.java#dynamic fails on win32

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -471,6 +471,7 @@ runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tes
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/aqa-tests/issues/5869 windows-x86
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86


### PR DESCRIPTION
Exclude for https://github.com/adoptium/aqa-tests/issues/5869

jdk17 win32 test runtime/cds/appcds/applications/JavacBench.java#dynamic fails due to no client CDS
