### PR TITLE
(v1.0.6) Run OpenJCEPlus tests without FIPS properties

### DIFF
--- a/functional/OpenJcePlusTests/build.xml
+++ b/functional/OpenJcePlusTests/build.xml
@@ -123,7 +123,6 @@
 	<target name="build">
 		<if>
 			<and>
-				<contains string="${TEST_FLAG}" substring="FIPS140_3_OpenJCEPlusFIPS"/>
 				<equals arg1="${JDK_VENDOR}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 				<not>

--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -43,8 +43,8 @@
 		cp -r ${REPORTDIR}/target/surefire-reports/* junitreports
 		</command>
 		<features>
-			<feature>FIPS140_3_OpenJCEPlusFIPS:required</feature>
-			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:required</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
 		</features>
 		<levels>
 			<level>extended</level>


### PR DESCRIPTION
Cherry-pick of https://github.com/adoptium/aqa-tests/pull/6010
The mvn based OpenJCEPlus tests are not intended to be run in FIPS mode this update runs these tests whenever FIPS flags are not present.

It should be noted that these tests are still expected to run and test from a functional perspective both FIPS and non FIPS related tests.
