### PR TITLE
(1.0.6) Re-enable java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -130,7 +130,6 @@ java/lang/Thread/virtual/MiscMonitorTests.java#Xcomp https://github.com/eclipse-
 java/lang/Thread/virtual/MiscMonitorTests.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
 java/lang/Thread/virtual/MiscMonitorTests.java#Xcomp-TieredStopAtLevel3 https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
 java/lang/Thread/virtual/MiscMonitorTests.java#Xint https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
-java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/20955 generic-all
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21036 macosx-x64
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all


### PR DESCRIPTION
Re-enable `java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java`

closes https://github.com/eclipse-openj9/openj9/issues/20955

Cherry-pick
* https://github.com/adoptium/aqa-tests/pull/6124

Signed-off-by: Jason Feng <fengj@ca.ibm.com>