### PR TITLE
Update portable scc combo list name for z17

### DIFF
--- a/external/sccSettings.mk
+++ b/external/sccSettings.mk
@@ -14,7 +14,7 @@
 
 # - is shell metacharacter. In PLATFORM value, replace - with _
 export PORTABLE_SCC_COMBO_LIST_linux_390_64_z14=sw.os.rhel.9-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z17
-export PORTABLE_SCC_COMBO_LIST_linux_390_64_next=sw.os.rhel.9-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z17
+export PORTABLE_SCC_COMBO_LIST_linux_390_64_z17=sw.os.rhel.9-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z17
 
 export PORTABLE_SCC_COMBO_LIST_linux_ppc_64_p9=sw.os.rhel.9-hw.arch.ppc64le.p9 sw.os.rhel.9-hw.arch.ppc64le.p11
 export PORTABLE_SCC_COMBO_LIST_linux_ppc_64_p11=sw.os.rhel.9-hw.arch.ppc64le.p9 sw.os.rhel.9-hw.arch.ppc64le.p11


### PR DESCRIPTION
Z17 has changed from next to z17, update it for combo list

Issue: [backlog 1542](https://github.ibm.com/runtimes/backlog/issues/1542#issuecomment-119163927)