### PR TITLE
Change Kerberos test runner default to use TCP rather than UDP

### DIFF
--- a/jck/jtrunner/config/default/krb5.conf
+++ b/jck/jtrunner/config/default/krb5.conf
@@ -10,6 +10,7 @@
 # 3. The values in the copied file must be updated to reflect the server set up.
 # The tests default to using 'default' as the config name.  If another name is used it must be
 # supplied to the test at run time - see opemjdk.test.jck/docs/README.md for more details.
+# 4. Use TCP rather than UDP to avoid auth login problems: https://github.com/adoptium/aqa-tests/issues/5929
 #----------------------------------------------------------------------------------
 
 [libdefaults]

--- a/jck/jtrunner/config/default/krb5.conf
+++ b/jck/jtrunner/config/default/krb5.conf
@@ -14,6 +14,7 @@
 
 [libdefaults]
 	default_realm = ADOPTIUM_NET
+	udp_preference_limit = 1
 
 [realms]
 	ADOPTIUM_NET = {


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/5929

Update krb5.conf default test config to use TCP to avoid login issues.