### PR TITLE
Enable java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -171,8 +171,6 @@ java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-open
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,linux-x64,macosx-all,windows-x64
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
-java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#default https://github.com/eclipse-openj9/openj9/issues/21824 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-all
-java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21824 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21425 generic-all
 java/lang/Thread/virtual/stress/Skynet100kWithMonitors.java#id0 https://github.com/eclipse-openj9/openj9/issues/20705 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,linux-x64,macosx-all,windows-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -173,8 +173,6 @@ java/lang/Thread/virtual/StackFrames.java https://github.com/eclipse-openj9/open
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,linux-x64,macosx-all,windows-x64
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/21182 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java#id0 https://github.com/eclipse-openj9/openj9/issues/21445 linux-ppc64le,aix-all
-java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#default https://github.com/eclipse-openj9/openj9/issues/21824 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-all
-java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java#LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/21824 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21425 generic-all
 java/lang/Thread/virtual/stress/Skynet100kWithMonitors.java#id0 https://github.com/eclipse-openj9/openj9/issues/20705 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,linux-x64,macosx-all,windows-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64


### PR DESCRIPTION
Enable `java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java`

Related to
* https://github.com/eclipse-openj9/openj9/issues/22153

Signed-off-by: Jason Feng <fengj@ca.ibm.com>