### PR TITLE
Remove machine info target from system playlists

### DIFF
--- a/system/daaLoadTest/playlist.xml
+++ b/system/daaLoadTest/playlist.xml
@@ -1,22 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<include>../system.mk</include>
-	<!-- 
-	Special target to get machine information. This target is in each subfolder playlist.xml.
-	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
-	<test>
-		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-			<level>extended</level>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
+
 	<!--  The following tests are specific to openj9 only -->
 	<test>
 		<testCaseName>DaaLoadTest_daa1_5m</testCaseName>

--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -6,7 +6,11 @@
 	In order to save machine resources, exclude jlm subfolder in parallel mode
 	To enable it, please update excludes array in JenkinsfileBase
 	-->
+	<!-- 
+	Special target to get machine information. This target is in each subfolder playlist.xml.
+	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	
+	<test>
 		<testCaseName>TestJlmLocal</testCaseName>
 		<disables>
 			<disable>

--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -6,23 +6,7 @@
 	In order to save machine resources, exclude jlm subfolder in parallel mode
 	To enable it, please update excludes array in JenkinsfileBase
 	-->
-	<!-- 
-	Special target to get machine information. This target is in each subfolder playlist.xml.
-	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
-	<test>
-		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-			<level>extended</level>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
-	<test>
+	
 		<testCaseName>TestJlmLocal</testCaseName>
 		<disables>
 			<disable>

--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -1,22 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<include>../system.mk</include>
-	<!--
-	Special target to get machine information. This target is in each subfolder playlist.xml.
-	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
-	<test>
-		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-			<level>extended</level>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
+
 	<test>
 		<testCaseName>LambdaLoadTest_HS_5m</testCaseName>
 		<variations>

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -1,22 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<include>../system.mk</include>
-	<!-- 
-	Special target to get machine information. This target is in each subfolder playlist.xml.
-	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
-	<test>
-		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-			<level>extended</level>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
+	
 	<test>
 		<testCaseName>MathLoadTest_all_5m</testCaseName>
 		<variations>

--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -1,22 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<include>../system.mk</include>
-	<!-- 
-	Special target to get machine information. This target is in each subfolder playlist.xml.
-	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
-	<test>
-		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-			<level>extended</level>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
+
 	<!-- Disabled from OpenJ9 on osx due to : https://github.com/eclipse-openj9/openj9/issues/4091 -->
 	<test>
 		<testCaseName>MauveSingleThrdLoad_J9_5m</testCaseName>

--- a/system/modularity/playlist.xml
+++ b/system/modularity/playlist.xml
@@ -6,22 +6,7 @@
 	In order to save machine resources, exclude modularity subfolder in parallel mode
 	To enable it, please update excludes array in JenkinsfileBase
 	-->
-	<!-- 
-	Special target to get machine information. This target is in each subfolder playlist.xml.
-	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
-	<test>
-		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-			<level>extended</level>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
+	
 	<!-- Tests below pertain to Java 9 Modularity -->
 	<test>
 		<testCaseName>CpMp_CpMp</testCaseName>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -1,22 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<include>../system.mk</include>
-	<!-- 
-	Special target to get machine information. This target is in each subfolder playlist.xml.
-	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
-	<test>
-		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-			<level>extended</level>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
+
 	<test>
 		<testCaseName>system_custom</testCaseName>
 		<variations>

--- a/system/security/playlist.xml
+++ b/system/security/playlist.xml
@@ -1,22 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<include>../system.mk</include>
-	<!-- 
-	Special target to get machine information. This target is in each subfolder playlist.xml.
-	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
-	<test>
-		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-			<level>extended</level>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
+	
 	<!--
 	We currently only run special.system in parallel mode and some subfolders do not have any system test in special level
 	In order to save machine resources, exclude sharedClasses subfolder in parallel mode

--- a/system/sharedClasses/playlist.xml
+++ b/system/sharedClasses/playlist.xml
@@ -6,22 +6,7 @@
 	In order to save machine resources, exclude sharedClasses subfolder in parallel mode
 	To enable it, please update excludes array in JenkinsfileBase
 	-->
-	<!--
-	Special target to get machine information. This target is in each subfolder playlist.xml.
-	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
-	<test>
-		<testCaseName>MachineInfo</testCaseName>
-		<command>$(JAVA_COMMAND) -cp $(JVM_TEST_ROOT)$(D)TKG$(D)bin$(D)TestKitGen.jar org.openj9.envInfo.EnvDetector MachineInfo; \
-	$(TEST_STATUS)</command>
-		<levels>
-			<level>sanity</level>
-			<level>extended</level>
-			<level>special</level>
-		</levels>
-		<groups>
-			<group>system</group>
-		</groups>
-	</test>
+	
 	<test>
 		<testCaseName>SharedClassesAPI</testCaseName>
 		<variations>


### PR DESCRIPTION
Removed machine info target from system playlists since it's already run in TKG level. 

Fixes: https://github.com/adoptium/aqa-tests/issues/6269