### PR TITLE
Check BUILD_LIST default value is set correctly

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -186,6 +186,10 @@ ARCH_OS_LIST.each { ARCH_OS ->
 				if (!expectedGroups.contains(GROUP)) {
 					assert false : "GROUP ${GROUP} is not in the the expected groups: ${expectedGroups}."
 				}
+				if ( BUILD_LIST && !BUILD_LIST.contains(GROUP) ) {
+					// Fail immediately, before we create a job that cannot build the tests it is expected to run.
+					assert false : "BUILD_LIST has been set (${BUILD_LIST}), but it does not contain the tests we expect the target job to run: ${GROUP}."
+				}
 				def ACTUAL_TEST_JOB_NAME = TEST_JOB_NAME ? TEST_JOB_NAME : "Test_openjdk${JDK_VERSION}_${JDK_IMPL_SN}_${LEVEL}.${GROUP}_${ARCH_OS}${SUFFIX}"
 				def ACTUAL_TARGET = TARGET ? TARGET : "${LEVEL}.${GROUP}"
 				def ACTUAL_BUILD_LIST = BUILD_LIST ? BUILD_LIST : GROUP


### PR DESCRIPTION
A check to ensure we never create a test job where the BUILD_LIST parameter has an invalid default value.

This should ensure we know https://github.com/adoptium/aqa-tests/issues/6378 is happening if the symptom crops up again.