### PR TITLE
Enable MockitoMockTest for JDK25

### DIFF
--- a/functional/MockitoTests/playlist.xml
+++ b/functional/MockitoTests/playlist.xml
@@ -21,10 +21,6 @@
 				<comment>https://github.com/eclipse-openj9/openj9/issues/19331</comment>
 				<platform>.*zos.*</platform>
 			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/21463</comment>
-				<version>25</version>
-			</disable>
 		</disables>
 		<command>
 			$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(RESOURCES_DIR)$(P)$(TEST_RESROOT)$(D)MockitoTests.jar$(P)$(LIB_DIR)$(D)mockito-core.jar$(P)$(LIB_DIR)$(D)byte-buddy.jar$(P)$(LIB_DIR)$(D)byte-buddy-agent.jar$(P)$(LIB_DIR)$(D)objenesis.jar$(Q) test.java.MockitoMockTest ; \


### PR DESCRIPTION
Enable `MockitoMockTest` for JDK25

depends on https://github.com/adoptium/TKG/pull/687
closes https://github.com/eclipse-openj9/openj9/issues/21497

Verified locally.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>