### PR TITLE
JDK25 excludes ClearAllFramePops.java#virtual

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -604,6 +604,7 @@ serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java https://github.com/ecl
 serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FramePop/ClearAllFramePops/ClearAllFramePops.java#platform https://github.com/eclipse-openj9/openj9/issues/21735 generic-all
+serviceability/jvmti/events/FramePop/ClearAllFramePops/ClearAllFramePops.java#virtual https://github.com/eclipse-openj9/openj9/issues/21735 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
JDK25 excludes `ClearAllFramePops.java#virtual`

Related to
* https://github.com/eclipse-openj9/openj9/issues/21735

Signed-off-by: Jason Feng <fengj@ca.ibm.com>