### PR TITLE
Update Jtrunner to correctly set interactives & robot keywords dependent on tests run

### DIFF
--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -484,10 +484,10 @@ public class JavatestUtil {
 		// Otherwise 'other' is required because the JCK harness has no inherent knowledge of AIX and zOS.
 		// Runtime settings
 		if (testSuite.equals("RUNTIME")) {
-			if ( interactive.equals("yes")) {
+			if ( interactive.equals("yes") || tests.contains("api/java_awt/interactive") ) {
 				keyword = "keywords interactive";
 			}
-			else { 
+			else {
 				keyword = "keywords !interactive";
 			}
 
@@ -519,7 +519,7 @@ public class JavatestUtil {
 			}
 			
 			if ( tests.contains("api/java_awt") || tests.contains("api/javax_swing") || tests.equals("api") ) {
-				if ( robot.equals("yes") ) {
+				if ( robot.equals("yes") || tests.contains("api/java_awt/interactive") ) {
 					keyword += "&robot";
 				} else {
 					keyword += "&!robot";

--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -521,10 +521,10 @@ public class JavatestUtil {
 			
 			if ( tests.contains("api/java_awt") || tests.contains("api/javax_swing") || tests.equals("api") ) {
 				if ( robot.equals("yes") ) {
-					keyword += "&robot";
+					keyword += (keyword.equals("")) ? "keywords robot" : "&robot";
 				} else if ( !tests.contains("api/java_awt/interactive") ) {
 					// Filter robot as long as not running a specific interactive custom list that may include robots
-					keyword += "&!robot";
+					keyword += (keyword.equals("")) ? "keywords !robot" : "&!robot";
 				}
 			}
 			

--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -527,6 +527,11 @@ public class JavatestUtil {
 					keyword += (keyword.equals("")) ? "keywords !robot" : "&!robot";
 				}
 			}
+
+			if ( keyword.equals("") ) {
+				// No specific keyword, so default to runtime
+				keyword = "keywords runtime";
+			}
 			
 			fileContent += "concurrency " + concurrencyString + ";\n";
                        

--- a/jck/jtrunner/JavatestUtil.java
+++ b/jck/jtrunner/JavatestUtil.java
@@ -484,10 +484,11 @@ public class JavatestUtil {
 		// Otherwise 'other' is required because the JCK harness has no inherent knowledge of AIX and zOS.
 		// Runtime settings
 		if (testSuite.equals("RUNTIME")) {
-			if ( interactive.equals("yes") || tests.contains("api/java_awt/interactive") ) {
+			if ( interactive.equals("yes")) {
 				keyword = "keywords interactive";
 			}
-			else {
+			else if ( !tests.contains("api/java_awt/interactive") ) {
+				// Filter interactives as long as not running a specific interactive custom list that may include interactives/robots
 				keyword = "keywords !interactive";
 			}
 
@@ -519,9 +520,10 @@ public class JavatestUtil {
 			}
 			
 			if ( tests.contains("api/java_awt") || tests.contains("api/javax_swing") || tests.equals("api") ) {
-				if ( robot.equals("yes") || tests.contains("api/java_awt/interactive") ) {
+				if ( robot.equals("yes") ) {
 					keyword += "&robot";
-				} else {
+				} else if ( !tests.contains("api/java_awt/interactive") ) {
+					// Filter robot as long as not running a specific interactive custom list that may include robots
 					keyword += "&!robot";
 				}
 			}


### PR DESCRIPTION
Now that interactive robot tests are run via automation, Jtrunner needs updating to correctly set the interactive and robot keywords in the case when they are re-run in a "custom list" as part of custom_runtime.

Fixes https://github.com/adoptium/aqa-tests/issues/6085

runtime_custom test: TC/job/Test_openjdk24_hs_extended.jck_aarch64_mac_rerun/9/ - SUCCESS java_awt + robots
special.jck grinder: TC/job/Grinder/4982/ - SUCCESS

