### PR TITLE
[JDK24+] Exclude TestMappedHandshake

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -546,6 +546,8 @@ java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
 
+java/foreign/TestMappedHandshake.java https://github.com/eclipse-openj9/openj9/issues/20527 generic-all
+
 ############################################################################
 
 # serviceability

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -522,6 +522,8 @@ java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues
 java/foreign/TestStubAllocFailure.java https://github.com/eclipse-openj9/openj9/issues/18938 generic-all
 java/foreign/TestHFA.java https://github.com/eclipse-openj9/openj9/issues/18944 linux-ppc64le
 
+java/foreign/TestMappedHandshake.java https://github.com/eclipse-openj9/openj9/issues/20527 generic-all
+
 ############################################################################
 
 # serviceability


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/issues/20527