### PR TITLE
For OpenJ9 exclude security2 from sanity on AIX and run it in extended

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1297,6 +1297,11 @@
 		<testCaseName>jdk_security2</testCaseName>
 		<disables>
 			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/19962</comment>
+				<impl>openj9</impl>
+				<platform>.*aix.*</platform>
+			</disable>
+			<disable>
 				<comment>https://github.ibm.com/runtimes/backlog/issues/1089</comment>
 				<impl>openj9</impl>
 				<testflag>fips140_2</testflag>
@@ -1325,6 +1330,43 @@
 		<groups>
 			<group>openjdk</group>
 		</groups>
+	</test>
+	<test>
+		<testCaseName>jdk_security2_extended</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.ibm.com/runtimes/backlog/issues/1089</comment>
+				<impl>openj9</impl>
+				<testflag>fips140_2</testflag>
+			</disable>
+		</disables>
+		<variations>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(TIMEOUT_HANDLER) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_JDK_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(JTREG_JDK_TEST_DIR):jdk_security2$(Q); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<platformRequirements>os.aix</platformRequirements>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
 	</test>
 	<test>
 		<testCaseName>jdk_security3</testCaseName>


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/19962