### PR TITLE
Exclude serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -623,6 +623,7 @@ serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorVMEventsTest.java#id1 http
 serviceability/jvmti/ModuleAwareAgents/ClassFileLoadHook/MAAClassFileLoadHook.java https://github.com/eclipse-openj9/openj9/issues/15985 generic-all
 serviceability/jvmti/ModuleAwareAgents/ClassLoadPrepare/MAAClassLoadPrepare.java https://github.com/eclipse-openj9/openj9/issues/15985 generic-all
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java https://github.com/eclipse-openj9/openj9/issues/15985 generic-all
+serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java https://github.com/eclipse-openj9/openj9/issues/21890 linux-ppc64le
 serviceability/jvmti/RedefineClasses/ClassVersionAfterRedefine.java https://github.com/eclipse-openj9/openj9/issues/15988 generic-all
 serviceability/jvmti/RedefineClasses/RedefineAddLambdaExpression.java https://github.com/eclipse-openj9/openj9/issues/15989 generic-all
 serviceability/jvmti/RedefineClasses/RedefineGenericSignatureTest.java https://github.com/eclipse-openj9/openj9/issues/15990 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -623,6 +623,7 @@ serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorVMEventsTest.java#id1 http
 serviceability/jvmti/ModuleAwareAgents/ClassFileLoadHook/MAAClassFileLoadHook.java https://github.com/eclipse-openj9/openj9/issues/15985 generic-all
 serviceability/jvmti/ModuleAwareAgents/ClassLoadPrepare/MAAClassLoadPrepare.java https://github.com/eclipse-openj9/openj9/issues/15985 generic-all
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java https://github.com/eclipse-openj9/openj9/issues/15985 generic-all
+serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java https://github.com/eclipse-openj9/openj9/issues/21890 linux-ppc64le
 serviceability/jvmti/RedefineClasses/ClassVersionAfterRedefine.java https://github.com/eclipse-openj9/openj9/issues/15988 generic-all
 serviceability/jvmti/RedefineClasses/RedefineAddLambdaExpression.java https://github.com/eclipse-openj9/openj9/issues/15989 generic-all
 serviceability/jvmti/RedefineClasses/RedefineGenericSignatureTest.java https://github.com/eclipse-openj9/openj9/issues/15990 generic-all


### PR DESCRIPTION
Exclude `serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java`

Exclude `serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java` on `linux-ppc64le`.

Related to
* https://github.com/eclipse-openj9/openj9/issues/21890

Signed-off-by: Jason Feng <fengj@ca.ibm.com>