### PR TITLE
aqa test exclude cherry picks

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -203,7 +203,8 @@ java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java https://github.c
 
 # jdk_tools
 
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 sun/tools/jstatd/TestJstatdExternalRegistry.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all

--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -345,7 +345,8 @@ runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tes
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
+#runtime/jni/nativeStack/TestNativeStack.java https://bugs.openjdk.org/browse/JDK-8311092 linux-arm
+runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,linux-arm
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -226,6 +226,7 @@ sun/security/util/Debug/DebugOptions.java https://bugs.openjdk.org/browse/JDK-83
 
 ## linux-riscv64 excluded tests are tracked with https://github.com/adoptium/aqa-tests/issues/4976
 
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
 sun/tools/jstatd/TestJstatdExternalRegistry.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -233,6 +233,7 @@ sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-824
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
 sun/tools/jstat/jstatLineCounts4.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm
+tools/jpackage/linux/LinuxWeirdOutputDirTest.java https://bugs.openjdk.org/browse/JDK-8324306 linux-riscv64
 tools/jpackage/linux/AppAboutUrlTest.java#id0 https://github.com/adoptium/aqa-tests/issues/4976 linux-riscv64
 tools/jpackage/linux/AppCategoryTest.java https://github.com/adoptium/aqa-tests/issues/4976 linux-riscv64
 tools/jpackage/linux/LinuxBundleNameTest.java https://github.com/adoptium/aqa-tests/issues/4976 linux-riscv64

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -471,7 +471,8 @@ runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tes
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
+#runtime/jni/nativeStack/TestNativeStack.java https://bugs.openjdk.org/browse/JDK-8311092 linux-arm
+runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,linux-arm
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
@@ -480,6 +481,7 @@ runtime/os/TestTracePageSizes.java#with-G1 https://bugs.openjdk.org/browse/JDK-8
 runtime/os/TestTracePageSizes.java#with-Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#with-Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://bugs.openjdk.org/browse/JDK-8347908 linux-arm
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -473,6 +473,7 @@ runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tes
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/aqa-tests/issues/5869 windows-x86
 #runtime/jni/nativeStack/TestNativeStack.java https://bugs.openjdk.org/browse/JDK-8311092 linux-arm
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,linux-arm
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -274,7 +274,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -283,7 +283,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -284,7 +284,8 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
+#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le


### PR DESCRIPTION
Cherry pick:
- [Exclude hotspot runtime tests on arm linux](https://github.com/adoptium/aqa-tests/commit/412cef5f8aea3fd80b436d59f2fb8bdf752262c6)
- [Exclude riscv headless failure for tools/jpackage/linux/LinuxWeirdOutputDirTest](https://github.com/adoptium/aqa-tests/commit/80e6a2ffed2f4fac40989cb231ae379113b6d1c2)
- [Exclude JShellHeapDumpTest for windows-all](https://github.com/adoptium/aqa-tests/commit/a0307f8706177f5bcd14f0545a937b2761413c7c)
- [New testcase JavacBench.java#dynamic fails on win32](https://github.com/adoptium/aqa-tests/commit/9dcc9a3c639e085dcca6488d728f6c9df159328e)
