### PR TITLE
Enable jdk_beans on aarch64_mac for JDK17+

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -795,7 +795,13 @@
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/20531</comment>
 				<impl>openj9</impl>
-				<platform>^(?!.*linux).*$</platform>
+				<platform>^(?!.*linux|aarch64_mac).*$</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/20531</comment>
+				<impl>openj9</impl>
+				<platform>aarch64_mac.*</platform>
+				<version>[8, 11]</version>
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>


### PR DESCRIPTION
- Enable jdk_beans on aarch64_mac for JDK17+

related: https://github.com/eclipse-openj9/openj9/issues/20531