### PR TITLE
JDK24+ VT exclude selected test platforms

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -127,7 +127,7 @@ java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issue
 java/lang/Thread/ThreadSleepEvent.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
 java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/17399 generic-all
-java/lang/Thread/virtual/CancelTimerWithContention.java https://github.com/eclipse-openj9/openj9/issues/21824 linux-aarch64,linux-ppc64le,linux-s390x
+java/lang/Thread/virtual/CancelTimerWithContention.java https://github.com/eclipse-openj9/openj9/issues/21824 linux-aarch64,linux-ppc64le,linux-s390x,linux-x64
 java/lang/Thread/virtual/Collectable.java https://github.com/eclipse-openj9/openj9/issues/18463 linux-x64,windows-all
 java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le
 java/lang/Thread/virtual/JfrEvents.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
@@ -171,8 +171,8 @@ java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-open
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 generic-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
-java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#default https://github.com/eclipse-openj9/openj9/issues/21824 aix-all,linux-ppc64le,linux-s390x,macosx-all,windows-all
-java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21824 aix-all,linux-ppc64le,linux-s390x,macosx-all,windows-all
+java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#default https://github.com/eclipse-openj9/openj9/issues/21824 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-all
+java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21824 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21425 generic-all
 java/lang/Thread/virtual/stress/Skynet100kWithMonitors.java#id0 https://github.com/eclipse-openj9/openj9/issues/20705 generic-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -127,7 +127,7 @@ java/lang/Thread/SleepSanity.java https://github.com/eclipse-openj9/openj9/issue
 java/lang/Thread/ThreadSleepEvent.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
 java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/issues/6690 generic-all
 java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/17399 generic-all
-java/lang/Thread/virtual/CancelTimerWithContention.java https://github.com/eclipse-openj9/openj9/issues/21824 linux-aarch64,linux-ppc64le,linux-s390x
+java/lang/Thread/virtual/CancelTimerWithContention.java https://github.com/eclipse-openj9/openj9/issues/21824 linux-aarch64,linux-ppc64le,linux-s390x,linux-x64
 java/lang/Thread/virtual/Collectable.java https://github.com/eclipse-openj9/openj9/issues/18463 linux-x64,windows-all
 java/lang/Thread/virtual/CustomScheduler.java https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le
 java/lang/Thread/virtual/JfrEvents.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all


### PR DESCRIPTION
JDK24+ VT exclude selected test platforms

```
java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java - linux-aarch64
java/lang/Thread/virtual/CancelTimerWithContention.java - linux-x64
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>