### PR TITLE
Enabled the renaissance tests for 18+ versions

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -38,10 +38,6 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/3469</comment>
-				<version>18+</version>
-			</disable>
-			<disable>
 				<comment>runtimes/infrastructure/issues/5444</comment>
 				<vendor>ibm</vendor>
 			</disable>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -111,10 +111,6 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/3469</comment>
-				<version>18+</version>
-			</disable>
-			<disable>
 				<comment>runtimes/infrastructure/issues/5444</comment>
 				<vendor>ibm</vendor>
 			</disable>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -252,15 +252,6 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/3469</comment>
-				<version>18+</version>
-			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/3469</comment>
-				<version>17</version>
-				<platform>s390_linux</platform>
-			</disable>
-			<disable>
 				<comment>runtimes/infrastructure/issues/5444</comment>
 				<vendor>ibm</vendor>
 			</disable>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -216,10 +216,6 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/3469</comment>
-				<version>18+</version>
-			</disable>
-			<disable>
 				<comment>runtimes/infrastructure/issues/5444</comment>
 				<vendor>ibm</vendor>
 			</disable>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -191,10 +191,6 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/3469</comment>
-				<version>18+</version>
-			</disable>
-			<disable>
 				<comment>runtimes/infrastructure/issues/5444</comment>
 				<vendor>ibm</vendor>
 			</disable>

--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -63,10 +63,6 @@
 				<platform>x86-32_windows|arm_linux</platform>
 			</disable>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/3469</comment>
-				<version>18+</version>
-			</disable>
-			<disable>
 				<comment>runtimes/infrastructure/issues/5444</comment>
 				<vendor>ibm</vendor>
 			</disable>


### PR DESCRIPTION
Enabled Test List for jdk 18 + versions and tested on windows and linux x86-64 platforms
renaissance-als
renaissance-chi-square
renaissance-dec-tree
renaissance-gauss-mix
renaissance-log-regression
renaissance-movie-lens : tested for platform s390_linux along with windows and linux x86-64 platforms