### PR TITLE
Re-enable CancelTimerWithContention

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -127,7 +127,6 @@ java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issue
 java/lang/Thread/ThreadSleepEvent.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
 java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/17399 generic-all
-java/lang/Thread/virtual/CancelTimerWithContention.java https://github.com/eclipse-openj9/openj9/issues/21037 generic-all
 java/lang/Thread/virtual/Collectable.java https://github.com/eclipse-openj9/openj9/issues/18463 linux-x64,windows-all
 java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le
 java/lang/Thread/virtual/JfrEvents.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -127,7 +127,6 @@ java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issue
 java/lang/Thread/ThreadSleepEvent.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
 java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/17399 generic-all
-java/lang/Thread/virtual/CancelTimerWithContention.java https://github.com/eclipse-openj9/openj9/issues/21037 generic-all
 java/lang/Thread/virtual/Collectable.java https://github.com/eclipse-openj9/openj9/issues/18463 linux-x64,windows-all
 java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le
 java/lang/Thread/virtual/JfrEvents.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all


### PR DESCRIPTION
Fixes: https://github.com/eclipse-openj9/openj9/issues/21683

Includes test marked excluded in https://github.com/eclipse-openj9/openj9/issues/21037

Related: https://github.com/eclipse-openj9/openj9/pull/22095