### PR TITLE
Exclude JDK 24/25 RetryMonitorEnterWhenPinned on aix-all

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -163,7 +163,7 @@ java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.c
 java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21423 generic-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
@@ -403,9 +403,9 @@ java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/ope
 jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4679 linux-x64,macosx-all
 java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/adoptium/aqa-tests/issues/1297 aix-all
 java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/adoptium/aqa-tests/issues/1297 aix-all
-java/nio/channels/vthread/BlockingChannelOps.java#default https://github.com/eclipse-openj9/openj9/issues/21649 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
-java/nio/channels/vthread/BlockingChannelOps.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21649 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
-java/nio/channels/vthread/BlockingChannelOps.java#poller-modes https://github.com/eclipse-openj9/openj9/issues/21649 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+java/nio/channels/vthread/BlockingChannelOps.java#default https://github.com/eclipse-openj9/openj9/issues/21649 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+java/nio/channels/vthread/BlockingChannelOps.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21649 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+java/nio/channels/vthread/BlockingChannelOps.java#poller-modes https://github.com/eclipse-openj9/openj9/issues/21649 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 
 ############################################################################
 
@@ -442,7 +442,7 @@ javax/net/ssl/SSLEngine/LargePacket.java	https://github.ibm.com/runtimes/backlog
 javax/net/ssl/SSLSocket/Tls13PacketSize.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 javax/net/ssl/TLSv11/TLSEnginesClosureTest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
 sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
-sun/security/pkcs12/AttributesMultiThread.java https://github.com/eclipse-openj9/openj9/issues/21696 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+sun/security/pkcs12/AttributesMultiThread.java https://github.com/eclipse-openj9/openj9/issues/21696 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
 sun/security/mscapi/CastError.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/CngCipher.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -163,7 +163,7 @@ java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.c
 java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21423 generic-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
@@ -403,9 +403,9 @@ java/nio/MappedByteBuffer/MapSyncFail.java https://github.com/eclipse-openj9/ope
 jdk/nio/zipfs/ZipFSTester.java https://github.com/eclipse-openj9/openj9/issues/4679 linux-x64,macosx-all
 java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/adoptium/aqa-tests/issues/1297 aix-all
 java/nio/channels/vthread/BlockingChannelOps.java#id1 https://github.com/adoptium/aqa-tests/issues/1297 aix-all
-java/nio/channels/vthread/BlockingChannelOps.java#default https://github.com/eclipse-openj9/openj9/issues/21649 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
-java/nio/channels/vthread/BlockingChannelOps.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21649 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
-java/nio/channels/vthread/BlockingChannelOps.java#poller-modes https://github.com/eclipse-openj9/openj9/issues/21649 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+java/nio/channels/vthread/BlockingChannelOps.java#default https://github.com/eclipse-openj9/openj9/issues/21649 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+java/nio/channels/vthread/BlockingChannelOps.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21649 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+java/nio/channels/vthread/BlockingChannelOps.java#poller-modes https://github.com/eclipse-openj9/openj9/issues/21649 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 
 ############################################################################
 
@@ -442,7 +442,7 @@ javax/net/ssl/SSLEngine/LargePacket.java	https://github.ibm.com/runtimes/backlog
 javax/net/ssl/SSLSocket/Tls13PacketSize.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 javax/net/ssl/TLSv11/TLSEnginesClosureTest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
 sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
-sun/security/pkcs12/AttributesMultiThread.java https://github.com/eclipse-openj9/openj9/issues/21696 linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
+sun/security/pkcs12/AttributesMultiThread.java https://github.com/eclipse-openj9/openj9/issues/21696 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
 sun/security/mscapi/CastError.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/CngCipher.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all


### PR DESCRIPTION
Exclude JDK 24/25 `RetryMonitorEnterWhenPinned` on `aix-all`

Excluded `java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java`, `java/nio/channels/vthread/BlockingChannelOps.java`, `sun/security/pkcs12/AttributesMultiThread.java` on `aix-all`.

Related to https://github.com/eclipse-openj9/openj9/issues/21717#issuecomment-2841842847

Signed-off-by: Jason Feng <fengj@ca.ibm.com>