### PR TITLE
Replaced deprecated wmic with powershell command to get TotalPhysicalMemory

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -62,10 +62,7 @@ ifeq ($(OS),FreeBSD)
 endif
 ifeq ($(CYGWIN),1)
  	NPROCS:=$(NUMBER_OF_PROCESSORS)
-	MEMORY_SIZE:=$(shell \
-		expr `wmic computersystem get totalphysicalmemory -value | grep = \
-		| cut -d "=" -f 2-` / 1024 / 1024 \
-		)
+	MEMORY_SIZE:=$(shell powershell -command "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1024 / 1024")
 endif
 ifeq ($(OS),SunOS)	
 	NPROCS:=$(shell psrinfo | wc -l)


### PR DESCRIPTION
WMIC is deprecated in windows 2025,causing issues in retrieving TotalPhysicalMemory.This update switches to PowerShell-based commands for future support

Related : runtimes/automation/issues/241