### PR TITLE
(v1.0.9) Exclude OpenJ9 jdk25 MethodHandleProxies/BasicTest (#6517)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -54,6 +54,7 @@ java/lang/invoke/condy/CondyNestedTest.java https://github.com/eclipse-openj9/op
 java/lang/invoke/FindAccessTest.java  https://github.com/eclipse-openj9/openj9/issues/6868 generic-all
 java/lang/invoke/lambda/LambdaStackTrace.java https://github.com/eclipse-openj9/openj9/issues/3394 generic-all
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/invoke/MethodHandleProxies/BasicTest.java https://github.com/eclipse-openj9/openj9/issues/22264 generic-all
 java/lang/invoke/MethodHandlesGeneralTest.java https://github.com/eclipse-openj9/openj9/issues/7043 generic-all
 java/lang/invoke/PrivateInvokeTest.java https://github.com/eclipse-openj9/openj9/issues/7071 generic-all
 java/lang/invoke/SpecialInterfaceCall.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/22264

Cherry pick https://github.com/adoptium/aqa-tests/pull/6517