### PR TITLE
<V1.0.6 release> Exclude tests related with https://bugs.openjdk.org/browse/JDK-8347124

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -329,6 +329,23 @@ tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/inf
 tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/launcher/JliLaunchTest.java https://github.com/adoptium/aqa-tests/issues/5010 aix-all
+tools/jpackage/linux/LinuxWeirdOutputDirTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/AddLauncherTest.java#id1 https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/AppLauncherEnvTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/AppVersionTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/ArgumentsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/BasicTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/DotInNameTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/EmptyFolderTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/InOutPathTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/JLinkOptionsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/JavaOptionsEqualsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/JavaOptionsEqualsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/JavaOptionsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/MainClassTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/MultipleJarAppTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/RuntimeImageSymbolicLinksTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/launcher/SourceMode.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 ############################################################################
 
 # jdk_jdi


### PR DESCRIPTION
Exclude tests related with https://bugs.openjdk.org/browse/JDK-8347124

Manually pick up #6021, which includes changes conflict.