### PR TITLE
Fix for CUSTOMIZED_SDK_URL path issue

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -212,6 +212,9 @@ getBinaryOpenjdk()
 	fi
 
 	if [ "$SDK_RESOURCE" == "nightly" ] && [ "$CUSTOMIZED_SDK_URL" != "" ]; then
+		if [[ ! "${CUSTOMIZED_SDK_URL}" =~ /$ ]]; then
+    			CUSTOMIZED_SDK_URL="${CUSTOMIZED_SDK_URL}/"
+		fi
 		result=$(curl -k ${curl_options} ${CUSTOMIZED_SDK_URL} | grep ">[0-9]*\/<" | sed -e 's/[^0-9/ ]//g' | sed 's/\/.*$//')
 		IFS=' ' read -r -a array <<< "$result"
 		arr=(${result/ / })


### PR DESCRIPTION
This update is a fix for CUSTOMIZED_SDK_URL path . The script adds "/" at the end if it is missing 
Fixes: #5947 
Signed-off-by: Denny Chacko Jacob denny.cjacob@ibm.com
