### PR TITLE
Exclude few tests on JDK17/21/25 on z/OS which are not supported

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -265,6 +265,7 @@ java/nio/channels/FileChannel/TempDirectBuffersReclamation.java https://github.c
 java/nio/channels/FileChannel/directio/WriteDirect.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/nio/channels/Pipe/PipeInterrupt.java https://github.com/eclipse-openj9/openj9/issues/18479 windows-all
 java/nio/channels/Selector/OutOfBand.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
+java/nio/channels/Selector/OutOfBand.java#id0 https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse-openj9/openj9/issues/4317 macosx-all
 java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java https://github.com/eclipse-openj9/openj9/issues/21959 windows-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -304,6 +304,10 @@ java/nio/channels/etc/NetworkChannelTests.java https://github.ibm.com/runtimes/b
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.ibm.com/runtimes/backlog/issues/684 generic-all
 java/nio/channels/FileChannel/Transfer.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/FileChannel/TransferTo6GBFile.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
+java/nio/channels/FileChannel/directio/PreadDirect.java https://github.com/adoptium/aqa-tests/issues/6447 z/OS-s390x
+java/nio/channels/FileChannel/directio/PwriteDirect.java https://github.com/adoptium/aqa-tests/issues/6447 z/OS-s390x
+java/nio/channels/FileChannel/directio/ReadDirect.java https://github.com/adoptium/aqa-tests/issues/6447 z/OS-s390x
+java/nio/channels/FileChannel/directio/WriteDirect.java https://github.com/adoptium/aqa-tests/issues/6447 z/OS-s390x
 java/nio/channels/Pipe/PipeInterrupt.java https://github.com/eclipse-openj9/openj9/issues/18479 windows-all
 java/nio/channels/Selector/Alias.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/Selector/BasicAccept.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
@@ -382,7 +386,9 @@ javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java	https://github.ibm.com/ru
 javax/net/ssl/SSLEngine/LargePacket.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all,aix-all,windows-all
 javax/net/ssl/SSLSocket/Tls13PacketSize.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 javax/net/ssl/TLSv11/TLSEnginesClosureTest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
+sun/security/ec/SignatureParameters.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
+sun/security/ec/ed/TestEdDSA.java https://github.com/adoptium/aqa-tests/issues/6447 z/OS-s390x
 sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
 sun/security/mscapi/CastError.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 sun/security/mscapi/CngCipher.java 	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
@@ -524,6 +530,7 @@ java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
+java/foreign/TestFallbackLookup.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
 java/foreign/TestHandshake.java https://github.com/eclipse-openj9/openj9/issues/13211 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -434,6 +434,7 @@ javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java	https://github.com/adopti
 javax/net/ssl/SSLEngine/LargePacket.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all,aix-all,windows-all
 javax/net/ssl/SSLSocket/Tls13PacketSize.java	https://github.ibm.com/runtimes/backlog/issues/795	windows-all
 javax/net/ssl/TLSv11/TLSEnginesClosureTest.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all
+sun/security/ec/SignatureParameters.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/pkcs12/AttributesMultiThread.java https://github.com/eclipse-openj9/openj9/issues/21696 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-all,windows-x64
 sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
@@ -596,6 +597,7 @@ java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
+java/foreign/TestFallbackLookup.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestBufferStack.java https://github.com/eclipse-openj9/openj9/issues/21944 generic-all
 java/foreign/TestFill.java https://github.com/eclipse-openj9/openj9/issues/22219 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all


### PR DESCRIPTION
This PR is to exclude few tests mentioned in https://github.com/adoptium/aqa-tests/issues/6447 which are not supported on z/OS. 
