### PR TITLE
Fix GROUP_LABEL generation to use UUID class in getEBCNode function

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -742,7 +742,7 @@ def getEBCNode() {
         string(name: 'PLATFORM', value: params.PLATFORM),
         string(name: 'NODE_TYPE', value: 'testmachine'),
         string(name: 'TIME_LIMIT', value: expectedNodeLifespan.toString()), 
-        string(name: 'GROUP_LABEL', value: UID.randomUUID().toString()), 
+        string(name: 'GROUP_LABEL', value: UUID.randomUUID().toString()), 
         booleanParam(name: 'WAIT', value: wait),
     ]
     return result.buildVariables.group_label


### PR DESCRIPTION
Fix a typo in code which prevent EBC call

Signed-off-by: mahdi@ibm.com