### PR TITLE
Skip CONFIG_JSON in rerun Grinder link

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1201,7 +1201,7 @@ def addGrinderLink() {
 	def customTargetKeyValue = ""
 	def urlParams = params.findAll {
 		// Exclude separator and help text parameters from url
-		!(it.key.endsWith('_PARAMS') || it.key.endsWith('_HELP_TEXT'))
+		!(it.key.endsWith('_PARAMS') || it.key.endsWith('_HELP_TEXT') || it.key == "CONFIG_JSON")
 	}
 	urlParams.each { key, value ->
 		value = URLEncoder.encode(value.toString(), "UTF-8")


### PR DESCRIPTION
- Remove the CONFIG_JSON from the rerun Grinder link to avoid unnecessary data in the URL

related:runtimes/backlog#1600