### PR TITLE
Disable jdk_jfr tests on jdk8 for temurin

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1921,7 +1921,7 @@
 		<disables>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3115#issuecomment-2256561374</comment>
-				<vendor>eclipse</vendor>
+				<vendor>temurin</vendor>
 				<platform>arm_linux</platform>
 				<version>8</version>
 			</disable>


### PR DESCRIPTION
Based on Shelley's comment here https://github.com/adoptium/infrastructure/issues/3043#issuecomment-2722458531. This should disable jdk_jfr tests on jdk8 for temurin