### PR TITLE
(1.0.7) Re-enable CompletableFutureTimedGet

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -183,7 +183,6 @@ java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/
 java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/TraceVirtualThreadLocals.java https://github.com/eclipse-openj9/openj9/issues/21441 generic-all
-java/lang/Thread/virtual/stress/CompletableFutureTimedGet.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-interrupt https://github.com/eclipse-openj9/openj9/issues/21445 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -162,7 +162,6 @@ java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/
 java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/TraceVirtualThreadLocals.java https://github.com/eclipse-openj9/openj9/issues/21441 generic-all
-java/lang/Thread/virtual/stress/CompletableFutureTimedGet.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-interrupt https://github.com/eclipse-openj9/openj9/issues/21445 generic-all


### PR DESCRIPTION
Related to https://github.com/eclipse-openj9/openj9/issues/21560

Backport of https://github.com/adoptium/aqa-tests/pull/6206