### PR TITLE
(v1.0.6) JDK24/25 Re-enable ObjectMonitorUsage.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -658,7 +658,6 @@ serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java h
 serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java https://github.com/eclipse-openj9/openj9/issues/21403 generic-all
 serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/mcontenter01.java https://github.com/eclipse-openj9/openj9/issues/21404 generic-all
 serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://github.com/eclipse-openj9/openj9/issues/21406 generic-all
-serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java https://github.com/eclipse-openj9/openj9/issues/21407 generic-all
 serviceability/jvmti/thread/GetThreadState/thrstat01/thrstat01.java https://github.com/eclipse-openj9/openj9/issues/21408 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -647,7 +647,6 @@ serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java h
 serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java https://github.com/eclipse-openj9/openj9/issues/21403 generic-all
 serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/mcontenter01.java https://github.com/eclipse-openj9/openj9/issues/21404 generic-all
 serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://github.com/eclipse-openj9/openj9/issues/21406 generic-all
-serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java https://github.com/eclipse-openj9/openj9/issues/21407 generic-all
 serviceability/jvmti/thread/GetThreadState/thrstat01/thrstat01.java https://github.com/eclipse-openj9/openj9/issues/21408 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all


### PR DESCRIPTION
ObjectMonitorUsage.java passes with the recent JEP-491 changes.

Backport of https://github.com/adoptium/aqa-tests/pull/6118