### PR TITLE
Reenable OpenJ9 System test SC_Softmx_JitAot

### DIFF
--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -101,12 +101,6 @@
 	</test>
 	<test>
 		<testCaseName>SC_Softmx_JitAot</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/21031</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
@@ -127,12 +121,6 @@
 	</test>
 	<test>
 		<testCaseName>SC_Softmx_JitAot_Linux</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/21031</comment>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>


### PR DESCRIPTION
The SC_Softmx_JitAot and SC_Softmx_JitAot_Linux tests were temporarily disabled for JDK 24 and later testing due to issue eclipse-openj9/openj9#21031.  That defect has been fixed, so those tests can be enabled again.