### PR TITLE
Re-enable java/lang/Thread/virtual/TraceVirtualThreadLocals.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -181,7 +181,6 @@ java/lang/ScopedValue/ScopedValueAPI.java https://github.com/eclipse-openj9/open
 java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le
 java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/lang/Thread/virtual/TraceVirtualThreadLocals.java https://github.com/eclipse-openj9/openj9/issues/21441 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-interrupt https://github.com/eclipse-openj9/openj9/issues/21445 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -161,7 +161,6 @@ java/lang/ScopedValue/ScopedValueAPI.java https://github.com/eclipse-openj9/open
 java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le
 java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/lang/Thread/virtual/TraceVirtualThreadLocals.java https://github.com/eclipse-openj9/openj9/issues/21441 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-interrupt https://github.com/eclipse-openj9/openj9/issues/21445 generic-all


### PR DESCRIPTION
The TraceVirtualThreadLocals test passes consistently in local runs.

Related: https://github.com/eclipse-openj9/openj9/issues/21441