### PR TITLE
Enable jdk_beans on all AIX

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -795,7 +795,7 @@
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/20531</comment>
 				<impl>openj9</impl>
-				<platform>^(?!.*linux).*$</platform>
+				<platform>^(?!.*linux|ppc64_aix).*$</platform>
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>


### PR DESCRIPTION
- Enable jdk_beans on aix for all java versions

related: eclipse-openj9/openj9#20531