### PR TITLE
Add TrustAnchor to Solaris excludes

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -277,11 +277,13 @@ sun/security/tools/keytool/PSS.java https://github.com/adoptium/infrastructure/i
 sun/security/util/math/TestIntegerModuloP.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 javax/net/ssl/TLSCommon/TLSTest.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 sun/security/rsa/pss/SignatureTestPSS.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
+sun/security/pkcs11/Secmod/TrustAnchors.java https://github.com/adoptium/infrastructure/issues/3981 solaris-all
 sun/security/provider/DSA/SupportedDSAParamGen.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 sun/security/provider/DSA/TestAlgParameterGenerator.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
 sun/security/ssl/X509TrustManagerImpl/distrust/Camerfirma.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 sun/security/ssl/X509TrustManagerImpl/distrust/Entrust.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/6292 generic-all
+
 ############################################################################
 
 # jdk_security4


### PR DESCRIPTION
Plus some tidying. No tests were removed or added (except for TrustAnchor); they were alphabetised.

Resolves https://github.com/adoptium/aqa-tests/issues/6449