### PR TITLE
Ensure jtrunner headless platforms run headless regardless of DISPLAY

### DIFF
--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -543,6 +543,8 @@ public class JavatestUtil {
 			if ( testsRequireDisplay(tests) ) {
 				if (spec.contains("zos") || spec.contains("alpine-linux") || spec.contains("riscv")) {
 					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
+                                        // Ensure JVM graphical device and system are headless, regardless of environment DISPLAY
+                                        jvmOpts +=  "-Djava.awt.headless=true ";
 				}
 				else {
 					if ( !spec.contains("win") ) {


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1195
for headless alpine, riscv

Update jtrunner so for headless platforms as well as setting jck headless property it also ensures
the JVM graphical device & system is headless with -Djava.awt.headless=true
Default JVM behavior will not fully be headless if the test environment has DISPLAY set.

TC Test job: Test_openjdk21_hs_extended.jck_x86-64_alpine-linux/64 - ?