### PR TITLE
Exclude hotspot runtime tests not supported on windows aarch64

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -483,8 +483,8 @@ runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-833755
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5909 windows-aarch64
-runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5909 windows-aarch64
+runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
+runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -483,6 +483,8 @@ runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-833755
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
+runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5909 windows-aarch64
+runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5909 windows-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
See https://github.com/adoptium/aqa-tests/issues/5909

2 hotspot tests are not supported on windows aarch64

Will merge into release branch after merged into master