### PR TITLE
ProblemList_openjdk8.txt: unexclude sun/misc/Version/Version.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -330,7 +330,6 @@ sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-80
 sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all,solaris-x64
 sun/tools/jstatd/TestJstatdServer.java https://github.com/adoptium/aqa-tests/issues/115 linux-all,solaris-x64
 sun/tools/native2ascii/Native2AsciiTests.sh https://github.com/adoptium/aqa-tests/issues/2667 windows-all
-sun/misc/Version/Version.java https://bugs.openjdk.java.net/browse/JDK-8244548 generic-all
 com/sun/tools/attach/StartManagementAgent.java https://github.com/adoptium/aqa-tests/issues/115 generic-all
 # tools/pack200/CommandLineTests.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 tools/pack200/CommandLineTests.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,solaris-sparcv9


### PR DESCRIPTION
Unexclude sun/misc/Version/Version.java on jdk 8. [JDK-8244548](https://bugs.openjdk.org/browse/JDK-8244548) has already been fixed.

**Testing:**
arm_linux: [OK](https://ci.adoptium.net/job/Grinder/12780/)
x86-64_linux: [OK](https://ci.adoptium.net/job/Grinder/12781/)
aarch64_linux: [OK](https://ci.adoptium.net/job/Grinder/12782/)
s390x_linux: [OK](https://ci.adoptium.net/job/Grinder/12783/)
x86-64_mac: [OK](https://ci.adoptium.net/job/Grinder/12784/)
x86-64_windows: [OK](https://ci.adoptium.net/job/Grinder/12785/)
ppc64_aix: [OK](https://ci.adoptium.net/job/Grinder/12786/)