### PR TITLE
(v1.0.6) Exclude openJcePlusTests in FIPS140_2

### DIFF
--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -43,6 +43,7 @@
 		cp -r ${REPORTDIR}/target/surefire-reports/* junitreports
 		</command>
 		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
 		</features>


### PR DESCRIPTION
fixes: https://github.com/eclipse-openj9/openj9/issues/21388