### PR TITLE
JDK24 VT test/platform update

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -130,6 +130,9 @@ java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/
 java/lang/Thread/virtual/CancelTimerWithContention.java https://github.com/eclipse-openj9/openj9/issues/21683 aix-all,linux-aarch64,linux-ppc64le,linux-s390x
 java/lang/Thread/virtual/Collectable.java https://github.com/eclipse-openj9/openj9/issues/18463 windows-all
 java/lang/Thread/virtual/JfrEvents.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
+java/lang/Thread/virtual/MiscMonitorTests.java#default https://github.com/eclipse-openj9/openj9/issues/22322 aix-all
+java/lang/Thread/virtual/MiscMonitorTests.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/22322 aix-all
+java/lang/Thread/virtual/MonitorEnterExit.java#Xcomp-noTieredCompilation-LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/22322 macosx-aarch64
 java/lang/Thread/virtual/MonitorWaitNotify.java#default https://github.com/eclipse-openj9/openj9/issues/22322 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-aarch64,windows-all
 java/lang/Thread/virtual/MonitorWaitNotify.java#LM_LEGACY https://github.com/eclipse-openj9/openj9/issues/22322 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-aarch64,windows-all
 java/lang/Thread/virtual/MonitorWaitNotify.java#LM_LIGHTWEIGHT https://github.com/eclipse-openj9/openj9/issues/22322 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-aarch64,windows-all
@@ -144,7 +147,8 @@ java/lang/Thread/virtual/MonitorWaitNotify.java#Xint-LM_LIGHTWEIGHT https://gith
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21957 aix-all,linux-ppc64le
 java/lang/Thread/virtual/ThreadAPI.java#default https://github.com/eclipse-openj9/openj9/issues/22029 windows-all
 java/lang/Thread/virtual/ThreadAPI.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/22029 windows-all
-java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x
+java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java#id0 https://github.com/eclipse-openj9/openj9/issues/22322 windows-all
+java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x,windows-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21957 generic-all
 java/lang/Thread/virtual/stress/Skynet100kWithMonitors.java#id0 https://github.com/eclipse-openj9/openj9/issues/22322 aix-all,linux-aarch64,linux-ppc64le,linux-s390x,macosx-aarch64,windows-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64


### PR DESCRIPTION
JDK24 VT test/platform update

Cherry-pick for JDK24 only
* https://github.com/adoptium/aqa-tests/pull/6479

Signed-off-by: Jason Feng <fengj@ca.ibm.com>