### PR TITLE
Fix Arctic dev.jck playback issues

### DIFF
--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -350,7 +350,7 @@ for i in "${active_versions[@]}"; do
 
             # Check testcase started successfully.
             ps -p $test_pid 2>/dev/null 1>&2
-            if [[ $? != 0 ]]; then
+            if [[ $skipped == true ]] || [[ $? != 0 ]]; then
               if [[ $skipped == false ]]; then
                 echo "ERROR: Test class failed prior to playback."
                 overallSuccess=false

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -363,7 +363,8 @@ ps -ef
 
             # Check testcase started successfully.
             ps -p $test_pid
-            if [[ $skipped == true ]] || [[ $? != 0 ]]; then
+            rc=$?
+            if [[ $skipped == true ]] || [[ $rc != 0 ]]; then
               if [[ $skipped == false ]]; then
                 echo "ERROR: Test class failed prior to playback."
                 overallSuccess=false

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -362,7 +362,7 @@ echo "after sleep ALL processes"
 ps -ef
 
             # Check testcase started successfully.
-            ps -p $test_pid 2>/dev/null 1>&2
+            ps -p $test_pid
             if [[ $skipped == true ]] || [[ $? != 0 ]]; then
               if [[ $skipped == false ]]; then
                 echo "ERROR: Test class failed prior to playback."

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -147,23 +147,6 @@ setupWindowsEnv() {
 
 JOPTIONS="-Djava.net.preferIPv4Stack=true -Djdk.attach.allowAttachSelf=true -Dsun.rmi.activation.execPolicy=none -Djdk.xml.maxXMLNameLimit=4000"
 
-if [ $(uname) = Linux ]; then
-    JENKINS_HOME_DIR=/home/jenkins
-    PPROP_LINE='s#arctic.common.repository.json.path.*$#arctic.common.repository.json.path = /home/jenkins/jck_run/arctic/linux/arctic_tests#g'
-    setupLinuxEnv
-
-elif [ $(uname) = Darwin ]; then
-    JENKINS_HOME_DIR="/Users/jenkins"
-    PPROP_LINE='s#arctic.common.repository.json.path.*$#arctic.common.repository.json.path = /Users/jenkins/jck_run/arctic/mac/arctic_tests#g'
-    setupMacEnv
-
-elif [ "$OS" = "Windows_NT" ]; then
-    JENKINS_HOME_DIR="c:/Users/jenkins"
-    PPROP_LINE='s#arctic.common.repository.json.path.*$#arctic.common.repository.json.path = c:/Users/jenkins/jck_run/arctic/windows/arctic_tests#g'
-    setupWindowsEnv
-
-fi
-
 # Verify that the contents are present in jck_run
 TEST_GROUP=$1
 SPEC=$2
@@ -178,10 +161,19 @@ fi
 OSNAME="Unknown"
 if [[ $SPEC =~ osx.* ]]; then
     OSNAME="mac"
+    JENKINS_HOME_DIR="/Users/jenkins"
+    PPROP_LINE='s#arctic.common.repository.json.path.*$#arctic.common.repository.json.path = /Users/jenkins/jck_run/arctic/mac/arctic_tests#g'
+    setupMacEnv
 elif [[ $SPEC =~ linux.* ]]; then
     OSNAME="linux"
+    JENKINS_HOME_DIR=/home/jenkins
+    PPROP_LINE='s#arctic.common.repository.json.path.*$#arctic.common.repository.json.path = /home/jenkins/jck_run/arctic/linux/arctic_tests#g'
+    setupLinuxEnv
 elif [[ $SPEC =~ win.* ]]; then
     OSNAME="windows"
+    JENKINS_HOME_DIR="c:/Users/jenkins"
+    PPROP_LINE='s#arctic.common.repository.json.path.*$#arctic.common.repository.json.path = c:/Users/jenkins/jck_run/arctic/windows/arctic_tests#g'
+    setupWindowsEnv
 fi
 
 ARCTIC_GROUP="${TEST_SUB_DIR}"

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -157,7 +157,7 @@ elif [ $(uname) = Darwin ]; then
     PPROP_LINE='s#arctic.common.repository.json.path.*$#arctic.common.repository.json.path = /Users/jenkins/jck_run/arctic/mac/arctic_tests#g'
     setupMacEnv
 
-elif [ $(uname) = Windows_NT ]; then
+elif [ "$OS" = "Windows_NT" ]; then
     JENKINS_HOME_DIR="c:/Users/jenkins"
     PPROP_LINE='s#arctic.common.repository.json.path.*$#arctic.common.repository.json.path = c:/Users/jenkins/jck_run/arctic/windows/arctic_tests#g'
     setupWindowsEnv

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -314,7 +314,12 @@ for i in "${active_versions[@]}"; do
             echo "       Testcase ${JCK_TEST} of scope ${i} ${ARCTIC_GROUP} ${ARCTIC_TESTCASE}"
             echo "         JCK class: ${TEST_CLASS}"
 
+   #'";C:\Users\jenkins\jck_root\JCK24-unzipped\JCK-runtime-24\classes;"' 
+if [ $OSNAME = "windows" ]; then
+            TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel -Dmultitest.testcaseOrder=sorted -classpath '\";${JCK_MATERIAL}/classes;\"' ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}"
+else
             TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel -Dmultitest.testcaseOrder=sorted -classpath :${JCK_MATERIAL}/classes: ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}"
+fi
 
             # Certain tests require extra options
             if [[ "${ARCTIC_TESTCASE}" =~ .*PageDialog.* ]] || [[ "${ARCTIC_TESTCASE}" =~ .*Print.* ]]; then

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -70,7 +70,7 @@ setupMacEnv() {
     export AWT_FORCE_HEADFUL=true
     echo "Setup Mac Environment"
 
-    # Temp fix, point to Temurin-21 installation
+    # Point to specific system installed Temurin-21
     export ARCTIC_JDK=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java
 
     cat <<EOF > JMinWindows.java
@@ -137,12 +137,9 @@ EOF
 
 setupWindowsEnv() {
     echo "Setup Windows Environment"
-    # Temp fix point to openjdk-21 installation
+
+    # Point to specific system installed openjdk-21
     ARCTIC_JDK=$(cygpath -u "c:/openjdk/jdk-21/bin/java")
-    #echo "Copying Arctic.jar Into Place"
-    #cp -rf /cygdrive/c/temp/arctic_jars/arctic-0.8.1.jar ${LIB_DIR}/arctic.jar
-    #cp -rf /cygdrive/c/temp/arctic_jars/JNativeHook-0.8.1.x86_64.dll ${LIB_DIR}/JNativeHook-0.8.1.x86_64.dll
-    #echo "Working directory: $(pwd)"
 }
 
 JOPTIONS="-Djava.net.preferIPv4Stack=true -Djdk.attach.allowAttachSelf=true -Dsun.rmi.activation.execPolicy=none -Djdk.xml.maxXMLNameLimit=4000"
@@ -246,7 +243,7 @@ echo "Java under test: $TEST_JDK_HOME"
 TOP_DIR=$JENKINS_HOME_DIR/jck_run/arctic/$OSNAME/arctic_tests
 echo "TEST_GROUP is $TEST_GROUP, OSNAME is $OSNAME, VERSION is $VERSION, STARTING_SCOPE is $STARTING_SCOPE"
 
-runTests=false
+hasRunTests=false
 overallSuccess=true
 FOUND_TESTS=()
 PASSED_TESTS=()
@@ -418,7 +415,7 @@ for i in "${active_versions[@]}"; do
                 fi
 
                 # Indicate we have run at least one arctic playback testcase
-                runTests=true
+                hasRunTests=true
 
                 # Get final Arctic status
                 result=$(${ARCTIC_JDK} -jar ${LIB_DIR}/arctic.jar -c test list ${ARCTIC_GROUP}/${ARCTIC_TESTCASE})
@@ -479,7 +476,7 @@ fi
 echo "Finished running testcases, overallSuccess = $overallSuccess"
 
 # Indicate failure if no overall success or no tests were run...
-if [[ $overallSuccess != true ]] || [[ $runTests != true ]]; then
+if [[ $overallSuccess != true ]] || [[ $hasRunTests != true ]]; then
     echo "Arctic playback failed"
     exit 1
 else

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -349,7 +349,7 @@ for i in "${active_versions[@]}"; do
             fi
 
             # Check testcase started successfully.
-            ps -p $test_pid -o pid 2>/dev/null 1>&2
+            ps -p $test_pid 2>/dev/null 1>&2
             if [[ $? != 0 ]]; then
               if [[ $skipped == false ]]; then
                 echo "ERROR: Test class failed prior to playback."
@@ -397,7 +397,7 @@ for i in "${active_versions[@]}"; do
                 sleep $SLEEP_TIME
 
                 echo "Testcase process $test_pid should have finished if successfully automated, getting test process completion status..."
-                if ps -p $test_pid -o pid; then
+                if ps -p $test_pid; then
                   echo "ERROR: Testcase process $test_pid is still running... terminating!"
                   kill -9 $test_pid
                 fi

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -319,7 +319,7 @@ for i in "${active_versions[@]}"; do
             elif [ $OSNAME = "mac" ]; then
                 TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel -Dmultitest.testcaseOrder=sorted -classpath :${JCK_MATERIAL}/classes: ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}"
             else
-                TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dmultitest.testcaseOrder=sorted -classpath :${JCK_MATERIAL}/classes: ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}
+                TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dmultitest.testcaseOrder=sorted -classpath :${JCK_MATERIAL}/classes: ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}"
             fi
 
             # Certain tests require extra options

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -344,22 +344,9 @@ for i in "${active_versions[@]}"; do
               echo "Testcase started process $test_pid"
             fi
 
-echo "ALL processes"
-ps -ef
-
-echo "process $test_pid"
-ps -p $test_pid
-
             if [[ $skipped == false ]]; then
               sleep $SLEEP_TIME
-echo "after sleep"
             fi
-
-echo "after sleep, process $test_pid"
-ps -p $test_pid
-echo "ps rc = $?"
-echo "after sleep ALL processes"
-ps -ef
 
             # Check testcase started successfully.
             ps -p $test_pid

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -314,12 +314,13 @@ for i in "${active_versions[@]}"; do
             echo "       Testcase ${JCK_TEST} of scope ${i} ${ARCTIC_GROUP} ${ARCTIC_TESTCASE}"
             echo "         JCK class: ${TEST_CLASS}"
 
-   #'";C:\Users\jenkins\jck_root\JCK24-unzipped\JCK-runtime-24\classes;"' 
-if [ $OSNAME = "windows" ]; then
-            TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel -Dmultitest.testcaseOrder=sorted -classpath '\";${JCK_MATERIAL}/classes;\"' ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}"
-else
-            TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel -Dmultitest.testcaseOrder=sorted -classpath :${JCK_MATERIAL}/classes: ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}"
-fi
+            if [ $OSNAME = "windows" ]; then
+                TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dmultitest.testcaseOrder=sorted -classpath '\";${JCK_MATERIAL}/classes;\"' ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}"
+            elif [ $OSNAME = "mac" ]; then
+                TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel -Dmultitest.testcaseOrder=sorted -classpath :${JCK_MATERIAL}/classes: ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}"
+            else
+                TEST_CMDLINE="${TEST_JDK_HOME}/bin/java -Dmultitest.testcaseOrder=sorted -classpath :${JCK_MATERIAL}/classes: ${TEST_CLASS} -TestDirURL file:${JCK_MATERIAL}/tests/${ARCTIC_GROUP}/${JCK_TESTCASE} -TestCaseID ${JCK_TEST}
+            fi
 
             # Certain tests require extra options
             if [[ "${ARCTIC_TESTCASE}" =~ .*PageDialog.* ]] || [[ "${ARCTIC_TESTCASE}" =~ .*Print.* ]]; then

--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -344,9 +344,22 @@ for i in "${active_versions[@]}"; do
               echo "Testcase started process $test_pid"
             fi
 
+echo "ALL processes"
+ps -ef
+
+echo "process $test_pid"
+ps -p $test_pid
+
             if [[ $skipped == false ]]; then
               sleep $SLEEP_TIME
+echo "after sleep"
             fi
+
+echo "after sleep, process $test_pid"
+ps -p $test_pid
+echo "ps rc = $?"
+echo "after sleep ALL processes"
+ps -ef
 
             # Check testcase started successfully.
             ps -p $test_pid 2>/dev/null 1>&2


### PR DESCRIPTION
Fix various issues with running Arctic playback of jck test cases:
- OS detection was incorrect for Windows
- Arctic itself must be run using a specific latest Temurin jdk-21+, which needs to be installed on the target nodes:
  - Linux: /usr/bin/java
  - Mac: /Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home 
  - Windows: c:/openjdk/jdk-21
- If an Arctic glitch occurred and testcases were not run at all, the job was returning SUCCESS, ensure testcases are actually run... and overall success flag is set properly
- The Testcase launch command was incorrect for the various platforms
- The Testcase process detection logic was incorrect for Windows
- 