### PR TITLE
Enable more DaCapo benchmarks in perf tests (Fixes #6268)

### DIFF
--- a/perf/config/hotspot/perfConfig.json
+++ b/perf/config/hotspot/perfConfig.json
@@ -1,7 +1,7 @@
 [
     {
         "BENCHMARK":"dacapo",
-        "TARGET":"testList TESTLIST=dacapo-h2",
+        "TARGET": "testList TESTLIST=dacapo-h2,dacapo-eclipse,dacapo-avrora,dacapo-fop,dacapo-luindex,dacapo-pmd,dacapo-sunflow,dacapo-xalan",
         "BUILD_LIST": "perf/dacapo",
         "PLAT_MACHINE_MAP":[
             {"x86-64_linux": "hw.arch.x86&&sw.os.linux&&ci.role.perf"}

--- a/perf/config/hotspot/perfConfig.json
+++ b/perf/config/hotspot/perfConfig.json
@@ -1,7 +1,7 @@
 [
     {
         "BENCHMARK":"dacapo",
-        "TARGET": "testList TESTLIST=dacapo-h2,dacapo-eclipse,dacapo-avrora,dacapo-fop,dacapo-luindex,dacapo-pmd,dacapo-sunflow,dacapo-xalan",
+        "TARGET": "testList TESTLIST=dacapo-h2,dacapo-avrora,dacapo-fop,dacapo-luindex,dacapo-pmd,dacapo-sunflow,dacapo-xalan",
         "BUILD_LIST": "perf/dacapo",
         "PLAT_MACHINE_MAP":[
             {"x86-64_linux": "hw.arch.x86&&sw.os.linux&&ci.role.perf"}


### PR DESCRIPTION
Updates `perfConfig.json` to include additional DaCapo test cases:

- dacapo-eclipse  
- dacapo-avrora  
- dacapo-fop  
- dacapo-luindex  
- dacapo-pmd  
- dacapo-sunflow  
- dacapo-xalan  

Closes: https://github.com/adoptium/aqa-tests/issues/6268  
Tested: https://ci.adoptium.net/job/Perf_Pipeline/