### PR TITLE
Exclude nonblockers from july 2025 release

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -243,7 +243,7 @@
 
 	<target name="dist" depends="getJtreg, getOpenjdk" description="generate the distribution">
 		<copy todir="${DEST}">
-			<fileset dir="${src}" includes="*.xml,excludes/ProblemList*.txt,*.mk"/>
+			<fileset dir="${src}" includes="*.xml,excludes/ProblemList*.txt,excludes/alpine/ProblemList*.txt,*.mk"/>
 		</copy>
 	</target>
 

--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -46,10 +46,7 @@ compiler/aot/verification/vmflags/NotTrackedFlagTest.java 8215224 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 # java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
 java/lang/String/StringRepeat.java#id1 https://github.com/adoptium/aqa-tests/issues/1272 windows-all
-# java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-# java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
-java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64,linux-all
-java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
 
 ############################################################################
 
@@ -59,8 +56,6 @@ sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adopti
 sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
-# alpine-linux https://github.com/adoptium/aqa-tests/issues/3238
-sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/aqa-tests/issues/3238 linux-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -54,9 +54,6 @@ java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/String/StringRepeat.java#id1 https://bugs.openjdk.java.net/browse/JDK-8221400 windows-x86
-# java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 generic-all
-java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 generic-all
 java/lang/StringBuffer/HugeCapacity.java https://bugs.openjdk.org/browse/JDK-8279954 windows-all
 java/lang/StringBuilder/HugeCapacity.java https://bugs.openjdk.org/browse/JDK-8279954 windows-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
@@ -455,6 +452,7 @@ compiler/loopopts/TestPredicateInputBelowLoopPredicate.java https://github.com/a
 compiler/print/PrintInlining.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/loopopts/TestRemoveEmptyLoop.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/loopopts/superword/TestEliminateAllocationWithCastP2XUse.java https://github.com/adoptium/aqa-tests/issues/6459 windows-x86
 
 # jdk_container/hotspot_container
 

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -62,10 +62,7 @@ java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tes
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
-# java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
-# java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
-java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
 java/lang/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8313260 linux-arm
 java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
@@ -248,9 +245,7 @@ sun/security/ssl/X509TrustManagerImpl/distrust/Entrust.java https://github.com/a
 
 # jdk_security4
 
-# Cleaners.java issue is specific to alpine-linux, but there appears to be no way to exclude on alpine-linux platform specifically
-# sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
-sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all,linux-all
+sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all
 
 ###########################################################################
 
@@ -466,8 +461,11 @@ runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tes
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5920 windows-aarch64
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
+runtime/memory/ReadFromNoaccessArea.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
+runtime/memory/ReserveMemory.java https://github.com/adoptium/aqa-tests/issues/5920 windows-aarch64
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all
@@ -514,4 +512,5 @@ serviceability/sa/ClhsdbWhere.java https://github.com/adoptium/aqa-tests/issues/
 serviceability/sa/TestJhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/TestClhsdbJstackLock.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/jvmti/RedefineClasses/RedefineSharedClass.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
+serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -73,10 +73,7 @@ java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tes
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
-# java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
-# java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
-java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
 java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 
@@ -221,6 +218,7 @@ java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/ado
 # java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
 java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java https://github.com/eclipse-openj9/openj9/issues/21959 windows-x64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
 java/nio/charset/spi/CharsetProviderBasicTest.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
@@ -257,9 +255,7 @@ sun/security/ssl/X509TrustManagerImpl/distrust/Entrust.java https://github.com/a
 
 # jdk_security4
 
-# Cleaners.java issue is specific to alpine-linux, but there appears to be no way to exclude on alpine-linux platform specifically
-# sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
-sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all,linux-all
+sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all
 
 ###########################################################################
 
@@ -506,7 +502,8 @@ runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-833755
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64
+# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/infrastructure/issues/3984 macosx-aarch64, linux-riscv64, linux-ppc64le
+runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-aarch64,linux-riscv64,linux-ppc64le
 runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64

--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -73,10 +73,7 @@ java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tes
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
-# java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
-# java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
-java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
 java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 
@@ -221,6 +218,7 @@ java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/ado
 # java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
 java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
+java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java https://github.com/eclipse-openj9/openj9/issues/21959 windows-x64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
 java/nio/charset/spi/CharsetProviderBasicTest.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
@@ -256,9 +254,7 @@ sun/security/ssl/X509TrustManagerImpl/distrust/Camerfirma.java https://github.co
 
 # jdk_security4
 
-# Cleaners.java issue is specific to alpine-linux, but there appears to be no way to exclude on alpine-linux platform specifically
-# sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
-sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all,linux-all
+sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all
 
 ###########################################################################
 
@@ -372,6 +368,7 @@ compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/is
 # compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/intrinsics/TestContinuationPinningAndEA.java https://bugs.openjdk.org/browse/JDK-8349193 linux-s390x
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/tiered/TieredLevelsTest.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
@@ -488,7 +485,8 @@ runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-833755
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64
+# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/infrastructure/issues/3984 macosx-aarch64, linux-riscv64, linux-ppc64le
+runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-aarch64,linux-riscv64,linux-ppc64le
 runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -140,8 +140,7 @@ java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-t
 # jdk_lang
 
 java/lang/Math/HypotTests.java https://github.com/adoptium/aqa-tests/issues/128 linux-all
-# java/lang/ProcessBuilder/Basic.java same issue with alpine linux, exclude by linux-all for now
-java/lang/ProcessBuilder/Basic.java https://bugs.openjdk.org/browse/JDK-8282219 aix-all,solaris-x64,linux-all
+java/lang/ProcessBuilder/Basic.java https://bugs.openjdk.org/browse/JDK-8282219 aix-all,solaris-x64
 java/lang/invoke/MethodHandles/CatchExceptionTest.java https://bugs.openjdk.java.net/browse/JDK-8146623 linux-s390x,linux-arm
 java/lang/instrument/BootClassPath/BootClassPathTest.sh https://bugs.openjdk.java.net/browse/JDK-8256405 macosx-all
 
@@ -157,8 +156,8 @@ sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adopti
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://bugs.openjdk.org/browse/JDK-8205653 generic-all
 sun/management/jmxremote/bootstrap/RmiRegistrySslTest.sh https://bugs.openjdk.org/browse/JDK-8205653 generic-all
-# alpine-linux https://github.com/adoptium/aqa-tests/issues/3238
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://bugs.openjdk.java.net/browse/JDK-8031420 linux-all
+sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.sh https://github.com/adoptium/aqa-tests/issues/5917 solaris-x64
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java https://bugs.openjdk.org/browse/JDK-8274337 generic-all
 ############################################################################
@@ -248,6 +247,7 @@ sun/security/pkcs11/ec/TestECGenSpec.java https://github.com/adoptium/aqa-tests/
 sun/security/pkcs11/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/issues/68 linux-all
 sun/security/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/issues/68 generic-all
 com/sun/crypto/provider/Mac/MacClone.java https://bugs.openjdk.java.net/browse/JDK-7087021 solaris-all
+javax/net/ssl/ciphersuites/DisabledAlgorithms.java https://github.com/adoptium/aqa-tests/issues/5915 solaris-x64
 javax/net/ssl/ServerName/BestEffortOnLazyConnected.java https://bugs.openjdk.org/browse/JDK-8155049 solaris-x64
 javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java https://bugs.openjdk.org/browse/JDK-8212096 solaris-x64
 javax/net/ssl/Stapling/HttpsUrlConnClient.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9

--- a/openjdk/excludes/alpine/ProblemList_openjdk11_alpine.txt
+++ b/openjdk/excludes/alpine/ProblemList_openjdk11_alpine.txt
@@ -1,0 +1,19 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+jdk/jshell/ExternalEditorTest.java https://github.com/adoptium/aqa-tests/issues/6458 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/aqa-tests/issues/3238 linux-all
+

--- a/openjdk/excludes/alpine/ProblemList_openjdk17_alpine.txt
+++ b/openjdk/excludes/alpine/ProblemList_openjdk17_alpine.txt
@@ -1,0 +1,18 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+jdk/jshell/ExternalEditorTest.java https://github.com/adoptium/aqa-tests/issues/6458 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+

--- a/openjdk/excludes/alpine/ProblemList_openjdk21_alpine.txt
+++ b/openjdk/excludes/alpine/ProblemList_openjdk21_alpine.txt
@@ -1,0 +1,19 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+jdk/jshell/ExternalEditorTest.java https://github.com/adoptium/aqa-tests/issues/6458 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
+

--- a/openjdk/excludes/alpine/ProblemList_openjdk24_alpine.txt
+++ b/openjdk/excludes/alpine/ProblemList_openjdk24_alpine.txt
@@ -1,0 +1,19 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+jdk/jshell/ExternalEditorTest.java https://github.com/adoptium/aqa-tests/issues/6458 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
+

--- a/openjdk/excludes/alpine/ProblemList_openjdk25_alpine.txt
+++ b/openjdk/excludes/alpine/ProblemList_openjdk25_alpine.txt
@@ -1,0 +1,19 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+jdk/jshell/ExternalEditorTest.java https://github.com/adoptium/aqa-tests/issues/6458 linux-all
+java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
+sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
+

--- a/openjdk/excludes/alpine/ProblemList_openjdk8_alpine.txt
+++ b/openjdk/excludes/alpine/ProblemList_openjdk8_alpine.txt
@@ -1,0 +1,18 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+sun/tools/native2ascii/Native2AsciiTests.sh https://github.com/adoptium/aqa-tests/issues/5893 linux-x64
+java/lang/ProcessBuilder/Basic.java https://bugs.openjdk.org/browse/JDK-8282219 linux-all
+sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/aqa-tests/issues/3238 linux-all
+

--- a/openjdk/excludes/alpine/README.md
+++ b/openjdk/excludes/alpine/README.md
@@ -1,0 +1,14 @@
+## Alpine Exclude Files
+
+These exclude files are used **in addition to** to the usual ProblemList_openjdk##.txt file, but only on Alpine.
+
+This is done this way because JTReg currently has no mechanism for excluding a test on Alpine linux only.
+
+Users are advised to use these platforms:
+
+- linux-all
+- linux-x64
+- linux-aarch64
+
+**Caution:** If a test is excluded in the usual ProblemList as well, then this may supersede that exclusion during Alpine testing.
+So if I exclude a test on linux-all in the usual ProblemList, and then exclude it here on linux-x64, then this test will run on aarch64 Alpine.

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -246,17 +246,17 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 endif
 
 # If we are on alpine, also use the exclude file specific to alpine.
-ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_ROOT)$(D)..$(D)jvmtest$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
+ALPINE_PROBLEM_LIST_FILE:=$(TEST_ROOT)$(D)..$(D)jvmtest$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt
 ifneq (,$(findstring alpine, $(SPEC)))
-	ifneq (,$(wildcard $(ALPINE_PROBLEM_LIST_FILE)))
+	ifneq (,$(wildcard $(realpath ALPINE_PROBLEM_LIST_FILE)))
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
-			FEATURE_PROBLEM_LIST_FILE:=-exclude:$(ALPINE_PROBLEM_LIST_FILE)
+			FEATURE_PROBLEM_LIST_FILE:=-exclude:$(Q)$(ALPINE_PROBLEM_LIST_FILE)$(Q)
 		else
-			FEATURE_PROBLEM_LIST_FILE+=-exclude:$(ALPINE_PROBLEM_LIST_FILE)
+			FEATURE_PROBLEM_LIST_FILE+=-exclude:$(Q)$(ALPINE_PROBLEM_LIST_FILE)$(Q)
 		endif
 	else
 		# Using a dummy variable here so we can produce the message while avoiding this fatal error: "recipe commences before first target"
-		DUMMY_VAR:=$(warning Warning: An Alpine-specific ProblemList could not be found here: $(ALPINE_PROBLEM_LIST_FILE))
+		DUMMY_VAR:=$(warning Warning: An Alpine-specific ProblemList could not be found here: $(Q)$(ALPINE_PROBLEM_LIST_FILE)$(Q))
 	endif
 endif
 

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -257,6 +257,7 @@ ifneq (,$(findstring alpine, $(SPEC)))
 	else
 		# Using a dummy variable here so we can produce the message while avoiding this fatal error: "recipe commences before first target"
 		DUMMY_VAR:=$(warning Warning: We are running on Alpine, but could not find an Alpine-specific ProblemList.)
+		DUMMY_VAR:=$(warning Attempted to find the alpine problemlist here: $(ALPINE_PROBLEM_LIST_FILE))
 	endif
 endif
 

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -246,9 +246,9 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 endif
 
 # If we are on alpine, also use the exclude file specific to alpine.
-ALPINE_PROBLEM_LIST_FILE:=$(TEST_ROOT)$(D)..$(D)jvmtest$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt
+ALPINE_PROBLEM_LIST_FILE:=$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt
 ifneq (,$(findstring alpine, $(SPEC)))
-	ifneq (,$(wildcard $(realpath ALPINE_PROBLEM_LIST_FILE)))
+	ifneq (,$(realpath $(ALPINE_PROBLEM_LIST_FILE))
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
 			FEATURE_PROBLEM_LIST_FILE:=-exclude:$(Q)$(ALPINE_PROBLEM_LIST_FILE)$(Q)
 		else

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -246,7 +246,7 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 endif
 
 # If we are on alpine, also use the exclude file specific to alpine.
-ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_ROOT)$(D)..$(D)jvmtest$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
+ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_ROOT)$(D)..$(D)jvmtest$(D)openjdk$(D)excludes$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
 ifneq (,$(findstring alpine, $(SPEC)))
 	ifneq (,$(wildcard $(ALPINE_PROBLEM_LIST_FILE)))
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -248,7 +248,7 @@ endif
 # If we are on alpine, also use the exclude file specific to alpine.
 ALPINE_PROBLEM_LIST_FILE:=$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt
 ifneq (,$(findstring alpine, $(SPEC)))
-	ifneq (,$(realpath $(ALPINE_PROBLEM_LIST_FILE))
+	ifneq (,$(realpath $(ALPINE_PROBLEM_LIST_FILE)))
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
 			FEATURE_PROBLEM_LIST_FILE:=-exclude:$(Q)$(ALPINE_PROBLEM_LIST_FILE)$(Q)
 		else

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -248,7 +248,7 @@ endif
 # If we are on alpine, also use the exclude file specific to alpine.
 FEATURE_PROBLEM_LIST_FILE:=debug0
 ifneq (,$(findstring alpine, $(SPEC)))
-	FEATURE_PROBLEM_LIST_FILE:=debug1
+	FEATURE_PROBLEM_LIST_FILE:=debug1-$(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
 	ifneq (,$(wildcard $($(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q))))
 		FEATURE_PROBLEM_LIST_FILE:=debug2
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -246,7 +246,7 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 endif
 
 # If we are on alpine, also use the exclude file specific to alpine.
-ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_ROOT)$(D)..$(D)jvmtest$(D)openjdk$(D)excludes$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
+ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_ROOT)$(D)..$(D)jvmtest$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
 ifneq (,$(findstring alpine, $(SPEC)))
 	ifneq (,$(wildcard $(ALPINE_PROBLEM_LIST_FILE)))
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -246,8 +246,11 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 endif
 
 # If we are on alpine, also use the exclude file specific to alpine.
+FEATURE_PROBLEM_LIST_FILE:=debug0
 ifneq (,$(findstring alpine, $(SPEC)))
+	FEATURE_PROBLEM_LIST_FILE:=debug1
 	ifneq (,$(wildcard $($(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q))))
+		FEATURE_PROBLEM_LIST_FILE:=debug2
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
 			FEATURE_PROBLEM_LIST_FILE:=-exclude:$(Q)$(TEST_ROOT)$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
 		else

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -246,7 +246,7 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 endif
 
 # If we are on alpine, also use the exclude file specific to alpine.
-ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
+ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_RESROOT)$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
 ifneq (,$(findstring alpine, $(SPEC)))
 	ifneq (,$(wildcard $(ALPINE_PROBLEM_LIST_FILE)))
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
@@ -256,8 +256,7 @@ ifneq (,$(findstring alpine, $(SPEC)))
 		endif
 	else
 		# Using a dummy variable here so we can produce the message while avoiding this fatal error: "recipe commences before first target"
-		DUMMY_VAR:=$(warning Warning: We are running on Alpine, but could not find an Alpine-specific ProblemList.)
-		DUMMY_VAR:=$(warning Attempted to find the alpine problemlist here: $(ALPINE_PROBLEM_LIST_FILE))
+		DUMMY_VAR:=$(warning Warning: An Alpine-specific ProblemList could not be found here: $(ALPINE_PROBLEM_LIST_FILE))
 	endif
 endif
 

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -246,16 +246,11 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 endif
 
 # If we are on alpine, also use the exclude file specific to alpine.
-FEATURE_PROBLEM_LIST_FILE:=debug0
 ifneq (,$(findstring alpine, $(SPEC)))
-	FEATURE_PROBLEM_LIST_FILE:=debug1-$(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
-	ifneq (,$(wildcard $($(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q))))
-		FEATURE_PROBLEM_LIST_FILE:=debug2
-		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
-			FEATURE_PROBLEM_LIST_FILE:=-exclude:$(Q)$(TEST_ROOT)$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
-		else
-			FEATURE_PROBLEM_LIST_FILE+=-exclude:$(Q)$(TEST_ROOT)$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
-		endif
+	ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
+		FEATURE_PROBLEM_LIST_FILE:=-exclude:$(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
+	else
+		FEATURE_PROBLEM_LIST_FILE+=-exclude:$(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
 	endif
 endif
 

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -246,7 +246,7 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 endif
 
 # If we are on alpine, also use the exclude file specific to alpine.
-ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_RESROOT)$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
+ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_ROOT)$(D)..$(D)jvmtest$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
 ifneq (,$(findstring alpine, $(SPEC)))
 	ifneq (,$(wildcard $(ALPINE_PROBLEM_LIST_FILE)))
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -245,6 +245,17 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 	FEATURE_PROBLEM_LIST_FILE:=-exclude:$(Q)$(JTREG_JDK_TEST_DIR)$(D)ProblemList-OpenJCEPlus.txt$(Q)
 endif
 
+# If we are on alpine, also use the exclude file specific to alpine.
+ifneq (,$(findstring alpine, $(SPEC)))
+	ifneq (,$(wildcard $($(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q))))
+		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
+			FEATURE_PROBLEM_LIST_FILE:=-exclude:$(Q)$(TEST_ROOT)$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
+		else
+			FEATURE_PROBLEM_LIST_FILE+=-exclude:$(Q)$(TEST_ROOT)$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
+		endif
+	endif
+endif
+
 VENDOR_PROBLEM_LIST_FILE:=
 ifeq ($(JDK_VENDOR),$(filter $(JDK_VENDOR),redhat azul alibaba microsoft eclipse))
 	VENDOR_FILE:=excludes$(D)vendors$(D)$(JDK_VENDOR)$(D)ProblemList_openjdk$(JDK_VERSION).txt

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -254,6 +254,8 @@ ifneq (,$(findstring alpine, $(SPEC)))
 		else
 			FEATURE_PROBLEM_LIST_FILE+=-exclude:$(ALPINE_PROBLEM_LIST_FILE)
 		endif
+	else
+		$(warning We are running on Alpine, but could not find an Alpine-specific ProblemList.)
 	endif
 endif
 

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -246,11 +246,14 @@ else ifneq (,$(findstring OpenJCEPlus, $(TEST_FLAG)))
 endif
 
 # If we are on alpine, also use the exclude file specific to alpine.
+ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
 ifneq (,$(findstring alpine, $(SPEC)))
-	ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
-		FEATURE_PROBLEM_LIST_FILE:=-exclude:$(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
-	else
-		FEATURE_PROBLEM_LIST_FILE+=-exclude:$(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
+	ifneq(,$(wildcard $(ALPINE_PROBLEM_LIST_FILE)))
+		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
+			FEATURE_PROBLEM_LIST_FILE:=-exclude:$(ALPINE_PROBLEM_LIST_FILE)
+		else
+			FEATURE_PROBLEM_LIST_FILE+=-exclude:$(ALPINE_PROBLEM_LIST_FILE)
+		endif
 	endif
 endif
 

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -248,7 +248,7 @@ endif
 # If we are on alpine, also use the exclude file specific to alpine.
 ALPINE_PROBLEM_LIST_FILE:=$(Q)$(TEST_ROOT)$(D)openjdk$(D)excludes$(D)alpine$(D)ProblemList_openjdk$(JDK_VERSION)_alpine.txt$(Q)
 ifneq (,$(findstring alpine, $(SPEC)))
-	ifneq(,$(wildcard $(ALPINE_PROBLEM_LIST_FILE)))
+	ifneq (,$(wildcard $(ALPINE_PROBLEM_LIST_FILE)))
 		ifeq (,$(FEATURE_PROBLEM_LIST_FILE))
 			FEATURE_PROBLEM_LIST_FILE:=-exclude:$(ALPINE_PROBLEM_LIST_FILE)
 		else

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -255,7 +255,8 @@ ifneq (,$(findstring alpine, $(SPEC)))
 			FEATURE_PROBLEM_LIST_FILE+=-exclude:$(ALPINE_PROBLEM_LIST_FILE)
 		endif
 	else
-		$(warning We are running on Alpine, but could not find an Alpine-specific ProblemList.)
+		# Using a dummy variable here so we can produce the message while avoiding this fatal error: "recipe commences before first target"
+		DUMMY_VAR:=$(warning Warning: We are running on Alpine, but could not find an Alpine-specific ProblemList.)
 	endif
 endif
 


### PR DESCRIPTION
And add the ability to exclude tests on Alpine-only

Test runs:
- Non-Alpine: https://ci.adoptium.net/job/Grinder/13810/ - Passed, no extra exclude file.
- Alpine: https://ci.adoptium.net/job/Grinder/13809/ - Passed, exclude file added.
- Alpine with excluded file in target: https://ci.adoptium.net/job/Grinder/13813/ - Passed, excluded test was not run.

Resolves https://github.com/adoptium/aqa-tests/issues/6451