### PR TITLE
(v1.0.6-release) Rename classesByName2Test to jdk_classesByName2Test (#6091)

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2138,7 +2138,7 @@
 	</test>
 	<!-- ClassesByName2Test is a subtest of jdk_jdi. Once jdk_jdi is fully enabled in openj9/ibm, the classesByName2Test below can be removed  -->
 	<test>
-		<testCaseName>classesByName2Test</testCaseName>
+		<testCaseName>jdk_classesByName2Test</testCaseName>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>


### PR DESCRIPTION
Cherry-pick https://github.com/adoptium/aqa-tests/pull/6091
Rerun of this test got skipped since rerun target is based on name.