### PR TITLE
Exclude serviceability/jvmti/GetMethodDeclaringClass/TestUnloadedClass.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -535,6 +535,7 @@ java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues
 # serviceability
 
 serviceability/jvmti/GetLocalVariable/GetLocalVars.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
+serviceability/jvmti/GetMethodDeclaringClass/TestUnloadedClass.java https://github.com/eclipse-openj9/openj9/issues/20676 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorEventOnOffTest.java https://github.com/eclipse-openj9/openj9/issues/16184 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorGCParallelTest.java https://github.com/eclipse-openj9/openj9/issues/16184 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorArrayAllSampledTest.java https://github.com/eclipse-openj9/openj9/issues/16184 generic-all

--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -599,6 +599,7 @@ java/foreign/TestMappedHandshake.java https://github.com/eclipse-openj9/openj9/i
 # serviceability
 
 serviceability/jvmti/GetLocalVariable/GetLocalVars.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
+serviceability/jvmti/GetMethodDeclaringClass/TestUnloadedClass.java https://github.com/eclipse-openj9/openj9/issues/20676 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorEventOnOffTest.java https://github.com/eclipse-openj9/openj9/issues/16184 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorGCParallelTest.java https://github.com/eclipse-openj9/openj9/issues/16184 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorArrayAllSampledTest.java https://github.com/eclipse-openj9/openj9/issues/16184 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -579,6 +579,7 @@ java/foreign/TestMappedHandshake.java https://github.com/eclipse-openj9/openj9/i
 # serviceability
 
 serviceability/jvmti/GetLocalVariable/GetLocalVars.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
+serviceability/jvmti/GetMethodDeclaringClass/TestUnloadedClass.java https://github.com/eclipse-openj9/openj9/issues/20676 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorEventOnOffTest.java https://github.com/eclipse-openj9/openj9/issues/16184 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorGCParallelTest.java https://github.com/eclipse-openj9/openj9/issues/16184 generic-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorArrayAllSampledTest.java https://github.com/eclipse-openj9/openj9/issues/16184 generic-all


### PR DESCRIPTION
Exclude `serviceability/jvmti/GetMethodDeclaringClass/TestUnloadedClass.java`

Related to
* https://github.com/eclipse-openj9/openj9/issues/20676

Signed-off-by: Jason Feng <fengj@ca.ibm.com>