### PR TITLE
Clean up Excludes Test List jdk24- 1st pass

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -74,8 +74,6 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all
-java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
-java/lang/ProcessBuilder/Basic.java https://github.com/eclipse-openj9/openj9/issues/10921 linux-ppc64le
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/ProcessHandle/InfoTest.java https://github.com/eclipse-openj9/openj9/issues/19757 aix-ppc64
@@ -123,10 +121,6 @@ java/lang/System/LoggerFinder/internal/BaseLoggerBridgeTest/BaseLoggerBridgeTest
 java/lang/System/LoggerFinder/internal/LoggerBridgeTest/LoggerBridgeTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
 java/lang/System/LoggerFinder/internal/LoggerFinderLoaderTest/LoggerFinderLoaderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
 java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
-java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
-java/lang/System/LoggerFinder/modules/LoggerInImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
-java/lang/System/LoggerFinder/modules/NamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
-java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issues/17638 windows-all
 java/lang/Thread/ThreadSleepEvent.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
@@ -168,7 +162,6 @@ jdk/internal/vm/Continuation/Fuzz.java https://github.com/eclipse-openj9/openj9/
 jdk/internal/vm/Continuation/LiveFramesDriver.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 jdk/internal/vm/Continuation/OSRTest.java https://github.com/eclipse-openj9/openj9/issues/19357 generic-all
 jdk/internal/vm/Continuation/Scoped.java https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
-jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issues/15370 linux-ppc64le,macosx-all
 java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/17399 generic-all
 
@@ -251,12 +244,10 @@ java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/i
 java/net/InetAddress/HostsFileOrderingTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
 java/net/InetAddress/InternalNameServiceTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
 java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-all
-java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
-java/net/ipv6tests/UdpTest.java https://github.com/adoptium/aqa-tests/issues/827 linux-all,macosx-all
 java/net/MulticastSocket/B6427403.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all,aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
 java/net/MulticastSocket/NoSetNetworkInterface.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all
-java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all,aix-all
+java/net/MulticastSocket/Promiscuous.java https://github.ibm.com/runtimes/backlog/issues/1598 linux-s390x,aix-all
 java/net/MulticastSocket/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.ibm.com/runtimes/backlog/issues/707 linux-s390x,macosx-all


### PR DESCRIPTION
Clean up Excludes Test List jdk24- 1st pass
related : Clean up ProblemList_openjdkXXX-openj9.txt for openj9 #5860
Signed-off-by: Denny Chacko Jacob denny.cjacob@ibm.com