### PR TITLE
Re-enable GetOwnedMonitorInfoTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -664,7 +664,6 @@ serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https
 serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/21399 generic-all
 serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java https://github.com/eclipse-openj9/openj9/issues/21402 generic-all
-serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://github.com/eclipse-openj9/openj9/issues/21406 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -642,7 +642,6 @@ serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https
 serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/21399 generic-all
 serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java https://github.com/eclipse-openj9/openj9/issues/21402 generic-all
-serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java https://github.com/eclipse-openj9/openj9/issues/21406 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all


### PR DESCRIPTION
The test is fixed by The test failures are fixed by https://github.com/eclipse-openj9/openj9/pull/21585.

Closes https://github.com/eclipse-openj9/openj9/issues/21406