### PR TITLE
[JDK24] Re-enable ProtectionDomainRace

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -41,7 +41,6 @@ java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java https://gi
 java/lang/annotation/loaderLeak/Main.java https://github.com/eclipse-openj9/openj9/issues/6701 generic-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
 java/lang/Class/GetModuleTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
-java/lang/Class/ProtectionDomainRace.java https://github.com/eclipse-openj9/openj9/issues/20351 generic-all
 java/lang/ClassLoader/Assert.java https://github.com/eclipse-openj9/openj9/issues/6668 macosx-x64
 java/lang/ClassLoader/EndorsedDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all
 java/lang/ClassLoader/ExtDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all


### PR DESCRIPTION
ProtectionDomainRace has been fixed by https://github.com/eclipse-openj9/openj9/pull/21077.