### PR TITLE
Enable JDK 24/25 java/lang/Thread/virtual/ThreadAPI.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -169,8 +169,6 @@ java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https:
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#default https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
-java/lang/Thread/virtual/ThreadAPI.java#default https://github.com/eclipse-openj9/openj9/issues/21183 generic-all
-java/lang/Thread/virtual/ThreadAPI.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21183 generic-all
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -169,8 +169,6 @@ java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https:
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#default https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
-java/lang/Thread/virtual/ThreadAPI.java#default https://github.com/eclipse-openj9/openj9/issues/21183 generic-all
-java/lang/Thread/virtual/ThreadAPI.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21183 generic-all
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all


### PR DESCRIPTION
Enable JDK 24/25 `java/lang/Thread/virtual/ThreadAPI.java`

Related to
* https://github.com/eclipse-openj9/openj9/issues/21827

Signed-off-by: Jason Feng <fengj@ca.ibm.com>