### PR TITLE
Fix typo in JenkinsfileBase and openjdk_tests

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1572,14 +1572,14 @@ def triggerRerunJob (String originalStatus, Map rerunTestJobParams = null) {
 					echo "Triggering rerun jobs in parallel ..."
 					def childJobs = parallel rerunTestJobs
 					def rerunResults = archiveChildJobTap(childJobs, originalStatus)
-					echo " rerun trigger job rerun jobsstatus is ${rerunResults.jobStatus}"
-					echo "current jbo status is ${currentBuild.result}"
+					echo "rerun job status is ${rerunResults.jobStatus}"
+					echo "current job status is ${currentBuild.result}"
 					if (env.JDK_IMPL == "openj9" || env.JDK_IMPL == "ibm") {
 						currentBuild.result = originalStatus
 					} else {
 						currentBuild.result = rerunResults.jobStatus
 					}
-					echo "after setting currentBuild.result is ${currentBuild.result}"
+					echo "set currentBuild.result to ${currentBuild.result}"
 				}
 			}
 		} else {

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -452,7 +452,6 @@ timestamps{
             env.SETUP_LABEL = params.SETUP_LABEL ?: "ci.role.test"
             if (env.PARALLEL == 'None' && env.jobStatus == 'UNSTABLE') {
                 jenkinsfile.triggerRerunJob(env.jobStatus)
-                echo " None paralle and after rerun job status is ${currentBuild.result}"
             } else if ( env.PARALLEL != 'None' && currentBuild.result != 'FAILURE') {
                 def parallelResults = jenkinsfile.runParallelTests()
                 echo "after parallel parallelResults.jobStatus is ${parallelResults.jobStatus}"
@@ -461,10 +460,8 @@ timestamps{
                 } else {
                     currentBuild.result = 'SUCCESS'
                 }
-                echo " Paralle and after rerun job status is ${currentBuild.result}"
             } else {
                 currentBuild.result = env.jobStatus
-                echo " None paralle non rerun or successjob status is ${currentBuild.result}"
             }
         } else {
             assert false : "Cannot find key PLATFORM: ${params.PLATFORM} in PLATFORM_MAP: ${PLATFORM_MAP}."


### PR DESCRIPTION
- Fix typo in JenkinsfileBase and openjdk_tests groovy scripts.
- Remove unnecessary echo statements.

related:https://github.com/adoptium/aqa-tests/issues/6455