### PR TITLE
Unexclude OpenJ9 vector jdk25 tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -544,15 +544,6 @@ java/util/stream/GatherersMapConcurrentTest.java https://github.com/eclipse-open
 
 # jdk_vector
 
-jdk/incubator/vector/Double256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/21945 generic-all
-jdk/incubator/vector/Double512VectorTests.java https://github.com/eclipse-openj9/openj9/issues/21945 generic-all
-jdk/incubator/vector/Double64VectorTests.java https://github.com/eclipse-openj9/openj9/issues/21945 generic-all
-jdk/incubator/vector/DoubleMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/21945 generic-all
-jdk/incubator/vector/Float256VectorTests.java https://github.com/eclipse-openj9/openj9/issues/21945 generic-all
-jdk/incubator/vector/Float512VectorTests.java https://github.com/eclipse-openj9/openj9/issues/21945 generic-all
-jdk/incubator/vector/Float64VectorTests.java https://github.com/eclipse-openj9/openj9/issues/21945 generic-all
-jdk/incubator/vector/FloatMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/21945 generic-all
-
 ############################################################################
 
 # svc_tools

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2724,12 +2724,6 @@
 	</test>
 	<test>
 		<testCaseName>jdk_vector_float128_j9</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/21945</comment>
-				<version>25+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xjit:{*Float128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
 		</variations>
@@ -2765,12 +2759,6 @@
 	</test>
 	<test>
 		<testCaseName>jdk_vector_double128_j9</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/21945</comment>
-				<version>25+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xjit:{*Double128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
 		</variations>


### PR DESCRIPTION
Closes https://github.com/eclipse-openj9/openj9/issues/21945
Related to https://github.com/adoptium/aqa-tests/pull/6426

xlinux tests pass in grinders with the latest JVM.
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/4460/
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/4463/