### PR TITLE
OpenJ9 excludes javax/management/security/HashedPasswordFileTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -216,6 +216,8 @@ sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/ado
 
 # jdk_jmx
 
+javax/management/security/HashedPasswordFileTest.java https://github.com/eclipse-openj9/openj9/issues/21138 generic-all
+
 ############################################################################
 
 # jdk_math

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -194,6 +194,8 @@ sun/management/jmxremote/startstop/JMXStatusTest.java     https://github.com/ado
 
 # jdk_jmx
 
+javax/management/security/HashedPasswordFileTest.java https://github.com/eclipse-openj9/openj9/issues/21138 generic-all
+
 ############################################################################
 
 # jdk_math


### PR DESCRIPTION
OpenJ9 excludes `javax/management/security/HashedPasswordFileTest.java`

Related to
* https://github.com/eclipse-openj9/openj9/issues/21138

Signed-off-by: Jason Feng <fengj@ca.ibm.com>