### PR TITLE
Allow user to set PerfConfig.json in Perf Pipeline

### DIFF
--- a/buildenv/jenkins/perfPipeline.groovy
+++ b/buildenv/jenkins/perfPipeline.groovy
@@ -36,9 +36,9 @@ params.each { param ->
 echo "All parameters and their current values:"
 params.each { k, v -> echo " - ${k} = '${v}'" }
 def perfConfigJson = []
-if (params.CONFIG_JSON) { 
-        echo "Read JSON from CONFIG_JSON parameter..." 
-        perfConfigJson = readJSON text: "${params.CONFIG_JSON}"
+if (params.PERFCONFIG_JSON) { 
+        echo "Read JSON from PERFCONFIG_JSON parameter..." 
+        perfConfigJson = readJSON text: "${params.PERFCONFIG_JSON}"
 } else { 
         node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
                 checkout scm

--- a/buildenv/jenkins/perfPipeline.groovy
+++ b/buildenv/jenkins/perfPipeline.groovy
@@ -33,8 +33,6 @@ params.each { param ->
 }
 
 // read JSON from perfConfig file
-echo "All parameters and their current values:"
-params.each { k, v -> echo " - ${k} = '${v}'" }
 def perfConfigJson = []
 if (params.PERFCONFIG_JSON) { 
         echo "Read JSON from PERFCONFIG_JSON parameter..." 

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -25,7 +25,6 @@ def getBaseJDKImpl(JDK_IMPL) {
 	return JDK_IMPL
 }
 
-if (!binding.hasVariable('PERFCONFIG_JSON')) PERFCONFIG_JSON = ""
 if (!binding.hasVariable('JDK_IMPL')) JDK_IMPL = "openj9"
 if (!binding.hasVariable('ARCHIVE_TEST_RESULTS')) ARCHIVE_TEST_RESULTS = false
 if (!binding.hasVariable('ARTIFACTORY_SERVER')) ARTIFACTORY_SERVER = ""
@@ -243,7 +242,6 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeader('Repositories where we pull test material from. Unless you are testing test code, these do not need to be changed.')
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
-                                                        stringParam('PERFCONFIG_JSON', PERFCONFIG_JSON, "set perfConfigJson")
 							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos.")
 							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch")
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -25,6 +25,7 @@ def getBaseJDKImpl(JDK_IMPL) {
 	return JDK_IMPL
 }
 
+if (!binding.hasVariable('PERFCONFIG_JSON')) PERFCONFIG_JSON = ""
 if (!binding.hasVariable('JDK_IMPL')) JDK_IMPL = "openj9"
 if (!binding.hasVariable('ARCHIVE_TEST_RESULTS')) ARCHIVE_TEST_RESULTS = false
 if (!binding.hasVariable('ARTIFACTORY_SERVER')) ARTIFACTORY_SERVER = ""
@@ -242,6 +243,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							    sectionHeader('Repositories where we pull test material from. Unless you are testing test code, these do not need to be changed.')
 							    sectionHeaderStyle(sectionHeaderHelpTextStyleCss)
 							}
+                                                        stringParam('PERFCONFIG_JSON', PERFCONFIG_JSON, "set perfConfigJson")
 							stringParam('ADOPTOPENJDK_REPO', ADOPTOPENJDK_REPO, "AdoptOpenJDK git repo. Please use ssh for zos.")
 							stringParam('ADOPTOPENJDK_BRANCH', ADOPTOPENJDK_BRANCH, "AdoptOpenJDK branch")
 							stringParam('OPENJ9_REPO', OPENJ9_REPO, "OpenJ9 git repo. Please use ssh for zos.")


### PR DESCRIPTION
Fixes: #6358 

[Grinder](https://ci.adoptium.net/view/Test_grinder/job/Perf_Pipeline/61/console)

updated testJobTemplate to support PERFCONFIG_JSON parameter, updated perfPipeline to use PERFCONFIG_JSON or default value