### PR TITLE
Disable java/lang/Thread/virtual/MonitorWaitNotify.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -130,6 +130,17 @@ java/lang/Thread/virtual/MiscMonitorTests.java#Xcomp https://github.com/eclipse-
 java/lang/Thread/virtual/MiscMonitorTests.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
 java/lang/Thread/virtual/MiscMonitorTests.java#Xcomp-TieredStopAtLevel3 https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
 java/lang/Thread/virtual/MiscMonitorTests.java#Xint https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#default https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#LM_LEGACY https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-LM_LEGACY https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-noTieredCompilation-LM_LEGACY https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-noTieredCompilation-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-TieredStopAtLevel1-LM_LEGACY https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-TieredStopAtLevel1-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LEGACY https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
+java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/20955 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21036 macosx-x64


### PR DESCRIPTION
Re-disabling due to timeout seen in nightly builds on a/p linux
https://github.com/eclipse-openj9/openj9/issues/21525