### PR TITLE
[v1.0.5-release] Exclude failing CDS tests on jdk17u mac-x64 as no CDS (#5878)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -470,10 +470,12 @@ runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/i
 #runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-x86
 runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-x86
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+#runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86,macosx-x64
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/aqa-tests/issues/5869 windows-x86
+#runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/aqa-tests/issues/5869 windows-x86,macosx-x64
 #runtime/jni/nativeStack/TestNativeStack.java https://bugs.openjdk.org/browse/JDK-8311092 linux-arm
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,linux-arm
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86


### PR DESCRIPTION
Cherry pick:
- [Exclude failing CDS tests on jdk17u mac-x64 as no CDS](https://github.com/adoptium/aqa-tests/commit/e74849823825effd1214befbbfbb52f14f5de7a0)

