### PR TITLE
Temporarily exclude OpenJDK RedefineVerifyError.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -521,4 +521,5 @@ serviceability/sa/ClhsdbWhere.java https://github.com/adoptium/aqa-tests/issues/
 serviceability/sa/TestJhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/TestClhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/jvmti/RedefineClasses/RedefineSharedClass.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/jvmti/RedefineClasses/RedefineVerifyError.java https://github.com/eclipse-openj9/openj9/issues/20708 generic-all
 


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/issues/20708