### PR TITLE
Problemlist Symantec.java in jdk17u and jdk21u

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -185,6 +185,7 @@ java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests
 ############################################################################
 
 # jdk_security
+sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/5955 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -231,6 +231,7 @@ java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adopti
 # jdk_security
 
 sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aqa-tests/issues/3811 windows-x86
+sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/5955 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Problemlist sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java in jdk17u and jdk21u, before the related [bug](https://github.com/adoptium/aqa-tests/issues/5955) has been fixed.

Fixes: #5956