### PR TITLE
OpenJ9 AArch64 Linux: Disable balanced GC modes

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -172,6 +172,43 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa1_special_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode501</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode551</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode553</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode554</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode555</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode556</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode557</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -220,6 +257,43 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_daa2_special_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode501</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode551</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode553</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode554</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode555</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode556</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode557</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>
@@ -316,6 +390,43 @@
 	</test>
 	<test>
 		<testCaseName>DaaLoadTest_all_special_5m</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode501</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode551</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode553</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode554</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode555</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode556</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21178</comment>
+				<variation>Mode557</variation>
+				<platform>aarch64_linux.*</platform>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode103</variation>


### PR DESCRIPTION
This is a temporary workaround for https://github.com/eclipse-openj9/openj9/issues/21178 . It disables balanced GC modes for some tests for OpenJ9 on AArch64 Linux.