### PR TITLE
Remove unnecessary OpenJ9 exclude for TimestampCheck.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -290,7 +290,6 @@ sun/security/ssl/X509TrustManagerImpl/distrust/Entrust.java https://github.com/a
 sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/eclipse-openj9/openj9/issues/21380 generic-all
 sun/security/tools/jarsigner/diffend.sh	https://github.com/adoptium/aqa-tests/issues/125	linux-all
 sun/security/tools/jarsigner/emptymanifest.sh	https://github.com/adoptium/aqa-tests/issues/125	generic-all
-sun/security/tools/jarsigner/TimestampCheck.java https://bugs.openjdk.org/browse/JDK-8352302 generic-all
 com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithProviderChange.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithRemoveAddProvider.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 


### PR DESCRIPTION
sun/security/tools/jarsigner/TimestampCheck.java

See
https://github.com/adoptium/aqa-tests/pull/6120
https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/809