### PR TITLE
Restrict dacapo-luindex test to Java 11+

### DIFF
--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -109,12 +109,9 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-luindex</testCaseName>
-                <disables>
-                        <disable>
-                                <comment>https://github.com/adoptium/aqa-tests/issues/4858#issuecomment-2968494739</comment>
-                                <version>8</version>
-                        </disable>
-                </disables>
+		<versions>
+			<version>11+</version>
+		</versions>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) luindex; \
 		$(TEST_STATUS)</command>
 		<levels>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -109,9 +109,6 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-luindex</testCaseName>
-		<versions>
-			<version>11+</version>
-		</versions>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) luindex; \
 		$(TEST_STATUS)</command>
 		<levels>
@@ -120,6 +117,9 @@
 		<groups>
 			<group>perf</group>
 		</groups>
+		<versions>
+			<version>11+</version>
+		</versions>
 	</test>
 	<test>
 		<testCaseName>dacapo-lusearch-fix</testCaseName>


### PR DESCRIPTION
The luindex benchmark requires Java 11 or newer to run.
Java 8 is incompatible due to API limitations.

This change replaces the <disables> block with a <versions> block
to explicitly declare version support in the playlist file. 

Fixes: #4858