### PR TITLE
Enable the disable tests Linter for subdirectories

### DIFF
--- a/.github/workflows/disabledTestsLinter.yml
+++ b/.github/workflows/disabledTestsLinter.yml
@@ -2,7 +2,7 @@ name: 'Disabled Tests Linter'
 on:
   pull_request:
     paths:
-    - 'openjdk/excludes/*'
+    - 'openjdk/excludes/**'
     - '**/playlist.xml'
 
 jobs:


### PR DESCRIPTION
Fix #6022 