### PR TITLE
Exclude Zos from using default ssh key

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -802,6 +802,8 @@ def runTest( ) {
 						}
 					}
 				}
+			} else if (env.SPEC.startsWith('zos')) { 
+				makeTest("${RUNTEST_CMD}")
 			} else {
 				sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"], ignoreMissing: true) {
 					makeTest("${RUNTEST_CMD}")


### PR DESCRIPTION
Exclude Zos from using default ssh key

Closes https://github.com/adoptium/aqa-tests/issues/6348