### PR TITLE
JDK24+ exclude java/lang/Thread/virtual/Starvation.java on linux-ppc64le

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -160,6 +160,7 @@ java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LEGACY https://github.co
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
+java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21957 linux-ppc64le
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -160,6 +160,7 @@ java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LEGACY https://github.co
 java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21525 generic-all
 java/lang/Thread/virtual/RetryMonitorEnterWhenPinned.java https://github.com/eclipse-openj9/openj9/issues/21717 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/openj9/issues/16045 generic-all
+java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21957 linux-ppc64le
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all
 java/lang/Thread/virtual/SynchronizedNative.java#Xint https://github.com/eclipse-openj9/openj9/issues/21727 macosx-all,linux-ppc64le,aix-all


### PR DESCRIPTION
JDK24+ exclude `java/lang/Thread/virtual/Starvation.java` on `linux-ppc64le`

Signed-off-by: Jason Feng <fengj@ca.ibm.com>