### PR TITLE
Disable custom target

### DIFF
--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -26,7 +26,7 @@
 		</command>
 		<disables>
 			<disable>
-				<comment>Disabled temporarily for July 2025 release, if compiler testcases fail, auto-reruns will fail</comment>
+				<comment>Temp exclude for Jul_2025 release, if testcases fail, auto-reruns will fail</comment>
 				<impl>hotspot</impl>
 			</disable>
 		</disables>

--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -24,6 +24,12 @@
 		$(TEST_STATUS); \
 		$(GEN_SUMMARY_GENERIC) testsuite=COMPILER tests="$(JCKCOMPILER_CUSTOM_TARGET)" isCustomTarget="isCustomTarget"
 		</command>
+		<disables>
+            <disable>
+                <comment>Disabled temporarily for July 2025 release, if compiler testcases fail, auto-reruns will fail</comment>
+                <impl>hotspot</impl>
+            </disable>
+        </disables>
 		<levels>
 			<level>dev</level>
 		</levels>

--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -25,11 +25,11 @@
 		$(GEN_SUMMARY_GENERIC) testsuite=COMPILER tests="$(JCKCOMPILER_CUSTOM_TARGET)" isCustomTarget="isCustomTarget"
 		</command>
 		<disables>
-            <disable>
-                <comment>Disabled temporarily for July 2025 release, if compiler testcases fail, auto-reruns will fail</comment>
-                <impl>hotspot</impl>
-            </disable>
-        </disables>
+			<disable>
+				<comment>Disabled temporarily for July 2025 release, if compiler testcases fail, auto-reruns will fail</comment>
+				<impl>hotspot</impl>
+			</disable>
+		</disables>
 		<levels>
 			<level>dev</level>
 		</levels>


### PR DESCRIPTION
This test target has been observed to fail, during investigation, temporarily exclude.

With this target excluded, in the rare case that compiler testcases fail in an original run, they will not be able to be auto-rerun.  Since this does not happen often, it is better to exclude this target, than see it failing for an unknown reason during release.  Plan to investigate and fix when there is time after release period ends.