### PR TITLE
(v1.0.6) Re-enable ThreadListStackTracesTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -655,7 +655,6 @@ serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://gi
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21412 generic-all
-serviceability/jvmti/vthread/ThreadListStackTracesTest/ThreadListStackTracesTest.java https://github.com/eclipse-openj9/openj9/issues/21415 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all
 

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -644,7 +644,6 @@ serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://gi
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21412 generic-all
-serviceability/jvmti/vthread/ThreadListStackTracesTest/ThreadListStackTracesTest.java https://github.com/eclipse-openj9/openj9/issues/21415 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all
 


### PR DESCRIPTION
The test has been fixed, and passes now.

Related: https://github.com/eclipse-openj9/openj9/issues/21415