### PR TITLE
(1.0.6) Restore java/util/Currency/ValidateISO4217 OpenJ9 jdk8

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -379,7 +379,6 @@ com/sun/jdi/RedefineCrossEvent.java	https://github.com/adoptium/aqa-tests/issues
 java/util/Arrays/ParallelPrefix.java	https://github.com/adoptium/aqa-tests/issues/830	linux-all
 java/util/Arrays/TimSortStackSize2.java		https://github.com/eclipse-openj9/openj9/issues/7223		generic-all
 java/util/Calendar/CalendarRegression.java https://bugs.openjdk.java.net/browse/JDK-8031145 generic-all
-java/util/Currency/ValidateISO4217.java https://github.com/eclipse-openj9/openj9/issues/21539 generic-all
 java/util/Locale/LocaleProviders.sh	https://github.com/adoptium/aqa-tests/issues/1261	windows-all
 java/util/Spliterator/SpliteratorCollisions.java		https://github.com/eclipse-openj9/openj9/issues/1131	generic-all
 java/util/SplittableRandom/SplittableRandomTest.java	https://github.com/adoptium/aqa-tests/issues/830	linux-ppc64le


### PR DESCRIPTION
Problem fixed in jdk8u452-b09

Issue https://github.com/eclipse-openj9/openj9/issues/21539

Port https://github.com/adoptium/aqa-tests/pull/6201