### PR TITLE
Temporarily exclude some tests for OpenJ9 jdk24

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -130,6 +130,7 @@ java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://git
 java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issues/17638 windows-all
 java/lang/Thread/ThreadSleepEvent.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
+java/lang/Thread/virtual/CancelTimerWithContention.java https://github.com/eclipse-openj9/openj9/issues/21037 generic-all
 java/lang/Thread/virtual/JfrEvents.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
 java/lang/Thread/virtual/MiscMonitorTests.java#default https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
 java/lang/Thread/virtual/MiscMonitorTests.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
@@ -149,6 +150,7 @@ java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LEGACY https://github.co
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/20369 generic-all
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/20955 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
+java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21036 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x
 java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#default https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
 java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/20705 generic-all


### PR DESCRIPTION
java/lang/Thread/virtual/CancelTimerWithContention.java
java/lang/Thread/virtual/Starvation.java

Issues:
https://github.com/eclipse-openj9/openj9/issues/21036
https://github.com/eclipse-openj9/openj9/issues/21037