### PR TITLE
Aggregate Perf log files in parent job

### DIFF
--- a/buildenv/jenkins/perfPipeline.groovy
+++ b/buildenv/jenkins/perfPipeline.groovy
@@ -139,18 +139,27 @@ def generateChildJobViaAutoGen(newJobName) {
 }
 
 def aggregateLogs(childJob) {
-        def jobInvocation = childJob.value.getRawBuild()
-        def buildId = jobInvocation.getNumber()
-        def name = childJob.value.getProjectName()
-        def childResult = childJob.value.getCurrentResult()
-        echo "${name} #${buildId} completed with status ${childResult}, copying logs..."
-        try {
-                timeout(time： 1， unit: 'HOURS') {
-                        copyArtifacts （projectName: "${name}" selector: specific("${buildId}"), filter: "**/${name}_${build_Id}.log"， target: "."）                       // drop it in parent CWD               
-                }
-                archiveArtifacts artifacts: "${name}_${buildId}.log", fingerprint: true, allowEmptyArchive: false
-        } catch (Exception e) {
-                echo 'Exception: ' + e.toString()
-                echo "Cannot copy ${name}_${build_Id}.log from ${name}."
-        }                                           
+    def run       = childJob.value            // RunWrapper
+    def buildId   = run.getNumber()
+    def name      = run.getProjectName()
+    def childResult = run.getCurrentResult()
+
+    echo "${name} #${buildId} completed with status ${childResult}, copying logs..."
+
+    try {
+        timeout(time: 1, unit: 'HOURS') {
+            copyArtifacts(
+                projectName: name,
+                selector: specific("${buildId}"),
+                filter: "**/${name}_${buildId}.log",
+                target: "."
+            )
+        }
+
+        archiveArtifacts artifacts: "${name}_${buildId}.log",
+                         fingerprint: true,
+                         allowEmptyArchive: false
+    } catch (Exception e) {
+        echo "Cannot copy ${name}_${buildId}.log from ${name}: ${e}"
+    }
 }

--- a/buildenv/jenkins/perfPipeline.groovy
+++ b/buildenv/jenkins/perfPipeline.groovy
@@ -138,11 +138,10 @@ def generateChildJobViaAutoGen(newJobName) {
     build job: 'Test_Job_Auto_Gen', parameters: jobParams, propagate: true
 }
 
-def aggregateLogs(childJob) {
-    def run       = childJob.value            // RunWrapper
-    def buildId   = run.getNumber()
-    def name      = run.getProjectName()
-    def childResult = run.getCurrentResult()
+def aggregateLogs(run) {
+    def buildId  = run.getRawBuild().getNumber()
+    def name     = run.getProjectName()
+    def result   = run.getCurrentResult()
 
     echo "${name} #${buildId} completed with status ${childResult}, copying logs..."
 

--- a/buildenv/jenkins/perfPipeline.groovy
+++ b/buildenv/jenkins/perfPipeline.groovy
@@ -139,24 +139,26 @@ def generateChildJobViaAutoGen(newJobName) {
 }
 
 def aggregateLogs(run) {
-        def buildId  = run.getRawBuild().getNumber()
-        def name     = run.getProjectName()
-        def result   = run.getCurrentResult()
+        node(env.SETUP_LABEL) {
+                def buildId  = run.getRawBuild().getNumber()
+                def name     = run.getProjectName()
+                def result   = run.getCurrentResult()
 
-        echo "${name} #${buildId} completed with status ${result}, copying logs..."
+                echo "${name} #${buildId} completed with status ${result}, copying logs..."
 
-        try {
-                timeout(time: 1, unit: 'HOURS') {
-                        copyArtifacts(
-                                projectName: name,
-                                selector: specific("${buildId}"),
-                                filter: "**/${name}_${buildId}.log",
-                                target: "."
-                        )
+                try {
+                        timeout(time: 1, unit: 'HOURS') {
+                                copyArtifacts(
+                                        projectName: name,
+                                        selector: specific("${buildId}"),
+                                        filter: "**/${name}_${buildId}.log",
+                                        target: "."
+                                )
+                        }
+
+                archiveArtifacts artifacts: "${name}_${buildId}.log", fingerprint: true, allowEmptyArchive: false
+                } catch (Exception e) {
+                        echo "Cannot copy ${name}_${buildId}.log from ${name}: ${e}"
                 }
-
-        archiveArtifacts artifacts: "${name}_${buildId}.log", fingerprint: true, allowEmptyArchive: false
-        } catch (Exception e) {
-                echo "Cannot copy ${name}_${buildId}.log from ${name}: ${e}"
         }
 }

--- a/buildenv/jenkins/perfPipeline.groovy
+++ b/buildenv/jenkins/perfPipeline.groovy
@@ -155,8 +155,8 @@ def aggregateLogs(run) {
                                         target: "."
                                 )
                         }
-
-                archiveArtifacts artifacts: "${name}_${buildId}.log", fingerprint: true, allowEmptyArchive: false
+                        archiveArtifacts artifacts: "${name}_${buildId}.log", fingerprint: true, allowEmptyArchive: false
+                        sh "rm -f '${name}_${buildId}.log'"
                 } catch (Exception e) {
                         echo "Cannot copy ${name}_${buildId}.log from ${name}: ${e}"
                 }

--- a/buildenv/jenkins/perfPipeline.groovy
+++ b/buildenv/jenkins/perfPipeline.groovy
@@ -139,26 +139,24 @@ def generateChildJobViaAutoGen(newJobName) {
 }
 
 def aggregateLogs(run) {
-    def buildId  = run.getRawBuild().getNumber()
-    def name     = run.getProjectName()
-    def result   = run.getCurrentResult()
+        def buildId  = run.getRawBuild().getNumber()
+        def name     = run.getProjectName()
+        def result   = run.getCurrentResult()
 
-    echo "${name} #${buildId} completed with status ${childResult}, copying logs..."
+        echo "${name} #${buildId} completed with status ${result}, copying logs..."
 
-    try {
-        timeout(time: 1, unit: 'HOURS') {
-            copyArtifacts(
-                projectName: name,
-                selector: specific("${buildId}"),
-                filter: "**/${name}_${buildId}.log",
-                target: "."
-            )
+        try {
+                timeout(time: 1, unit: 'HOURS') {
+                        copyArtifacts(
+                                projectName: name,
+                                selector: specific("${buildId}"),
+                                filter: "**/${name}_${buildId}.log",
+                                target: "."
+                        )
+                }
+
+        archiveArtifacts artifacts: "${name}_${buildId}.log", fingerprint: true, allowEmptyArchive: false
+        } catch (Exception e) {
+                echo "Cannot copy ${name}_${buildId}.log from ${name}: ${e}"
         }
-
-        archiveArtifacts artifacts: "${name}_${buildId}.log",
-                         fingerprint: true,
-                         allowEmptyArchive: false
-    } catch (Exception e) {
-        echo "Cannot copy ${name}_${buildId}.log from ${name}: ${e}"
-    }
 }


### PR DESCRIPTION
Fixes: #6328 
[Grinder](https://ci.adoptium.net/view/Test_grinder/job/Perf_Pipeline/27/)

Note: Still using .log as stated in #6328 description instead of .json, can another issue be opened to handle that for #6328 and #6327? 