### PR TITLE
Fall back to regenerate parallel lists with preferred  NUM_MACHINES

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -249,7 +249,7 @@ def setupParallelEnv() {
 					echo "Regenerate parallel list with NUM_MACHINES=6 for TARGET ${TARGET}."
 					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=6 TEST_TIME="
 					NUM_LIST = genParallelList(PARALLEL_OPTIONS)
-				} else if (NUM_LIST == 1 && env.JDK_IMPL == "hotspot") {
+				} else if (NUM_LIST == 1 && env.JDK_IMPL == "hotspot" && (TARGET.contains("openjdk") || TARGET.contains("system"))) {
 					echo "NUM_LIST=1, Fall back to regenerate parallel lists with NUM_MACHINES=${MAX_NUM_MACHINES}."
 					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=${MAX_NUM_MACHINES} TEST_TIME="
 					NUM_LIST = genParallelList(PARALLEL_OPTIONS)

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -249,8 +249,7 @@ def setupParallelEnv() {
 					echo "Regenerate parallel list with NUM_MACHINES=6 for TARGET ${TARGET}."
 					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=6 TEST_TIME="
 					NUM_LIST = genParallelList(PARALLEL_OPTIONS)
-				}
-				if (NUM_LIST == 1 && env.JDK_IMPL == "hotspot") {
+				} else if (NUM_LIST == 1 && env.JDK_IMPL == "hotspot") {
 					echo "NUM_LIST=1, Fall back to regenerate parallel lists with NUM_MACHINES=${MAX_NUM_MACHINES}."
 					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=${MAX_NUM_MACHINES} TEST_TIME="
 					NUM_LIST = genParallelList(PARALLEL_OPTIONS)

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -250,8 +250,9 @@ def setupParallelEnv() {
 					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=6 TEST_TIME="
 					NUM_LIST = genParallelList(PARALLEL_OPTIONS)
 				} else if (NUM_LIST == 1 && env.JDK_IMPL == "hotspot" && (TARGET.contains("openjdk") || TARGET.contains("system"))) {
-					echo "NUM_LIST=1, Fall back to regenerate parallel lists with NUM_MACHINES=${MAX_NUM_MACHINES}."
-					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=${MAX_NUM_MACHINES} TEST_TIME="
+					int FORCE_NUM_MACHINES = Math.min(3, MAX_NUM_MACHINES);
+					echo "NUM_LIST=1, Fall back to regenerate parallel lists with NUM_MACHINES=${FORCE_NUM_MACHINES}."
+					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=${FORCE_NUM_MACHINES} TEST_TIME="
 					NUM_LIST = genParallelList(PARALLEL_OPTIONS)
 				}
 			} else {

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -250,6 +250,11 @@ def setupParallelEnv() {
 					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=6 TEST_TIME="
 					NUM_LIST = genParallelList(PARALLEL_OPTIONS)
 				}
+				if (NUM_LIST == 1 && env.JDK_IMPL == "hotspot") {
+					echo "NUM_LIST=1, Fall back to regenerate parallel lists with NUM_MACHINES=${MAX_NUM_MACHINES}."
+					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=${MAX_NUM_MACHINES} TEST_TIME="
+					NUM_LIST = genParallelList(PARALLEL_OPTIONS)
+				}
 			} else {
 				PARALLEL_OPTIONS += " TEST_TIME= NUM_MACHINES="
 				NUM_LIST = genParallelList(PARALLEL_OPTIONS)


### PR DESCRIPTION
Fall back to regenerate parallel lists with NUM_MACHINES=${MAX_NUM_MACHINES} if testList number=1 based on time limit.

Fix #5997 