### PR TITLE
Re-enable serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -648,7 +648,6 @@ serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#default https://git
 serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/18811 generic-all
 serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetStackTraceAndRetransformTest.java https://github.com/eclipse-openj9/openj9/issues/18809 generic-all
 serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/18807 generic-all
-serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -648,7 +648,6 @@ serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#default https://git
 serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/18811 generic-all
 serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetStackTraceAndRetransformTest.java https://github.com/eclipse-openj9/openj9/issues/18809 generic-all
 serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/18807 generic-all
-serviceability/jvmti/events/MonitorWait/monitorwait01/monitorwait01.java https://github.com/eclipse-openj9/openj9/issues/21400 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all


### PR DESCRIPTION
Closes: https://github.com/eclipse-openj9/openj9/issues/21400

Fixed by: https://github.com/eclipse-openj9/openj9/pull/21590

[50x Grinder](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/50045/) passed