### PR TITLE
Re-enable JVMTI framepop02 test

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -656,7 +656,6 @@ serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#default https://git
 serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/18811 generic-all
 serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetStackTraceAndRetransformTest.java https://github.com/eclipse-openj9/openj9/issues/18809 generic-all
 serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/18807 generic-all
-serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/21399 generic-all
 serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java https://github.com/eclipse-openj9/openj9/issues/21402 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -634,7 +634,6 @@ serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#default https://git
 serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/18811 generic-all
 serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetStackTraceAndRetransformTest.java https://github.com/eclipse-openj9/openj9/issues/18809 generic-all
 serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/18807 generic-all
-serviceability/jvmti/events/FramePop/framepop02/framepop02.java#id1 https://github.com/eclipse-openj9/openj9/issues/21399 generic-all
 serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/events/MonitorWaited/monitorwaited01/monitorwaited01.java https://github.com/eclipse-openj9/openj9/issues/21402 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all


### PR DESCRIPTION
The failure is fixed by
https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/985

Closes: https://github.com/eclipse-openj9/openj9/issues/21399