### PR TITLE
Enable java/security/Security/ConfigFileTest JDK24

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -389,7 +389,6 @@ java/rmi/server/Unreferenced/leaseCheckInterval/LeaseCheckInterval.java https://
 java/security/KeyPairGenerator/FinalizeHalf.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/SecureRandom/ApiTest.java https://github.com/eclipse-openj9/openj9/issues/16734 windows-all
 java/security/SecureRandom/EnoughSeedTest.java https://github.com/eclipse-openj9/openj9/issues/16734 windows-all
-java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/openj9/issues/20357 generic-all
 java/security/Signature/ResetAfterException.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 


### PR DESCRIPTION
Depends on: https://github.com/eclipse-openj9/openj9/pull/21170

Fixes: https://github.com/eclipse-openj9/openj9/issues/20357