### PR TITLE
Update testhost1name in jck default config

### DIFF
--- a/jck/jtrunner/config/default/jcktest.properties
+++ b/jck/jtrunner/config/default/jcktest.properties
@@ -7,8 +7,8 @@
 # The tests default to using 'default' as the config name.  If another name is used it must be
 # supplied to the test at run time - see openjdk.test.jck/docs/README.md for more details.
 
-testhost1name=www.eclipse.org
-testhost1ip=198.41.30.198
+testhost1name=jckservices.adoptium.net
+testhost1ip=40.121.206.1
 testhost2name=hg.openjdk.java.net
 testhost2ip=137.254.56.63
 httpurl=http://httpforever.com/index.html


### PR DESCRIPTION
Should fix problems we are seeing with jck net tests