### PR TITLE
[JDK24/25] Re-exclude SynchronizedNative and Parking tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -168,6 +168,10 @@ java/lang/Thread/virtual/MonitorEnterExit.java#Xint-LM_LEGACY https://github.com
 java/lang/Thread/virtual/MonitorEnterExit.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21422 generic-all
 java/lang/Thread/virtual/MonitorEnterExit.java#default https://github.com/eclipse-openj9/openj9/issues/21422 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21423 generic-all
+java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
+java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
+java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
+java/lang/Thread/virtual/SynchronizedNative.java#default https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21425 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-notify https://github.com/eclipse-openj9/openj9/issues/21426 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-notify-interrupt https://github.com/eclipse-openj9/openj9/issues/21426 generic-all
@@ -180,6 +184,10 @@ java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-o
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-interrupt https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
+java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
+java/lang/Thread/virtual/Parking.java#default https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
+java/lang/Thread/virtual/Parking.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
+java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 generic-all
 
 ############################################################################

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -148,6 +148,10 @@ java/lang/Thread/virtual/MonitorEnterExit.java#Xint-LM_LEGACY https://github.com
 java/lang/Thread/virtual/MonitorEnterExit.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21422 generic-all
 java/lang/Thread/virtual/MonitorEnterExit.java#default https://github.com/eclipse-openj9/openj9/issues/21422 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21423 generic-all
+java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
+java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
+java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
+java/lang/Thread/virtual/SynchronizedNative.java#default https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21425 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-notify https://github.com/eclipse-openj9/openj9/issues/21426 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-notify-interrupt https://github.com/eclipse-openj9/openj9/issues/21426 generic-all
@@ -160,6 +164,10 @@ java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-o
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/stress/TimedWaitALot.java#timeout-interrupt https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
+java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
+java/lang/Thread/virtual/Parking.java#default https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
+java/lang/Thread/virtual/Parking.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
+java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 generic-all
 
 ############################################################################


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/issues/21446#issuecomment-2830885991
Related: https://github.com/eclipse-openj9/openj9/issues/21727#issuecomment-2830873286