### PR TITLE
Execute OpenJCEPlus testing on all Semeru arch

### DIFF
--- a/buildenv/jenkins/config/openj9/release/default.json
+++ b/buildenv/jenkins/config/openj9/release/default.json
@@ -23,20 +23,26 @@
     {
         "TEST_FLAG" : "FIPS140_3_OpenJCEPlusFIPS",
         "PLATFORM_TARGETS" : [
+            { "aarch64_linux" : "defaultFipsTestTargets" },
+            { "aarch64_mac" : "defaultFipsTestTargets" },
             { "ppc64_aix" : "defaultFipsTestTargets" },
             { "ppc64le_linux" : "defaultFipsTestTargets" },
             { "s390x_linux" : "defaultFipsTestTargets" },
             { "x86-64_linux" : "defaultFipsTestTargets" },
+            { "x86-64_mac" : "defaultFipsTestTargets" },
             { "x86-64_windows" : "defaultFipsTestTargets" }
         ]
     },
     {
         "TEST_FLAG" : "FIPS140_3_OpenJCEPlusFIPS.FIPS140-3",
         "PLATFORM_TARGETS" : [
+            { "aarch64_linux" : "defaultFipsTestTargets" },
+            { "aarch64_mac" : "defaultFipsTestTargets" },
             { "ppc64_aix" : "defaultFipsTestTargets" },
             { "ppc64le_linux" : "defaultFipsTestTargets" },
             { "s390x_linux" : "defaultFipsTestTargets" },
             { "x86-64_linux" : "defaultFipsTestTargets" },
+            { "x86-64_mac" : "defaultFipsTestTargets" },
             { "x86-64_windows" : "defaultFipsTestTargets" }
         ]
     },

--- a/functional/OpenJcePlusTests/build.xml
+++ b/functional/OpenJcePlusTests/build.xml
@@ -128,13 +128,6 @@
 				<not>
 					<matches string="${JDK_VERSION}" pattern="^(8)$" />
 				</not>
-				<or>
-					<contains string="${SPEC}" substring="aix_ppc-64"/>
-					<contains string="${SPEC}" substring="linux_ppc-64_le"/>
-					<contains string="${SPEC}" substring="linux_x86-64"/>
-					<contains string="${SPEC}" substring="win_x86-64"/>
-					<contains string="${SPEC}" substring="linux_390-64"/>
-				</or>
 			</and>
 			<then>
 				<antcall target="clean" inheritall="true" />

--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -20,10 +20,6 @@
 				<comment>only applicable for Semeru atm</comment>
 				<vendor>eclipse</vendor>
 			</disable>
-			<disable>
-				<comment>Only applicable on aix, pliunx, xlinux, wins64 and zlinux atm</comment>
-				<platform>^((?!(ppc64_aix|ppc64le_linux|x86-64_linux|x86-64_windows|s390x_linux)).)*$</platform>
-			</disable>
 		</disables>
 		<command>cp -r ${TEST_RESROOT}/* ${REPORTDIR}/. ; \
 		cd ${REPORTDIR}; \


### PR DESCRIPTION
OpenJCEPlus can now be enabled in developer mode for use on all Semeru platforms. This update allows the restricted security features associated with FIPS 140-3 to be enabled including the use of security profiles associated with OpenJCEPlusFIPS and Semeru fips mode.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
