### PR TITLE
Exclude failed system tests running loads with java.lang.Math.tanh for jdk24

### DIFF
--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -42,6 +42,12 @@
 		<testCaseName>MauveSingleThrdLoad_HS_5m</testCaseName>
 		<disables>
 			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6072</comment>
+				<version>24+</version>
+				<impl>hotspot</impl>
+				<platform>x86-64_.*</platform>
+			</disable>
+			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
@@ -95,6 +101,12 @@
 		<testCaseName>MauveSingleInvocLoad_HS_5m</testCaseName>
 		<disables>
 			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6072</comment>
+				<version>24+</version>
+				<impl>hotspot</impl>
+				<platform>x86-64_.*</platform>
+			</disable>
+			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
 				<impl>hotspot</impl>
 				<platform>riscv64_linux</platform>
@@ -126,6 +138,12 @@
 	<test>
 		<testCaseName>MauveMultiThrdLoad_5m</testCaseName>
 		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6072</comment>
+				<version>24+</version>
+				<impl>hotspot</impl>
+				<platform>x86-64_.*</platform>
+			</disable>
 			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/4976</comment>
 				<impl>hotspot</impl>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -35,6 +35,12 @@
 		<testCaseName>MiniMix_5m</testCaseName>
 		<disables>
 			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6072</comment>
+				<version>24+</version>
+				<impl>hotspot</impl>
+				<platform>x86-64_.*</platform>
+			</disable>
+			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3819</comment>
 				<version>11+</version>
 				<impl>hotspot</impl>
@@ -70,6 +76,12 @@
 		<testCaseName>MiniMix_10m</testCaseName>
 		<disables>
 			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6072</comment>
+				<version>24+</version>
+				<impl>hotspot</impl>
+				<platform>x86-64_.*</platform>
+			</disable>
+			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/3819</comment>
 				<version>11+</version>
 				<impl>hotspot</impl>
@@ -104,6 +116,12 @@
 	<test>
 		<testCaseName>MiniMix_aot_5m</testCaseName>
 		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6072</comment>
+				<version>24+</version>
+				<impl>hotspot</impl>
+				<platform>x86-64_.*</platform>
+			</disable>
 			<disable>
 				<comment>eclipse-openj9/openj9/issues/14165，https://github.com/adoptium/aqa-tests/issues/3230</comment>
 				<platform>x86-32_windows</platform>


### PR DESCRIPTION
Tracked by https://github.com/adoptium/aqa-systemtest/issues/499