### PR TITLE
Update portable scc machine label for s390x z17

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -248,7 +248,7 @@ timestamps{
                 imageUploadMap = [
                     's390x_linux' : [
                                 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.next"],
+                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z17"],
                             ],
                     'ppc64le_linux' : [
                                 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p9"],
@@ -258,7 +258,7 @@ timestamps{
                 imagePullMap = [
                     's390x_linux' : [
                                 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.next"],
+                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z17"],
                             ],
                     'ppc64le_linux' : [
                                 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p9"],

--- a/external/sccSettings.mk
+++ b/external/sccSettings.mk
@@ -13,8 +13,8 @@
 ##############################################################################
 
 # - is shell metacharacter. In PLATFORM value, replace - with _
-export PORTABLE_SCC_COMBO_LIST_linux_390_64_z14=sw.os.rhel.9-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.next
-export PORTABLE_SCC_COMBO_LIST_linux_390_64_next=sw.os.rhel.9-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.next
+export PORTABLE_SCC_COMBO_LIST_linux_390_64_z14=sw.os.rhel.9-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z17
+export PORTABLE_SCC_COMBO_LIST_linux_390_64_next=sw.os.rhel.9-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z17
 
 export PORTABLE_SCC_COMBO_LIST_linux_ppc_64_p9=sw.os.rhel.9-hw.arch.ppc64le.p9 sw.os.rhel.9-hw.arch.ppc64le.p11
 export PORTABLE_SCC_COMBO_LIST_linux_ppc_64_p11=sw.os.rhel.9-hw.arch.ppc64le.p9 sw.os.rhel.9-hw.arch.ppc64le.p11


### PR DESCRIPTION
Update portable scc machine label for s390x z17