### PR TITLE
Clean up Excludes Test List jdk17 and jdk11- 1st pass

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -35,8 +35,6 @@ java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/ec
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-openj9/openj9/issues/3178	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
-java/lang/ProcessBuilder/Basic.java#id0		https://github.com/eclipse-openj9/openj9/issues/9032	linux-aarch64,aix-all,linux-ppc64le
-java/lang/ProcessBuilder/Basic.java#id1		https://github.com/eclipse-openj9/openj9/issues/9032	linux-aarch64,linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
@@ -61,10 +59,6 @@ java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java	ht
 java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/LoggerFinder/internal/backend/LoggerFinderBackendTest.java	https://github.com/eclipse-openj9/openj9/issues/6675	generic-all
 java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/Thread/UncaughtExceptions.sh	https://github.com/eclipse-openj9/openj9/issues/6690	generic-all
 java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse-openj9/openj9/issues/6691	generic-all
 java/lang/Throwable/SuppressedExceptions.java	https://github.com/eclipse-openj9/openj9/issues/6692	generic-all
@@ -112,7 +106,6 @@ java/lang/reflect/Proxy/ProxyForMethodHandle.java	https://github.com/eclipse-ope
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 
 ############################################################################
@@ -199,8 +192,6 @@ java/net/HttpURLConnection/HttpURLConWithProxy.java  https://github.com/eclipse-
 # java/net/ipv6tests/B6521014.java on macosx-all issue	https://github.com/adoptium/aqa-tests/issues/1524
 # java/net/ipv6tests/B6521014.java on macosx-all issue https://github.com/adoptium/infrastructure/issues/1085
 java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issues/1105 linux-all,macosx-all
-java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
-java/net/ipv6tests/UdpTest.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all,macosx-all
 com/sun/net/httpserver/bugs/B6361557.java	https://github.com/adoptium/aqa-tests/issues/1272	windows-all
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -78,10 +78,6 @@ java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java	ht
 java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/LoggerFinder/internal/backend/LoggerFinderBackendTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
 java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java	https://github.com/eclipse-openj9/openj9/issues/6674	generic-all
-java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/Thread/UncaughtExceptions.sh	https://github.com/eclipse-openj9/openj9/issues/6690	generic-all
 java/lang/ThreadGroup/SetMaxPriority.java	https://github.com/eclipse-openj9/openj9/issues/6691	generic-all
 java/lang/Throwable/SuppressedExceptions.java	https://github.com/eclipse-openj9/openj9/issues/6692	generic-all
@@ -124,7 +120,6 @@ java/lang/reflect/Nestmates/TestReflectionAPI.java	https://github.com/adoptium/a
 java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/7775	generic-all
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
@@ -196,12 +191,10 @@ java/net/DatagramSocket/DatagramSocketExample.java https://github.ibm.com/runtim
 java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
 java/net/DatagramSocket/SendReceiveMaxSize.java https://github.ibm.com/runtimes/backlog/issues/684 aix-all
 java/net/Inet4Address/PingThis.java	https://github.com/adoptium/infrastructure/issues/1127	aix-all
-java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
-java/net/ipv6tests/UdpTest.java	https://github.com/adoptium/aqa-tests/issues/827	linux-all,macosx-all
 java/net/MulticastSocket/B6427403.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all,aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
 java/net/MulticastSocket/NoSetNetworkInterface.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
-java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all,aix-all
+java/net/MulticastSocket/Promiscuous.java https://github.ibm.com/runtimes/backlog/issues/1598 linux-s390x,aix-all
 java/net/MulticastSocket/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.ibm.com/runtimes/backlog/issues/707 linux-s390x,macosx-all


### PR DESCRIPTION
Clean up Excludes Test List jdk17 and jdk11- 1st pass
related : Clean up ProblemList_openjdkXXX-openj9.txt for openj9 #5860
Signed-off-by: Denny Chacko Jacob denny.cjacob@ibm.com