### PR TITLE
Exclude MBCS_Tests_unicode_linux on alinux

### DIFF
--- a/functional/MBCS_Tests/unicode/playlist.xml
+++ b/functional/MBCS_Tests/unicode/playlist.xml
@@ -15,6 +15,13 @@ limitations under the License.
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/resources/playlist.xsd">
 	<test>
 		<testCaseName>MBCS_Tests_unicode_linux</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21187</comment>
+				<platform>aarch64_linux.*</platform>
+				<version>24</version>
+			</disable>
+		</disables>   
 		<command>$(RUN_SCRIPT) $(TEST_RESROOT)$(D)test.sh; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.linux</platformRequirements>


### PR DESCRIPTION
- Exclude MBCS_Tests_unicode_linux on alinux

related:https://github.com/eclipse-openj9/openj9/issues/21187