### PR TITLE
Re-enable java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -141,7 +141,6 @@ java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-TieredStopAtLevel1-LM_LEGA
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-TieredStopAtLevel1-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LEGACY https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
-java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/20955 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21036 macosx-x64
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all


### PR DESCRIPTION
Re-enable `java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java`

Issue https://github.com/eclipse-openj9/openj9/issues/20955

Signed-off-by: Jason Feng <fengj@ca.ibm.com>