### PR TITLE
fixed typo in get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -811,8 +811,8 @@ checkRepoSHA()
 	sha_file="$TESTDIR/TKG/SHA.txt"
 	testenv_file="$TESTDIR/testenv/testenv.properties"
 
-	echo "$TESTDIR/TKG/scripts/getSHA.sh --repo_dir $1 --output_file $sha_file"
-	$TESTDIR/TKG/scripts/getSHA.sh --repo_dir $1 --output_file $sha_file
+	echo "$TESTDIR/TKG/scripts/getSHAs.sh --repo_dir $1 --output_file $sha_file"
+	$TESTDIR/TKG/scripts/getSHAs.sh --repo_dir $1 --output_file $sha_file
 
 	echo "$TESTDIR/TKG/scripts/getTestenvProperties.sh --repo_dir $1 --output_file $testenv_file --repo_name $2"
 	$TESTDIR/TKG/scripts/getTestenvProperties.sh --repo_dir $1 --output_file $testenv_file --repo_name $2


### PR DESCRIPTION
This typo currently breaks get.sh

We can see (in the link below) that the proper file title is getSHAs.sh (note the lowercase 's' before the file extension)
https://github.com/adoptium/TKG/tree/master/scripts