### PR TITLE
[JDK24/25] Re-enable SynchronizedNative and Parking tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -168,10 +168,6 @@ java/lang/Thread/virtual/MonitorEnterExit.java#Xint-LM_LEGACY https://github.com
 java/lang/Thread/virtual/MonitorEnterExit.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21422 generic-all
 java/lang/Thread/virtual/MonitorEnterExit.java#default https://github.com/eclipse-openj9/openj9/issues/21422 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21423 generic-all
-java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21424 generic-all
-java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21424 generic-all
-java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21424 generic-all
-java/lang/Thread/virtual/SynchronizedNative.java#default https://github.com/eclipse-openj9/openj9/issues/21424 generic-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21425 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-notify https://github.com/eclipse-openj9/openj9/issues/21426 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-notify-interrupt https://github.com/eclipse-openj9/openj9/issues/21426 generic-all
@@ -184,10 +180,6 @@ java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-o
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-interrupt https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 generic-all
-java/lang/Thread/virtual/Parking.java#default https://github.com/eclipse-openj9/openj9/issues/21446 generic-all
-java/lang/Thread/virtual/Parking.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/21446 generic-all
-java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21446 generic-all
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 generic-all
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -148,10 +148,6 @@ java/lang/Thread/virtual/MonitorEnterExit.java#Xint-LM_LEGACY https://github.com
 java/lang/Thread/virtual/MonitorEnterExit.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21422 generic-all
 java/lang/Thread/virtual/MonitorEnterExit.java#default https://github.com/eclipse-openj9/openj9/issues/21422 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21423 generic-all
-java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21424 generic-all
-java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21424 generic-all
-java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21424 generic-all
-java/lang/Thread/virtual/SynchronizedNative.java#default https://github.com/eclipse-openj9/openj9/issues/21424 generic-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21425 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-notify https://github.com/eclipse-openj9/openj9/issues/21426 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-notify-interrupt https://github.com/eclipse-openj9/openj9/issues/21426 generic-all
@@ -164,10 +160,6 @@ java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-o
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-interrupt https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 generic-all
-java/lang/Thread/virtual/Parking.java#default https://github.com/eclipse-openj9/openj9/issues/21446 generic-all
-java/lang/Thread/virtual/Parking.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/21446 generic-all
-java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21446 generic-all
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 generic-all
 
 ############################################################################


### PR DESCRIPTION
Both Parking and SynchronizedNative tests successfully ran 150 times
locally.

Related: https://github.com/eclipse-openj9/openj9/issues/21424
Related: https://github.com/eclipse-openj9/openj9/issues/21446