### PR TITLE
(v1.0.6-release) - Exclude MBCS locale matching tests on AIX (#6057)

### DIFF
--- a/functional/MBCS_Tests/locale_matching/playlist.xml
+++ b/functional/MBCS_Tests/locale_matching/playlist.xml
@@ -158,6 +158,11 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_locale_matching_zh_CN_aix</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6023</comment>
+			</disable>
+		</disables>
 		<command>LANG=zh_CN perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>
@@ -173,6 +178,11 @@ limitations under the License.
 	</test>
 	<test>
 		<testCaseName>MBCS_Tests_locale_matching_Zh_CN_aix</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6023</comment>
+			</disable>
+		</disables>
 		<command>LANG=Zh_CN perl $(TEST_RESROOT)$(D)test.pl; \
 	$(TEST_STATUS)</command>
 		<platformRequirements>os.aix</platformRequirements>


### PR DESCRIPTION
MBCS_Tests_locale_matching_zh_CN_aix
MBCS_Tests_locale_matching_Zh_CN_aix