### PR TITLE
(v1.0.9) )Unexclude jdk25 OpenJ9 serviceability GetStackTraceSuspendedStressTest (#6514)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -598,7 +598,6 @@ serviceability/jvmti/RedefineClasses/RedefineSubtractLambdaExpression.java https
 serviceability/jvmti/RedefineClasses/TestAddDeleteMethods.java https://github.com/eclipse-openj9/openj9/issues/15989 generic-all
 serviceability/jvmti/StartPhase/AllowedFunctions/AllowedFunctions.java https://github.com/eclipse-openj9/openj9/issues/15992 generic-all
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/18730 generic-all
-serviceability/jvmti/stress/StackTrace/Suspended/GetStackTraceSuspendedStressTest.java https://github.com/eclipse-openj9/openj9/issues/19886 generic-all
 serviceability/jvmti/SuspendWithObjectMonitorWait/SuspendWithObjectMonitorWait.java https://github.com/eclipse-openj9/openj9/issues/15993 generic-all
 serviceability/jvmti/SuspendWithObjectMonitorEnter/SuspendWithObjectMonitorEnter.java https://github.com/eclipse-openj9/openj9/issues/15993 generic-all
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java https://github.com/eclipse-openj9/openj9/issues/15994 generic-all


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/19886

Cherry pick https://github.com/adoptium/aqa-tests/pull/6514