### PR TITLE
[v1.0.6-release] Problem correct jdk_tool testcase IDs

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -336,11 +336,11 @@ tools/jpackage/share/AppVersionTest.java https://bugs.openjdk.org/browse/JDK-834
 tools/jpackage/share/ArgumentsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/BasicTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/DotInNameTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
-tools/jpackage/share/EmptyFolderTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/EmptyFolderTest.java#id1 https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/InOutPathTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/JLinkOptionsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
-tools/jpackage/share/JavaOptionsEqualsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
-tools/jpackage/share/JavaOptionsEqualsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/JavaOptionsEqualsTest.java#id0 https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/JavaOptionsEqualsTest.java#id1 https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/JavaOptionsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/MainClassTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/MultipleJarAppTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all


### PR DESCRIPTION
Only update in release branch as the issue will be fixed for April release.