### PR TITLE
Re-include tests mcontenter01 and mcontentered01

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -661,7 +661,6 @@ serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://gith
 serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java https://github.com/eclipse-openj9/openj9/issues/21402 generic-all
 serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java https://github.com/eclipse-openj9/openj9/issues/21403 generic-all
-serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/mcontenter01.java https://github.com/eclipse-openj9/openj9/issues/21404 generic-all
 serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://github.com/eclipse-openj9/openj9/issues/21406 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all

--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -660,7 +660,6 @@ serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https
 serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/21399 generic-all
 serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java https://github.com/eclipse-openj9/openj9/issues/21402 generic-all
-serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java https://github.com/eclipse-openj9/openj9/issues/21403 generic-all
 serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://github.com/eclipse-openj9/openj9/issues/21406 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -639,7 +639,6 @@ serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://gith
 serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java https://github.com/eclipse-openj9/openj9/issues/21402 generic-all
 serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java https://github.com/eclipse-openj9/openj9/issues/21403 generic-all
-serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/mcontenter01.java https://github.com/eclipse-openj9/openj9/issues/21404 generic-all
 serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://github.com/eclipse-openj9/openj9/issues/21406 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -638,7 +638,6 @@ serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https
 serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/21399 generic-all
 serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java https://github.com/eclipse-openj9/openj9/issues/21402 generic-all
-serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/mcontentered01.java https://github.com/eclipse-openj9/openj9/issues/21403 generic-all
 serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://github.com/eclipse-openj9/openj9/issues/21406 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default https://github.com/eclipse-openj9/openj9/issues/21412 generic-all


### PR DESCRIPTION
The test failures are fixed by https://github.com/eclipse-openj9/openj9/pull/21585

Fixes https://github.com/eclipse-openj9/openj9/issues/21404 and
https://github.com/eclipse-openj9/openj9/issues/21403
