### PR TITLE
(j9.0.54) JDK24+ exclude Skynet100kWithMonitors.java on aix-all

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -134,6 +134,7 @@ java/lang/Thread/virtual/ThreadAPI.java#default https://github.com/eclipse-openj
 java/lang/Thread/virtual/ThreadAPI.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/22029 windows-all
 java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id0 https://github.com/eclipse-openj9/openj9/issues/18908 linux-s390x,windows-all
 java/lang/Thread/virtual/stress/Skynet.java#default https://github.com/eclipse-openj9/openj9/issues/21957 generic-all
+java/lang/Thread/virtual/stress/Skynet100kWithMonitors.java#id0 https://github.com/eclipse-openj9/openj9/issues/22388 aix-all
 java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/openj9/issues/15184 macosx-x64
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all


### PR DESCRIPTION
JDK24+ exclude `Skynet100kWithMonitors.java` on `aix-all`

Cherry-pick for `openjdk/excludes/ProblemList_openjdk24-openj9.txt` only
* https://github.com/adoptium/aqa-tests/pull/6493

Signed-off-by: Jason Feng <fengj@ca.ibm.com>