### PR TITLE
Upgrade renaissance-mit jar version from v0.14.0 to v0.16.0

### DIFF
--- a/perf/renaissance/build.xml
+++ b/perf/renaissance/build.xml
@@ -34,7 +34,7 @@
 		        <echo message="${FILE_NAME} exists. Hence, not downloading it." />
 		    </then>
 		    <else>
-				<var name="curl_options" value="-Lks -C - https://github.com/renaissance-benchmarks/renaissance/releases/download/v0.14.0/renaissance-mit-0.14.0.jar -o ${FILE_NAME}"/>
+				<var name="curl_options" value="-Lks -C - https://github.com/renaissance-benchmarks/renaissance/releases/download/v0.16.0/renaissance-mit-0.16.0.jar -o ${FILE_NAME}"/>
 				<retry retrycount="3">
 		 			<sequential>
 						<echo message="curl ${curl_options}" />


### PR DESCRIPTION
To fix 'renaissance-db-shootout' failure
Related : #6029
Signed-off-by: Amrutha Kanhirathingal <Amrutha.Kanhirathingal@ibm.com>