### PR TITLE
MockitoMockTest doesn't support JDK25

### DIFF
--- a/functional/MockitoTests/playlist.xml
+++ b/functional/MockitoTests/playlist.xml
@@ -21,6 +21,10 @@
 				<comment>https://github.com/eclipse-openj9/openj9/issues/19331</comment>
 				<platform>.*zos.*</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21463</comment>
+				<version>25</version>
+			</disable>
 		</disables>
 		<command>
 			$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(RESOURCES_DIR)$(P)$(TEST_RESROOT)$(D)MockitoTests.jar$(P)$(LIB_DIR)$(D)mockito-core.jar$(P)$(LIB_DIR)$(D)byte-buddy.jar$(P)$(LIB_DIR)$(D)byte-buddy-agent.jar$(P)$(LIB_DIR)$(D)objenesis.jar$(Q) test.java.MockitoMockTest ; \


### PR DESCRIPTION
`MockitoMockTest` doesn't support JDK25

This avoids the following test failure:
```
08:16:47  Caused by: java.lang.IllegalArgumentException: Java 25 (69) is not supported by the current version of Byte Buddy which officially supports Java 24 (68) - update Byte Buddy or set net.bytebuddy.experimental as a VM property
08:16:47  	at net.bytebuddy.utility.OpenedClassReader.of(OpenedClassReader.java:120)
08:16:47  	at net.bytebuddy.utility.OpenedClassReader.of(OpenedClassReader.java:95)
08:16:47  	at net.bytebuddy.utility.AsmClassReader$Factory$Default.make(AsmClassReader.java:82)
08:16:47  	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForInlining.create(TypeWriter.java:4036)
08:16:47  	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2246)
08:16:47  	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$UsingTypeWriter.make(DynamicType.java:4057)
08:16:47  	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3741)
08:16:47  	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.transform(InlineBytecodeGenerator.java:402)
08:16:47  	at java.instrument/java.lang.instrument.ClassFileTransformer.transform(ClassFileTransformer.java:257)
08:16:47  	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
08:16:47  	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:594)
08:16:47  	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses0(Native Method)
08:16:47  	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses(InstrumentationImpl.java:221)
08:16:47  	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.triggerRetransformation(InlineBytecodeGenerator.java:281)
08:16:47  	... 16 more
08:16:47  -----------------------------------
08:16:47  MockitoMockTest_0_FAILED
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>