### PR TITLE
[v1.0.7-release] April 2025 release Arm32 Linux JDK8 tags

### DIFF
--- a/testenv/testenv_arm32.properties
+++ b/testenv/testenv_arm32.properties
@@ -9,6 +9,6 @@ OPENJ9_SYSTEMTEST_BRANCH=master
 ADOPTOPENJDK_SYSTEMTEST_REPO=https://github.com/adoptium/aqa-systemtest.git
 ADOPTOPENJDK_SYSTEMTEST_BRANCH=master
 JDK8_REPO=https://github.com/adoptium/aarch32-jdk8u.git
-JDK8_BRANCH=dev
+JDK8_BRANCH=jdk8u452-b09-aarch32-20250424
 AQA_REQUIRED_TARGETS=sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,extended.perf
 


### PR DESCRIPTION
GA tags for JDK8 Arm32 linux have been released [https://github.com/adoptium/aarch32-jdk8u/tags](https://github.com/adoptium/aarch32-jdk8u/tags)