### PR TITLE
[v1.0.5-release] January 2025 release Arm32 Linux JDK8 tags

### DIFF
--- a/testenv/testenv_arm32.properties
+++ b/testenv/testenv_arm32.properties
@@ -9,6 +9,6 @@ OPENJ9_SYSTEMTEST_BRANCH=v1.0.5
 ADOPTOPENJDK_SYSTEMTEST_REPO=https://github.com/adoptium/aqa-systemtest.git
 ADOPTOPENJDK_SYSTEMTEST_BRANCH=v1.0.5
 JDK8_REPO=https://github.com/adoptium/aarch32-jdk8u.git
-JDK8_BRANCH=jdk8u442-b05-aarch32-20250107
+JDK8_BRANCH=jdk8u442-b06-aarch32-20250125
 AQA_REQUIRED_TARGETS=sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,extended.perf
 


### PR DESCRIPTION
GA tags for JDK8 Arm32 linux have been released https://github.com/adoptium/aarch32-jdk8u/tags