### PR TITLE
Automate java_awt interactive robot tests

### DIFF
--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -51,6 +51,7 @@ public class JavatestUtil {
 	private static String testExecutionType;
 	private static String withAgent;
 	private static String interactive;
+        private static String robot;
 	private static String extraJvmOptions = "";
 	private static String concurrencyString;
         private static String timeoutFactorString;
@@ -113,6 +114,7 @@ public class JavatestUtil {
 	private static final String TEST_EXECUTION_TYPE = "testExecutionType";
 	private static final String WITH_AGENT = "withAgent";
 	private static final String INTERACTIVE = "interactive";
+        private static final String ROBOT = "robot";
 	private static final String CONFIG = "config";
 	private static final String CONCURRENCY = "concurrency";
         private static final String TIMEOUT_FACTOR = "timeoutFactor";
@@ -211,6 +213,7 @@ public class JavatestUtil {
 		testExecutionType = testArgs.get(TEST_EXECUTION_TYPE) == null ? "default" : testArgs.get(TEST_EXECUTION_TYPE);
 		withAgent = testArgs.get(WITH_AGENT) == null ? "off" : testArgs.get(WITH_AGENT);
 		interactive = testArgs.get(INTERACTIVE) == null ? "no" : testArgs.get(INTERACTIVE);
+                robot = testArgs.get(ROBOT) == null ? "no" : testArgs.get(ROBOT);
 		concurrencyString = testArgs.get("concurrency") == null ? "NULL" : testArgs.get("concurrency");
                 timeoutFactorString = testArgs.get(TIMEOUT_FACTOR) == null ? "NULL" : testArgs.get(TIMEOUT_FACTOR);
 		config = testArgs.get(CONFIG) == null ? "NULL" : testArgs.get(CONFIG);
@@ -515,7 +518,11 @@ public class JavatestUtil {
 			}
 			
 			if ( tests.contains("api/java_awt") || tests.contains("api/javax_swing") || tests.equals("api") ) {
-				keyword += "&!robot";
+				if ( robot.equals("yes") ) {
+					keyword += "&robot";
+				} else {
+					keyword += "&!robot";
+				}
 			}
 			
 			fileContent += "concurrency " + concurrencyString + ";\n";
@@ -543,6 +550,8 @@ public class JavatestUtil {
 			if ( testsRequireDisplay(tests) ) {
 				if (spec.contains("zos") || spec.contains("alpine-linux") || spec.contains("riscv")) {
 					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
+                                        // Ensure JVM graphical device and system are headless, regardless of environment DISPLAY
+                                        jvmOpts +=  "-Djava.awt.headless=true ";
 				}
 				else {
 					if ( !spec.contains("win") ) {

--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -140,6 +140,7 @@ public class JavatestUtil {
 		essentialParameters.add(TEST_EXECUTION_TYPE);
 		essentialParameters.add(WITH_AGENT);
 		essentialParameters.add(INTERACTIVE);
+		essentialParameters.add(ROBOT);
 		essentialParameters.add(CONFIG);
 		essentialParameters.add(CONCURRENCY);
                 essentialParameters.add(TIMEOUT_FACTOR);

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -503,6 +503,33 @@
 			<group>jck</group>
 		</groups>
 	</test>
+        <test>  
+                <testCaseName>jck-runtime-api-java_awt-robot</testCaseName>
+                <disables>
+                        <disable>
+                                <comment>backlog/issues/608 : To be run manually</comment>
+                                <impl>ibm</impl>
+                        </disable>
+                        <disable>
+                                <comment>backlog/issues/608 : To be run manually</comment>
+                                <impl>openj9</impl>
+                        </disable>
+                </disables>
+                <variations>
+                        <variation>NoOptions</variation>
+                </variations>
+                <command>$(GEN_JTB_GENERIC) tests=api/java_awt testsuite=RUNTIME interactive=yes robot=yes; \
+                $(EXEC_RUNTIME_TEST); \
+                $(TEST_STATUS); \
+                $(GEN_SUMMARY_GENERIC) tests=api/java_awt testsuite=RUNTIME interactive=yes robot=yes
+                </command>
+                <levels>        
+                        <level>extended</level>
+                </levels>
+                <groups>
+                        <group>jck</group>
+                </groups>
+        </test> 
 	<test>
 		<testCaseName>jck-runtime-api-java_beans</testCaseName>
 		<disables>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -514,6 +514,11 @@
                                 <comment>backlog/issues/608 : To be run manually</comment>
                                 <impl>openj9</impl>
                         </disable>
+                        <disable>
+                                <comment>Disabled on aix and windows as no xvfb capable of robot interaction</comment>
+                                <platform>ppc64_aix|x86-64_windows|x86-32_windows|aarch64_windows</platform>
+                                <impl>hotspot</impl>
+                        </disable>
                 </disables>
                 <variations>
                         <variation>NoOptions</variation>


### PR DESCRIPTION
jck java_awt interactive robot tests can be run on most platforms via Jenkins, as long as a virtual display is available:
Platforms with **NO virtual display** capable of interactive robot tests:
- Windows
- AIX

Platforms tested with new jck-runtime-api-java_awt-robot group, on jck17:
- x64 Linux : SUCCESS
- x64 Mac : SUCCESS
- aarch64 Linux : SUCCESS
- aarch64 Mac : SUCCESS
- ppc64le Linux : SUCCESS
- s390x Linux : SUCCESS
- x64 Alpine Linux : SUCCESS (Skipped as headless)
- aarch64 Alpine Linux (jck21) : SUCCESS (Skipped as headless)
- riscv64 Linux : SUCCESS (Skipped as headless)
- arm32 Linux : SUCCESS
- 