### PR TITLE
Exclude failing CDS tests on jdk17u mac-x64 as Temurin does not build a CDS

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -470,10 +470,12 @@ runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/i
 #runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-x86
 runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-x86
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+#runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86,macosx-x64
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/aqa-tests/issues/5869 windows-x86
+#runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/aqa-tests/issues/5869 windows-x86,macosx-x64
 #runtime/jni/nativeStack/TestNativeStack.java https://bugs.openjdk.org/browse/JDK-8311092 linux-arm
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,linux-arm
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86


### PR DESCRIPTION
We don't build a CDS on Mac x64 (ref: https://github.com/adoptium/adoptium-support/issues/937#issuecomment-2312015504)
There are some tests not excluded on jdk17u for mac x64.
Note: jdk21+ excludes all CDS tests when no-CDS ref: https://github.com/openjdk/jdk21u/blob/e45287d1ad9dcadf8a23d3271f1b675b8dade0ac/test/hotspot/jtreg/TEST.groups#L56
