### PR TITLE
Removed machine label in perfConfig.json.

### DIFF
--- a/perf/config/hotspot/perfConfig.json
+++ b/perf/config/hotspot/perfConfig.json
@@ -4,7 +4,7 @@
         "TARGET":"testList TESTLIST=dacapo-h2",
         "BUILD_LIST": "perf/dacapo",
         "PLAT_MACHINE_MAP":[
-            {"x86-64_linux": "hw.arch.x86&&sw.os.linux&&ci.role.perf&&!test-docker-ubi9-x64-1"}
+            {"x86-64_linux": "hw.arch.x86&&sw.os.linux&&ci.role.perf"}
         ]
     }
 ]


### PR DESCRIPTION
Removed &&!test-docker-ubi9-x64-1 from
 {"x86-64_linux": "hw.arch.x86&&sw.os.linux&&ci.role.perf&&!test-docker-ubi9-x64-1"}
in perfConfig.json.

Fixes: #6314