### PR TITLE
Temporarily exclude zlinux z15 criu due to lack of machines

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -199,12 +199,12 @@ timestamps{
                     's390x_linux' : [
                                 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z13"],
                                 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z14"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z15"],
+                                // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z15"],
                                 // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z13"],
                                 ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z14"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z15"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z15"]
+                                // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z15"],
+                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"]
+                                // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z15"]
                             ],
                     'ppc64le_linux' : [
                                 // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p9"],
@@ -227,8 +227,8 @@ timestamps{
                             ],
                     's390x_linux' : [
                                 ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z13"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z14"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z15"]
+                                ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z14"]
+                                // no machine available ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z15"]
                             ],
                     'ppc64le_linux' : [
                                 // Temporarily exclude ubuntu 24 machines due to issue runtimes_backlog 1506

--- a/external/criuSettings.mk
+++ b/external/criuSettings.mk
@@ -19,7 +19,7 @@ export CRIU_COMBO_LIST_linux_x86_64=sw.os.ubuntu.22-hw.arch.x86.broadwell sw.os.
 export CRIU_COMBO_LIST_linux_390_64_z13=sw.os.ubuntu.22-hw.arch.s390x.z13 sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
 # not available: sw.os.rhel.8-hw.arch.s390x.z13
 export CRIU_COMBO_LIST_linux_390_64_z14=sw.os.ubuntu.22-hw.arch.s390x.z14 sw.os.rhel.8-hw.arch.s390x.z14 sw.os.rhel.9-hw.arch.s390x.z14 sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
-export CRIU_COMBO_LIST_linux_390_64_z15=sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
+# not available: export CRIU_COMBO_LIST_linux_390_64_z15=sw.os.ubuntu.22-hw.arch.s390x.z15 sw.os.rhel.8-hw.arch.s390x.z15 sw.os.rhel.9-hw.arch.s390x.z15
 
 export CRIU_COMBO_LIST_linux_aarch64=sw.os.rhel.9-hw.arch.aarch64.armv8 sw.os.rhel.8-hw.arch.aarch64.armv8 sw.os.ubuntu.22-hw.arch.aarch64.armv8
 # not available: sw.os.ubuntu.20-hw.arch.aarch64.armv8


### PR DESCRIPTION
Temporarily exclude zlinux z15 criu due to lack of machines

Issue: [git_ibmr/untimes/infrastructure/issues/10984](https://github.ibm.com/runtimes/infrastructure/issues/10984)