### PR TITLE
Add FIPS140-3-Strongly-Enforced nonapplicable for openJcePlusTests

### DIFF
--- a/functional/OpenJcePlusTests/playlist.xml
+++ b/functional/OpenJcePlusTests/playlist.xml
@@ -42,6 +42,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<levels>


### PR DESCRIPTION
Add FIPS140-3-Strongly-Enforced nonapplicable for openJcePlusTests

Issue: [Git_ibm/runtimes/automation/issues/590](https://github.ibm.com/runtimes/automation/issues/590)