### PR TITLE
Exclude TypoInBeanDescription.java on AIX JDK11

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -22,6 +22,8 @@
 
 # jdk_beans
 
+java/beans/Beans/TypoInBeanDescription.java https://github.ibm.com/runtimes/backlog/issues/1589 aix-all
+
 ############################################################################
 
 # jdk_lang


### PR DESCRIPTION
- Exclude `java/beans/Beans/TypoInBeanDescription.java` on AIX JDK11

related: eclipse-openj9/openj9#20531, runtimes/backlog#1589