### PR TITLE
Turn off auto failed test rerun for OpenJCEPlus test builds

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -216,7 +216,7 @@ def generateJobs(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets, jobParall
                     }
                 }
 
-                if (jobTestFlag.contains("FIPS") || (TARGET.contains("dev"))) {
+                if (jobTestFlag.contains("FIPS") || jobTestFlag.contains("OpenJCEPlus") || (TARGET.contains("dev"))) {
                     rerunIterations = 0
                 }
             } else if (params.VARIANT == "temurin") {


### PR DESCRIPTION
resolves: [internal issue](https://github.ibm.com/runtimes/automation/issues/471)