### PR TITLE
Exclude JShellHeapDumpTest for windows-all

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -203,7 +203,8 @@ java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java https://github.c
 
 # jdk_tools
 
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 sun/tools/jstatd/TestJstatdExternalRegistry.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -226,6 +226,7 @@ sun/security/util/Debug/DebugOptions.java https://bugs.openjdk.org/browse/JDK-83
 
 ## linux-riscv64 excluded tests are tracked with https://github.com/adoptium/aqa-tests/issues/4976
 
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
 sun/tools/jstatd/TestJstatdExternalRegistry.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -274,7 +274,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -283,7 +283,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -284,7 +284,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le

--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -284,7 +284,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le


### PR DESCRIPTION
Exclude for issue: https://github.com/adoptium/aqa-tests/issues/5871

JShellHeapDumpTest fails consistently on jdk-11+ all windows

ref: https://github.com/adoptium/aqa-tests/issues/5852#issuecomment-2593073381