### PR TITLE
Enable jdk_time for j9 on xlinux

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1621,6 +1621,7 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
+				<platform>^((?!(x86-64_linux)).)*$</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>


### PR DESCRIPTION
Enable jdk_time for j9 on xlinux

Closes https://github.com/adoptium/aqa-tests/issues/5962