### PR TITLE
Re-enable CancelTimerWithContention test

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -123,7 +123,6 @@ java/lang/System/LoggerFinder/jdk/DefaultLoggerBridgeTest/DefaultLoggerBridgeTes
 java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issues/17638 windows-all
 java/lang/Thread/ThreadSleepEvent.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
-java/lang/Thread/virtual/CancelTimerWithContention.java https://github.com/eclipse-openj9/openj9/issues/21037 generic-all
 java/lang/Thread/virtual/JfrEvents.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
 java/lang/Thread/virtual/MiscMonitorTests.java#default https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
 java/lang/Thread/virtual/MiscMonitorTests.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/20705 generic-all


### PR DESCRIPTION
This test was not excluded in JDK25

Related to eclipse-openj9/openj9#21037