### PR TITLE
JDK24/25 Re-enable StopThreadTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -673,8 +673,6 @@ serviceability/jvmti/thread/GetThreadState/thrstat01/thrstat01.java https://gith
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21412 generic-all
-serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java#default https://github.com/eclipse-openj9/openj9/issues/21413 generic-all
-serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21413 generic-all
 serviceability/jvmti/vthread/ThreadListStackTracesTest/ThreadListStackTracesTest.java https://github.com/eclipse-openj9/openj9/issues/21415 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -651,8 +651,6 @@ serviceability/jvmti/thread/GetThreadState/thrstat01/thrstat01.java https://gith
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21412 generic-all
-serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java#default https://github.com/eclipse-openj9/openj9/issues/21413 generic-all
-serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21413 generic-all
 serviceability/jvmti/vthread/ThreadListStackTracesTest/ThreadListStackTracesTest.java https://github.com/eclipse-openj9/openj9/issues/21415 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all


### PR DESCRIPTION
Fixed by:
- https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/979
- https://github.com/ibmruntimes/openj9-openjdk-jdk24/pull/57