### PR TITLE
Terminate notepad.exe if found post job check

### DIFF
--- a/terminateTestProcesses.sh
+++ b/terminateTestProcesses.sh
@@ -15,6 +15,7 @@ if [ "$OS" = "Windows_NT" ]; then
              CommandLine like '%rmid%' or \
              CommandLine like '%rmiregistry%' or \
              CommandLine like '%tnameserv%' or \
+             CommandLine like '%notepad.exe%' or \
              CommandLine like '%make.exe%')"
 
   # Ignore Jenkins agent and grep cmd


### PR DESCRIPTION
Some java testcases for java_awt launch notepad.exe, which ends up with a process lock on the aqa-tests workspace so it cannot be deleted, nor can a future job checkout.
So this PR ensures any notepad.exe process that is spawned by the jenkins user is terminated...