### PR TITLE
Forward port DeflateIn_InflateOut.java exclude for OpenJ9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -469,6 +469,7 @@ java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java http
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java https://github.com/eclipse-openj9/openj9/issues/3447 generic-all
 java/util/WeakHashMap/GCDuringIteration.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/util/zip/CloseInflaterDeflaterTest.java	https://github.com/eclipse-openj9/openj9/issues/14948	linux-s390x
+java/util/zip/DeflateIn_InflateOut.java https://github.com/eclipse-openj9/openj9/issues/14948 linux-s390x
 java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/8872  generic-all
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -500,6 +500,7 @@ java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java http
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java https://github.com/eclipse-openj9/openj9/issues/3447 generic-all
 java/util/WeakHashMap/GCDuringIteration.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/util/zip/CloseInflaterDeflaterTest.java	https://github.com/eclipse-openj9/openj9/issues/14948	linux-s390x
+java/util/zip/DeflateIn_InflateOut.java https://github.com/eclipse-openj9/openj9/issues/14948 linux-s390x
 java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/8872  generic-all
 java/util/zip/ZipFile/ZipSourceCache.java https://github.com/eclipse-openj9/openj9/issues/18987 linux-s390x
 

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -476,6 +476,7 @@ java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java http
 java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java https://github.com/eclipse-openj9/openj9/issues/3447 generic-all
 java/util/WeakHashMap/GCDuringIteration.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/util/zip/CloseInflaterDeflaterTest.java	https://github.com/eclipse-openj9/openj9/issues/14948	linux-s390x
+java/util/zip/DeflateIn_InflateOut.java https://github.com/eclipse-openj9/openj9/issues/14948 linux-s390x
 java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/8872  generic-all
 java/util/zip/ZipFile/ZipSourceCache.java https://github.com/eclipse-openj9/openj9/issues/18987 linux-s390x
 


### PR DESCRIPTION
It's already excluded jdk8 - 17, and a failure is seen on jdk24.

Issue https://github.com/eclipse-openj9/openj9/issues/14948