### PR TITLE
Exclude Test5102804 and Test6397609 for AIX jdk8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -19,8 +19,8 @@
 # jdk_beans
 
 java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
-java/beans/Introspector/Test5102804.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all,linux-all
-java/beans/PropertyEditor/Test6397609.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all,linux-all
+java/beans/Introspector/Test5102804.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all,linux-all,aix-all
+java/beans/PropertyEditor/Test6397609.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all,linux-all,aix-all
 java/beans/XMLEncoder/Test6570354.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
 java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all
 java/beans/PropertyEditor/TestColorClass.java https://github.com/eclipse-openj9/openj9/issues/20531 macosx-all


### PR DESCRIPTION
- Exclude jdk_beans subtests: `Test5102804` & `Test6397609` for AIX jdk8

related: eclipse-openj9/openj9#20531