### PR TITLE
Re-enable dacapo-tomcat test for JDK 11+

### DIFF
--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -24,7 +24,7 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) eclipse; \
 		$(TEST_STATUS)</command>
 		<versions>
-			<version>8</version>
+			<version>11+</version>
 		</versions>
 		<levels>
 			<level>sanity</level>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -176,13 +176,11 @@
 	</test>
 	<test>
 		<testCaseName>dacapo-tomcat</testCaseName>
-                <disables>
-                        <disable>
-                                <comment>https://bugs.openjdk.java.net/browse/JDK-8155588</comment>
-                        </disable>
-                </disables>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) tomcat; \
 		$(TEST_STATUS)</command>
+		<versions>
+    			<version>11+</version>
+		</versions>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -15,12 +15,6 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<test>
 		<testCaseName>dacapo-eclipse</testCaseName>
-                <disables>
-                        <disable>
-                                <comment>https://github.com/adoptium/aqa-tests/issues/4858#issuecomment-2968494739</comment>
-                                <version>8</version>
-                        </disable>
-                </disables>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) eclipse; \
 		$(TEST_STATUS)</command>
 		<versions>


### PR DESCRIPTION
- Removed the disable block that was preventing dacapo-tomcat from running
- Added version constraint to restrict the test to JDK 11+ only


The test failures on JDK 8 confirm that restricting to JDK 11+ is the correct approach