### PR TITLE
Re-enable JDK24+ java/lang/Thread/virtual/Parking.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -158,10 +158,6 @@ java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-TieredStopAtLevel1-LM_LEGA
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-TieredStopAtLevel1-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LEGACY https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
-java/lang/Thread/virtual/Parking.java#default https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
-java/lang/Thread/virtual/Parking.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
-java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
-java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -158,10 +158,6 @@ java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-TieredStopAtLevel1-LM_LEGA
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xcomp-TieredStopAtLevel1-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LEGACY https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
-java/lang/Thread/virtual/Parking.java#default https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
-java/lang/Thread/virtual/Parking.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
-java/lang/Thread/virtual/Parking.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
-java/lang/Thread/virtual/Parking.java#Xint https://github.com/eclipse-openj9/openj9/issues/21446 linux-s390x
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all


### PR DESCRIPTION
Re-enable JDK24+ `java/lang/Thread/virtual/Parking.java`

Related to
* https://github.com/eclipse-openj9/openj9/issues/21446

Signed-off-by: Jason Feng <fengj@ca.ibm.com>