### PR TITLE
Exclude MBCS_Tests for JDK24

### DIFF
--- a/functional/MBCS_Tests/codepoint/playlist.xml
+++ b/functional/MBCS_Tests/codepoint/playlist.xml
@@ -15,6 +15,12 @@ limitations under the License.
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/resources/playlist.xsd">
 	<test>
 		<testCaseName>MBCS_Tests_codepoint_linux</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.ibm.com/runtimes/backlog/issues/1610</comment>
+				<version>24</version>
+			</disable>
+		</disables>
 		<command>bash $(TEST_RESROOT)$(D)test.sh; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.linux</platformRequirements>

--- a/functional/MBCS_Tests/locale_matching/playlist.xml
+++ b/functional/MBCS_Tests/locale_matching/playlist.xml
@@ -46,6 +46,12 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_locale_matching_zh_CN_linux</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.ibm.com/runtimes/backlog/issues/1610</comment>
+				<version>24</version>
+			</disable>
+		</disables>
 		<command>LANG=zh_CN.UTF-8 perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.linux</platformRequirements>


### PR DESCRIPTION
- Temporarily exclude `MBCS_Tests_codepoint_linux` and `MBCS_Tests_locale_matching_zh_CN_linux` for JDK24 on all platforms

related:https://github.ibm.com/runtimes/backlog/issues/1610