### PR TITLE
Update JDK24+ exclude entries

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -161,14 +161,14 @@ java/lang/Thread/virtual/Parking.java#default https://github.com/eclipse-openj9/
 java/lang/Thread/virtual/Parking.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
-java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#default https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
+java/lang/Thread/virtual/ThreadAPI.java#default https://github.com/eclipse-openj9/openj9/issues/21183 aarch64_macos,aix-all,linux-s390x,windows-all
+java/lang/Thread/virtual/ThreadAPI.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21183 aarch64_macos,aix-all,linux-s390x,windows-all
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all
@@ -201,8 +201,6 @@ jdk/internal/vm/Continuation/Fuzz.java https://github.com/eclipse-openj9/openj9/
 jdk/internal/vm/Continuation/LiveFramesDriver.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 jdk/internal/vm/Continuation/OSRTest.java https://github.com/eclipse-openj9/openj9/issues/19357 generic-all
 jdk/internal/vm/Continuation/Scoped.java https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
-jdk/internal/misc/ThreadFlock/ThreadFlockTest.java#virtual https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-jdk/internal/misc/ThreadFlock/ThreadFlockTest.java#virtual.ThreadFlockTest_virtual https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 
 ############################################################################
 
@@ -536,10 +534,7 @@ java/util/zip/DeflateIn_InflateOut.java https://github.com/eclipse-openj9/openj9
 java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/8872  generic-all
 java/util/zip/ZipFile/ZipSourceCache.java https://github.com/eclipse-openj9/openj9/issues/18987 linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
-java/util/concurrent/ExecutorService/InvokeTest.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/util/concurrent/ExecutorService/SubmitTest.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le
-java/util/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java#platform https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/util/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java#virtual https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/util/concurrent/ThreadPerTaskExecutor/ThreadPerTaskExecutorTest.java#virtual https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/util/stream/GatherersMapConcurrentTest.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -161,14 +161,14 @@ java/lang/Thread/virtual/Parking.java#default https://github.com/eclipse-openj9/
 java/lang/Thread/virtual/Parking.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
-java/lang/Thread/virtual/Reflection.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/lang/Thread/virtual/Reflection.java.Reflection https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#default https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
+java/lang/Thread/virtual/ThreadAPI.java#default https://github.com/eclipse-openj9/openj9/issues/21183 aarch64_macos,aix-all,linux-s390x,windows-all
+java/lang/Thread/virtual/ThreadAPI.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/21183 aarch64_macos,aix-all,linux-s390x,windows-all
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all
@@ -201,8 +201,6 @@ jdk/internal/vm/Continuation/Fuzz.java https://github.com/eclipse-openj9/openj9/
 jdk/internal/vm/Continuation/LiveFramesDriver.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
 jdk/internal/vm/Continuation/OSRTest.java https://github.com/eclipse-openj9/openj9/issues/19357 generic-all
 jdk/internal/vm/Continuation/Scoped.java https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
-jdk/internal/misc/ThreadFlock/ThreadFlockTest.java#virtual https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-jdk/internal/misc/ThreadFlock/ThreadFlockTest.java#virtual.ThreadFlockTest_virtual https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 
 ############################################################################
 
@@ -536,10 +534,7 @@ java/util/zip/DeflateIn_InflateOut.java https://github.com/eclipse-openj9/openj9
 java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/issues/8872  generic-all
 java/util/zip/ZipFile/ZipSourceCache.java https://github.com/eclipse-openj9/openj9/issues/18987 linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
-java/util/concurrent/ExecutorService/InvokeTest.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/util/concurrent/ExecutorService/SubmitTest.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le
-java/util/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java#platform https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
-java/util/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java#virtual https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/util/concurrent/ThreadPerTaskExecutor/ThreadPerTaskExecutorTest.java#virtual https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 java/util/stream/GatherersMapConcurrentTest.java https://github.com/eclipse-openj9/openj9/issues/21445 generic-all
 


### PR DESCRIPTION
Update JDK24+ exclude entries

Excluded java/lang/Thread/virtual/ThreadAPI.java on `aarch64_macos,aix-all,linux-s390x,windows-all` platforms;
Enabled `java/lang/Thread/virtual/Reflection.java`, `jdk/internal/misc/ThreadFlock/ThreadFlockTest.java`, `java/util/concurrent/ExecutorService/InvokeTest.java` and `java/util/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java`.

Related to
* https://github.com/eclipse-openj9/openj9/issues/21861
* https://github.com/eclipse-openj9/openj9/issues/21445

Signed-off-by: Jason Feng <fengj@ca.ibm.com>