### PR TITLE
JDK25 excludes java/lang/StringBuilder/StressSBTest.java linux-aarch64

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -114,6 +114,7 @@ java/lang/String/EqualsIgnoreCase.java https://github.com/eclipse-openj9/openj9/
 java/lang/String/UnicodeCasingTest.java https://github.com/eclipse-openj9/openj9/issues/4597 linux-s390x
 java/lang/StringBuffer/HugeCapacity.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/StringBuilder/HugeCapacity.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/StringBuilder/StressSBTest.java https://github.com/eclipse-openj9/openj9/issues/21946 linux-aarch64
 java/lang/System/Logger/custom/CustomLoggerTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
 java/lang/System/Logger/default/DefaultLoggerTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all
 java/lang/System/LoggerFinder/BaseLoggerFinderTest/BaseLoggerFinderTest.java https://github.com/eclipse-openj9/openj9/issues/6674 generic-all


### PR DESCRIPTION
JDK25 excludes `java/lang/StringBuilder/StressSBTest.java` `linux-aarch64`

Related to 
* https://github.com/eclipse-openj9/openj9/issues/21946

Signed-off-by: Jason Feng <fengj@ca.ibm.com>