### PR TITLE
Exclude robot test target on s390x_linux

### DIFF
--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -515,8 +515,8 @@
                                 <impl>openj9</impl>
                         </disable>
                         <disable>
-                                <comment>Disabled on aix and windows as no xvfb capable of robot interaction</comment>
-                                <platform>ppc64_aix|x86-64_windows|x86-32_windows|aarch64_windows</platform>
+                                <comment>Disabled on aix and windows as no xvfb capable of robot interaction, hangs on s390x</comment>
+                                <platform>ppc64_aix|x86-64_windows|x86-32_windows|aarch64_windows|s390x_linux</platform>
                                 <impl>hotspot</impl>
                         </disable>
                 </disables>


### PR DESCRIPTION
This target seems to be hanging on s390x_linux, so exclude and add those tests back into the 'manual' bucket.