### PR TITLE
RAS - jlm tests migration for IBM Java 8 - aqa Playlist.xml

### DIFF
--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -10,6 +10,211 @@
 	Special target to get machine information. This target is in each subfolder playlist.xml.
 	To avoid test target duplication, this belongs to sanity, extended and special. Regular test should only belong to one level -->
 	
+	<!-- 	#############################AIX BLOCK##############################  -->
+		<test>
+		<testCaseName>TestJlmLocalaix</testCaseName>
+		
+		    <variations>
+	<!--	<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation>  -->
+			<variation>Mode101</variation>
+			<variation>Mode112</variation>
+			<variation>Mode121</variation>
+			<variation>Mode614</variation>			
+		</variations>
+		
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmLocal; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+		<platformRequirements>os.aix</platformRequirements>
+	</test>
+	
+	
+	<!-- #################################################################### -->
+	<!-- ######################################################################-->
+	<test>
+		<testCaseName>TestJlmRemoteClassAuthaix</testCaseName>
+		
+		 <variations>
+	<!--	<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation> 103,119 ,553 -->
+			<variation>Mode103</variation>
+			<variation>Mode119</variation>
+			<variation>Mode553</variation>
+		</variations>
+		
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteClassAuth; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+		<platformRequirements>os.aix</platformRequirements>
+	</test>
+	<!-- ######################################################################-->
+	
+	<test>
+		<testCaseName>TestJlmRemoteClassNoAuthaix</testCaseName>
+		
+		 <variations>
+	<!--	<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation> 103,119 ,553 -->
+			<variation>Mode103</variation>
+			<variation>Mode119</variation>
+			<variation>Mode553</variation>
+		</variations>
+		
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteClassNoAuth; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+		<platformRequirements>os.aix</platformRequirements>
+	</test>
+	<!-- ######################################################################-->		
+	<test>
+		<testCaseName>TestJlmRemoteMemoryAuthaix</testCaseName>
+		
+		<variations>
+	<!--	<variation>Mode150</variation>,<variation>Mode650</variation>
+			<variation>Mode1000</variation> 103,112,121,503,610 -->
+			<variation>Mode103</variation>
+			<variation>Mode112</variation>
+			<variation>Mode121</variation>
+			<variation>Mode610</variation>
+			<variation>Mode503</variation>
+		</variations>
+		
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteMemoryAuth; \
+	$(TEST_STATUS)</command>
+	<!-- ###################################################################### 
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+		</features>  -->
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+		<platformRequirements>os.aix</platformRequirements>
+	</test>
+	<!-- ######################################################################-->
+	
+	<test>
+		<testCaseName>TestJlmRemoteMemoryNoAuthaix</testCaseName>
+		
+	<variations>
+	<!--	<variation>Mode150</variation>,<variation>Mode650</variation>
+			<variation>Mode1000</variation> 103,112,121,503,610 -->
+			<variation>Mode103</variation>
+			<variation>Mode112</variation>
+			<variation>Mode121</variation>
+			<variation>Mode610</variation>
+			<variation>Mode503</variation>
+		</variations>
+		
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteMemoryNoAuth; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	<!-- Excluded from Windows due to https://github.com/adoptium/aqa-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
+	<test>
+		<testCaseName>TestJlmRemoteNotifierProxyAuthaix</testCaseName>
+		
+		<variations>
+	<!--	<variation>Mode150</variation>,<variation>Mode650</variation>
+			<variation>Mode1000</variation> 112,121 ,501,614	 -->
+		
+			<variation>Mode112</variation>
+			<variation>Mode121</variation>
+			<variation>Mode614</variation>
+			<variation>Mode501</variation>
+		</variations>
+		
+		
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteNotifierProxyAuth; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+		<platformRequirements>os.aix</platformRequirements>
+	</test>
+	<!-- ######################################################################  -->
+	<!-- Excluded from Windows due to https://github.com/adoptium/aqa-systemtest/issues/198 -->
+	<!-- Temporarily excluding from z/OS due to : jdk11-zos/issues/567 -->
+	<test>
+		<testCaseName>TestJlmRemoteThreadAuthaix</testCaseName>
+		
+		<variations>
+	<!--	<variation>Mode150</variation>,<variation>Mode650</variation>
+			<variation>Mode1000</variation>105,121,555	 -->
+		
+			<variation>Mode105</variation>
+			<variation>Mode121</variation>
+			<variation>Mode555</variation>
+		</variations>
+		
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteThreadAuth; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+		<platformRequirements>os.aix</platformRequirements>
+	</test>
+	<!-- ######################################################################  -->
+	<test>
+		<testCaseName>TestJlmRemoteThreadNoAuthaix</testCaseName>
+		
+	<variations>
+	<!--	<variation>Mode150</variation>,<variation>Mode650</variation>
+			<variation>Mode1000</variation>105,121,555	 -->
+		
+			<variation>Mode105</variation>
+			<variation>Mode121</variation>
+			<variation>Mode555</variation>
+		</variations>
+		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestJlmRemoteThreadNoAuth; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>system</group>
+		</groups>
+	</test>
+	<!-- ######################################################################  -->
+	
+	
+	
+	
+<!-- 	###########################################################  -->
+	
 	<test>
 		<testCaseName>TestJlmLocal</testCaseName>
 		<disables>


### PR DESCRIPTION
RAS Playlist backlog issue resolved for the below :
TestJlmLocal,
TestJlmRemoteClassAuth,
TestJlmRemoteClassNoAuth,
TestJlmRemoteNotifierProxyAuth,
TestJlmRemoteMemoryAuth,
TestJlmRemoteMemoryNoAuth,
TestJlmRemoteNotifierProxyAuth,
TestJlmRemoteThreadAuth,
TestJlmRemoteThreadNoAuth

Aix 64bit : Passed

64 bit :
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/42559
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/42558

32bit : Passed

TARGET: testList TESTLIST=TestJlmLocal:
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/42589/

TARGET: testList TESTLIST=TestJlmRemoteClassAuth,TestJlmRemoteClassNoAuth
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/42596/

TARGET: testList TESTLIST=TestJlmRemoteMemoryAuth
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/42654/

TARGET: testList TESTLIST=TestJlmRemoteMemoryNoAuth
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/42667/

TARGET: testList TESTLIST=TestJlmRemoteThreadAuth
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/42649/console

TARGET: testList TESTLIST=TestJlmRemoteThreadNoAuth
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/42674/

TARGET: testList TESTLIST=TestJlmRemoteNotifierProxyAuth
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/42672/

All :
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR_iteration_1/1471/
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR_iteration_0/1479/