### PR TITLE
Exclude subtest TestClock_System in jdk_time for j9 jdk11+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -326,6 +326,7 @@ sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java	https://gith
 ############################################################################
 
 # jdk_time
+java/time/test/java/time/TestClock_System.java https://github.com/eclipse-openj9/openj9/issues/20610 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -378,6 +378,7 @@ sun/security/krb5/auto/NoAddresses.java https://github.com/adoptium/aqa-tests/is
 ############################################################################
 
 # jdk_time
+java/time/test/java/time/TestClock_System.java https://github.com/eclipse-openj9/openj9/issues/20610 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -437,6 +437,7 @@ sun/security/krb5/auto/NoAddresses.java https://github.com/adoptium/aqa-tests/is
 ############################################################################
 
 # jdk_time
+java/time/test/java/time/TestClock_System.java https://github.com/eclipse-openj9/openj9/issues/20610 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -446,6 +446,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/eclipse-openj9/openj9/is
 ############################################################################
 
 # jdk_time
+java/time/test/java/time/TestClock_System.java https://github.com/eclipse-openj9/openj9/issues/20610 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -458,6 +458,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/eclipse-openj9/openj9/is
 ############################################################################
 
 # jdk_time
+java/time/test/java/time/TestClock_System.java https://github.com/eclipse-openj9/openj9/issues/20610 generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -435,6 +435,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/eclipse-openj9/openj9/is
 ############################################################################
 
 # jdk_time
+java/time/test/java/time/TestClock_System.java https://github.com/eclipse-openj9/openj9/issues/20610 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Exclude subtest TestClock_System in jdk_time for j9 jdk11+

Issue: https://github.com/eclipse-openj9/openj9/issues/20610