### PR TITLE
Add unique group_label to build variables in getEBCNode function

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -739,9 +739,10 @@ def getEBCNode() {
     propagate: false,
     wait: true,
     parameters: [
-        string(name: 'platform', value: params.PLATFORM),
-        string(name: 'nodeType', value: 'testmachine'),
+        string(name: 'PLATFORM', value: params.PLATFORM),
+        string(name: 'NODE_TYPE', value: 'testmachine'),
         string(name: 'TIME_LIMIT', value: expectedNodeLifespan.toString()), 
+        string(name: 'GROUP_LABEL', value: UID.randomUUID().toString()), 
         booleanParam(name: 'WAIT', value: wait),
     ]
     return result.buildVariables.group_label


### PR DESCRIPTION
This avoid issue with merging similar run of create node pipeline into one and not creating a node per each test list

Signed-off-by: mahdi@ibm.com