### PR TITLE
De-problemlist ExtractFilesTest.java and MultipleManifestTest.java in jdk8u

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -269,8 +269,6 @@ sun/security/pkcs11/Secmod/TestNssDbSqlite.java https://github.com/adoptium/aqa-
 sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/adoptium/aqa-tests/issues/2123 generic-all
 sun/security/tools/jarsigner/diffend.sh https://github.com/adoptium/infrastructure/issues/2623 linux-all
 sun/security/tools/jarsigner/emptymanifest.sh https://github.com/adoptium/infrastructure/issues/2623 linux-all
-tools/jar/ExtractFilesTest.java https://bugs.openjdk.org/browse/JDK-8346140 generic-all
-tools/jar/MultipleManifestTest.java https://bugs.openjdk.org/browse/JDK-8346140 generic-all
 sun/security/rsa/SignatureTest.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 sun/security/tools/keytool/WeakAlg.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 sun/security/tools/keytool/standard.sh https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9


### PR DESCRIPTION
De-problemlist tools/jar/ExtractFilesTest.java and tools/jar/MultipleManifestTest.java in jdk8u since the upstream test-fix openjdk/jdk8u-dev#612 has been integrated.

Fixes: #5995