### PR TITLE
Added NULL check for PLATFORMS values in AQA Test Pipeline

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -3,7 +3,7 @@
 import groovy.transform.Field
 
 def JDK_VERSIONS = params.JDK_VERSIONS.trim().split("\\s*,\\s*")
-def PLATFORMS = params.PLATFORMS.trim().split("\\s*,\\s*")
+def PLATFORMS = params.PLATFORMS ? params.PLATFORMS.trim().split("\\s*,\\s*") : ""
 def TARGETS = params.TARGETS ?: "Grinder"
 TARGETS = TARGETS.trim().split("\\s*,\\s*")
 def TEST_FLAG = (params.TEST_FLAG) ?: ""


### PR DESCRIPTION
Added ternary statment to check whether PLATFORMS is set and proceed accordingly.

Fixes: #6267