### PR TITLE
[JDK24/25] Re-enable GetStackTraceNotSuspendedStressTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -653,7 +653,6 @@ serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetSta
 serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/18807 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
-serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all
 
 # jdk_container
 jdk/internal/platform/docker/TestDockerBasic.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -653,7 +653,6 @@ serviceability/jvmti/thread/GetStackTrace/GetStackTraceAndRetransformTest/GetSta
 serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/18807 generic-all
 serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21411 generic-all
 serviceability/jvmti/vthread/VThreadMonitorTest/VThreadMonitorTest.java https://github.com/eclipse-openj9/openj9/issues/21416 generic-all
-serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/21434 generic-all
 
 # jdk_container
 jdk/internal/platform/docker/TestDockerBasic.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all


### PR DESCRIPTION
GetStackTraceNotSuspendedStressTest no longer fails.

Closes: https://github.com/eclipse-openj9/openj9/issues/21434