### PR TITLE
Exclude symantec test for JDK11 all platforms

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -69,6 +69,7 @@ sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/ad
 javax/net/ssl/SSLEngine/LargePacket.java https://bugs.openjdk.org/browse/JDK-8227651 generic-all
 javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java https://github.com/adoptium/aqa-tests/issues/2123 linux-all,macosx-all
 sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aqa-tests/issues/3811 windows-x86
+sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/6199#issuecomment-2809383179 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
https://github.com/adoptium/aqa-tests/issues/6199#issuecomment-2809383179

Should be excluded, its excluded for other JDK versions