### PR TITLE
Re-enable javax/management/MBeanServer/OldMBeanServerTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -140,8 +140,6 @@ sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/ad
 
 # jdk_jmx
 
-javax/management/MBeanServer/OldMBeanServerTest.java https://github.com/eclipse-openj9/openj9/issues/20777 generic-all
-
 ############################################################################
 
 # jdk_math


### PR DESCRIPTION
Related to: https://github.com/eclipse-openj9/openj9/pull/21954

Fixes: https://github.com/eclipse-openj9/openj9/issues/20777