### PR TITLE
Enable system load tests for JDK 24+

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -20,12 +20,6 @@
 	<!--  The following tests are specific to openj9 only -->
 	<test>
 		<testCaseName>DaaLoadTest_daa1_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -45,12 +39,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa2_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -70,12 +58,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa3_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -95,12 +77,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_all_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -120,12 +96,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa1_CS_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -145,12 +115,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa2_CS_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -170,12 +134,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa3_CS_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -195,12 +153,6 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_all_CS_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -49,12 +49,6 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteClassAuth</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -78,10 +72,6 @@
 				<version>8</version>
 				<impl>hotspot</impl>
 				<platform>arm_linux</platform>
-			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
 			</disable>
 		</disables>
 		<variations>
@@ -113,10 +103,6 @@
 				<version>11+</version>
 				<impl>hotspot</impl>
 				<platform>arm_linux|ppc64le_linux</platform>
-			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
 			</disable>
 		</disables>
 		<variations>
@@ -151,10 +137,6 @@
 				<impl>hotspot</impl>
 				<platform>arm_linux</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -174,12 +156,6 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteNotifierProxyAuth</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -199,12 +175,6 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestJlmRemoteThreadAuth</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -222,12 +192,6 @@
 	</test>
 	<test>
 		<testCaseName>TestJlmRemoteThreadNoAuth</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -267,12 +231,6 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassAuth</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -345,12 +303,6 @@
 	<!--Exclude TestIBMJlmRemoteClassNoAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: adoptium/aqa-systemtest/issues/145-->
 	<test>
 		<testCaseName>TestIBMJlmRemoteClassNoAuth</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -422,12 +374,6 @@
 	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryAuth</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -500,12 +446,6 @@
 	<!--Exclude TestIBMJlmRemoteMemoryNoAuth from running on openjdk8-openj9 on ppc64le Linux. Reason: adoptium/aqa-systemtest/issues/145-->
 	<test>
 		<testCaseName>TestIBMJlmRemoteMemoryNoAuth</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -38,12 +38,6 @@
 	</test>
 	<test>
 		<testCaseName>LambdaLoadTest_J9_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -63,12 +57,6 @@
 	</test>
 	<test>
 		<testCaseName>LambdaLoadTest_CS_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -155,12 +143,6 @@
 	</test>
 	<test>
 		<testCaseName>ParallelStreamsLoadTest_J9</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -180,12 +162,6 @@
 	</test>
 	<test>
 		<testCaseName>ParallelStreamsLoadTest_CS</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -19,12 +19,6 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_all_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -41,12 +35,6 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_autosimd_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -63,12 +51,6 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_bigdecimal_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -85,12 +67,6 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_all_CS_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -110,12 +86,6 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_autosimd_CS_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>
@@ -135,12 +105,6 @@
 	</test>
 	<test>
 		<testCaseName>MathLoadTest_bigdecimal_CS_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -20,12 +20,6 @@
 	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse-openj9/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleThrdLoad_J9_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -79,12 +73,6 @@
 	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse-openj9/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleInvocLoad_J9_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -148,10 +136,6 @@
 				<version>8</version>
 				<impl>hotspot</impl>
 				<platform>.*windows.*</platform>
-			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
 			</disable>
 		</disables>
 		<variations>

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -709,12 +709,6 @@
 	</test>
 	<test>
 		<testCaseName>CLLoad</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -51,10 +51,6 @@
 				<impl>hotspot</impl>
 				<platform>.*windows.*</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -89,10 +85,6 @@
 				<version>8</version>
 				<impl>hotspot</impl>
 				<platform>.*windows.*</platform>
-			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
 			</disable>
 		</disables>
 		<variations>
@@ -133,10 +125,6 @@
 				<impl>hotspot</impl>
 				<platform>.*windows.*</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
 		</disables>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -debug-generation -java-debug-args=$(Q)-Xmx3g -Xms3g$(Q) -test-args=$(Q)timeLimit=5m$(Q) -java-args-execute-initial=$(Q)$(ADD_OPENS_CMD) -Xmx3g -Xms3g$(Q); \
 	$(SYSTEMTEST_CMD_TEMPLATE) -test=MixedLoadTest -test-args=$(Q)timeLimit=5m$(Q) -java-args-execute-initial=$(Q)$(ADD_OPENS_CMD) -Xmx2g -Xms2g$(Q); \
@@ -169,12 +157,6 @@
 	</test>
 	<test>
 		<testCaseName>ClassLoadingTest_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -251,10 +233,6 @@
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -273,12 +251,6 @@
 	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/571-->
 	<test>
 		<testCaseName>DBBLoadTest_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -296,12 +268,6 @@
 	</test>
 	<test>
 		<testCaseName>LangLoadTest_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -318,12 +284,6 @@
 	</test>
 	<test>
 		<testCaseName>LockingLoadTest</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -342,12 +302,6 @@
 	<!-- Temporarily excluded from z/Os due to : jdk11-zos/issues/342-->
 	<test>
 		<testCaseName>NioLoadTest_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -365,12 +319,6 @@
 	</test>
 	<test>
 		<testCaseName>UtilLoadTest_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>
@@ -463,12 +411,6 @@
 	</test>
 	<test>
 		<testCaseName>HeapHogLoadTest_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -488,12 +430,6 @@
 	</test>
 	<test>
 		<testCaseName>ObjectTreeLoadTest_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -514,12 +450,6 @@
 	<!-- The tests below are added to test concurrent scavenge on z/OS, z/Linux, x/Linux and x/Windows using 64-bit OpenJ9 SDK -->
 	<test>
 		<testCaseName>ClassLoadingTest_CS_5m</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:gencon -Xgc:concurrentScavenge</variation>
 		</variations>

--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -24,12 +24,6 @@
 	</test>
 	<test>
 		<testCaseName>SharedClassesAPI</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -50,12 +44,6 @@
 	</test>
 	<test>
 		<testCaseName>SharedClassesWorkload</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/adoptium/STF/issues/142</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>

--- a/system/system.mk
+++ b/system/system.mk
@@ -50,11 +50,7 @@ endif
 # In JDK 24+ any attempts to enable the security manager will result in an error.
 # In JDK18+, java.security.manager == null behaves as -Djava.security.manager=disallow.
 # In JDK17-, java.security.manager == null behaves as -Djava.security.manager=allow.
-# In case of system tests, the base infra (STF) which is used to launch tests utilizes
-# the security manager in net.adoptopenjdk.loadTest.LoadTest.overrideSecurityManager.
-# For system tests to work as expected, -Djava.security.manager=allow behaviour is
-# needed in JDK18-23.
-# Related: https://github.com/eclipse-openj9/openj9/issues/14412
+# This is needed for Mauve tests that use the SecurityManager.
 ifneq ($(filter 18 19 20 21 22 23, $(JDK_VERSION)),)
   export JAVA_TOOL_OPTIONS:=-Djava.security.manager=allow
   $(warning Environment variable JAVA_TOOL_OPTIONS is set to '$(JAVA_TOOL_OPTIONS)')


### PR DESCRIPTION
System load tests were disabled in https://github.com/adoptium/aqa-tests/pull/5817 due to the system test framework's reliance on the SecurityManager. Once https://github.com/adoptium/STF/pull/143 is merged this reliance will be removed and the tests pass.

Depends on: https://github.com/adoptium/STF/pull/143
Depends on: https://github.com/adoptium/aqa-systemtest/pull/494

sanity.system: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/47194/
extended.system: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/47195/