### PR TITLE
openjdk: add jdk tier1 cipher tests

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2636,6 +2636,35 @@
 		</features>
 	</test>
 	<test>
+		<testCaseName>jdk11_tier1_cipher</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(TIMEOUT_HANDLER) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_JDK_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(JTREG_JDK_TEST_DIR)/com/sun/crypto/provider/Cipher$(Q); \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+		</features>
+	</test>
+	<test>
 		<testCaseName>jdk_vector</testCaseName>
 		<disables>
 			<disable>


### PR DESCRIPTION
This adds tier1 cipher tests [present in jdk11+](https://github.com/openjdk/jdk11u-dev/blob/659a4669208645420e151e78ab5fd3ac3808b310/test/jdk/TEST.groups#L55). Similar targets already exists for buffer, iso8859 and pack200 tests. Goal is, that sanity level includes all tests from tier1.

**Testing:**
jdk11:
linux-x86_64-jdk11: [OK](https://ci.adoptium.net/job/Grinder/12696/)
linux-x86_64-jdk11-openj9: [OK](https://ci.adoptium.net/job/Grinder/12698/)
linux-arm-jdk11: [OK](https://ci.adoptium.net/job/Grinder/12702/)
linux-s390x-jdk11: [OK](https://ci.adoptium.net/job/Grinder/12710/)
mac-x86_64-jdk11: [OK](https://ci.adoptium.net/job/Grinder/12703/)
aix-ppc64-jdk11: [OK](https://ci.adoptium.net/job/Grinder/12704/)
jdk17:
linux-aarch64-jdk17: [OK](https://ci.adoptium.net/job/Grinder/12708/)
jdk21:
linux-aarch64-jdk21: [OK](https://ci.adoptium.net/job/Grinder/12709/)
