### PR TITLE
Disable jdk_tools for hotspot jdk24

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -1815,6 +1815,11 @@
 		<testCaseName>jdk_tools</testCaseName>
 		<disables>
 			<disable>
+				<comment>https://bugs.openjdk.org/browse/JDK-8345185</comment>
+				<impl>hotspot</impl>
+				<version>24</version>
+			</disable>
+			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/10757</comment>
 				<impl>openj9</impl>
 			</disable>


### PR DESCRIPTION
Related with https://bugs.openjdk.org/browse/JDK-8345185