### PR TITLE
Set current build result based on Perf metrics.

### DIFF
--- a/buildenv/jenkins/perfPipeline.groovy
+++ b/buildenv/jenkins/perfPipeline.groovy
@@ -168,7 +168,7 @@ def generateChildJobViaAutoGen(newJobName) {
 
 def aggregateLogs(run, runtimes) {
         def json 
-        node(env.SETUP_LABEL) {
+        node(ci.role.test&&hw.arch.x86&&sw.os.linux) {
                 def buildId  = run.getRawBuild().getNumber()
                 def name = run.getProjectName()
                 def result = run.getCurrentResult()


### PR DESCRIPTION
Modified aggregateLogs to read JSON logs and save
accumulate the runtimes as doubles in lists.
The stats functions returns a map of performance
statistics based on those runtimes. At the end of
each iteration, score is calculated to determine
possible regression or #6330 EXIT_EARLY. 

Note: Implementation not very robust and contains
a few hardcoded assumptions, waiting for issues to extend #6327 and #6328 first.

Fixes: #6329