### PR TITLE
OpenJ9 excludes jvmti/RedefineClasses/RedefineVerifyError.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -599,6 +599,7 @@ serviceability/jvmti/thread/GetStackTrace/getstacktr03/getstacktr03.java https:/
 serviceability/jvmti/thread/GetStackTrace/getstacktr05/getstacktr05.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/VThreadNotifyFramePopTest/VThreadNotifyFramePopTest.java https://github.com/adoptium/aqa-tests/issues/1297 aix-all
 serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+serviceability/jvmti/RedefineClasses/RedefineVerifyError.java https://github.com/eclipse-openj9/openj9/issues/20708 generic-all
 serviceability/jvmti/vthread/ToggleNotifyJvmtiTest/ToggleNotifyJvmtiTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#default https://github.com/eclipse-openj9/openj9/issues/18811 generic-all
 serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/18811 generic-all

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -523,5 +523,3 @@ serviceability/sa/ClhsdbWhere.java https://github.com/adoptium/aqa-tests/issues/
 serviceability/sa/TestJhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/TestClhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/jvmti/RedefineClasses/RedefineSharedClass.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
-serviceability/jvmti/RedefineClasses/RedefineVerifyError.java https://github.com/eclipse-openj9/openj9/issues/20708 generic-all
-


### PR DESCRIPTION
OpenJ9 excludes `jvmti/RedefineClasses/RedefineVerifyError.java`

Restored `ProblemList_openjdk24.txt` for non-OpenJ9 version.

Related to
* https://github.com/adoptium/aqa-tests/pull/5936

Signed-off-by: Jason Feng <fengj@ca.ibm.com>