### PR TITLE
[JDK25] Re-enable java/lang/Thread/virtual/StackFrames.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -136,7 +136,6 @@ java/lang/Thread/virtual/ThreadAPI.java#default https://github.com/eclipse-openj
 java/lang/Thread/virtual/ThreadAPI.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/22029 windows-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x,windows-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21957 generic-all
-java/lang/Thread/virtual/StackFrames.java https://github.com/eclipse-openj9/openj9/issues/21734 generic-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all


### PR DESCRIPTION
`StackFrames.java` has been fixed by the below PR:
https://github.com/eclipse-openj9/openj9/pull/22382

Related: https://github.com/eclipse-openj9/openj9/issues/21734