### PR TITLE
Add Mac specific java.security files for OpenJCEPlus

### DIFF
--- a/config/openjceplus/jdk/aarch64_mac/java.security
+++ b/config/openjceplus/jdk/aarch64_mac/java.security
@@ -1,0 +1,17 @@
+# Add OpenJCEPlus to the top of the provider list. This file should be kept in sync with
+# the out of the box security provider list except for placing OpenJCEPlus at the highest
+# priority.
+security.provider.1=com.ibm.crypto.plus.provider.OpenJCEPlus
+security.provider.2=SUN
+security.provider.3=SunRsaSign
+security.provider.4=SunEC
+security.provider.5=SunJSSE
+security.provider.6=SunJCE
+security.provider.7=SunJGSS
+security.provider.8=SunSASL
+security.provider.9=XMLDSig
+security.provider.10=SunPCSC
+security.provider.11=JdkLDAP
+security.provider.12=JdkSASL
+security.provider.13=Apple
+security.provider.14=SunPKCS11

--- a/config/openjceplus/jdk/x86-64_mac/java.security
+++ b/config/openjceplus/jdk/x86-64_mac/java.security
@@ -1,0 +1,17 @@
+# Add OpenJCEPlus to the top of the provider list. This file should be kept in sync with
+# the out of the box security provider list except for placing OpenJCEPlus at the highest
+# priority.
+security.provider.1=com.ibm.crypto.plus.provider.OpenJCEPlus
+security.provider.2=SUN
+security.provider.3=SunRsaSign
+security.provider.4=SunEC
+security.provider.5=SunJSSE
+security.provider.6=SunJCE
+security.provider.7=SunJGSS
+security.provider.8=SunSASL
+security.provider.9=XMLDSig
+security.provider.10=SunPCSC
+security.provider.11=JdkLDAP
+security.provider.12=JdkSASL
+security.provider.13=Apple
+security.provider.14=SunPKCS11


### PR DESCRIPTION
For Mac, the `Apple` provider needs to be on the provider list as well.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>