### PR TITLE
Enable tools/jpackage/share disabled by jdk_tools for non jdk17

### DIFF
--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk21.txt
@@ -95,7 +95,7 @@ java/nio/file/DirectoryStream/SecureDS.java https://github.com/adoptium/aqa-test
 ############################################################################
 
 # jdk_tools
-
+tools/jpackage/share/AppLauncherEnvTest.java https://github.com/adoptium/aqa-tests/issues/3232 linux-all
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk23.txt
@@ -95,7 +95,7 @@ java/nio/file/DirectoryStream/SecureDS.java https://github.com/adoptium/aqa-test
 ############################################################################
 
 # jdk_tools
-
+tools/jpackage/share/RuntimeImageTest.java https://github.com/adoptium/aqa-tests/issues/5892 linux-all
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk24.txt
@@ -95,7 +95,7 @@ java/nio/file/DirectoryStream/SecureDS.java https://github.com/adoptium/aqa-test
 ############################################################################
 
 # jdk_tools
-
+tools/jpackage/share/RuntimeImageTest.java https://github.com/adoptium/aqa-tests/issues/5892 linux-all
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk8.txt
@@ -96,7 +96,8 @@ java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issu
 ############################################################################
 
 # jdk_tools
-
+sun/tools/native2ascii/Native2AsciiTests.sh https://github.com/adoptium/aqa-tests/issues/5893 linux-all
+tools/launcher/ExecutionEnvironment.java https://github.com/adoptium/aqa-tests/issues/5894 linux-all
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1719,6 +1719,8 @@
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3232#issuecomment-1032587426</comment>
 				<platform>x86-64_alpine-linux|aarch64_alpine-linux</platform>
+				<version>17</version>
+				<impl>hotspot</impl>
 			</disable>
 		</disables>
 		<variations>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1717,7 +1717,7 @@
 				<impl>ibm</impl>
 			</disable>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/3232#issuecomment-1032587426</comment>
+				<comment>https://bugs.openjdk.org/browse/JDK-8324306</comment>
 				<platform>x86-64_alpine-linux|aarch64_alpine-linux</platform>
 				<version>17</version>
 				<impl>hotspot</impl>


### PR DESCRIPTION
Exclude one failing test with alpine by linux-all under adoptium. So test is only excluded for adoptium on other linux platforms including alpine.

Close https://github.com/adoptium/aqa-tests/issues/3232

See [tools/jpackage/share](https://github.com/adoptium/aqa-tests/issues/3232#issuecomment-2605760205)
related https://github.com/adoptium/aqa-tests/issues/5892
https://github.com/adoptium/aqa-tests/issues/5893
https://github.com/adoptium/aqa-tests/issues/5894
