### PR TITLE
[JDK25] Re-enable ClearAllFramePops.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -603,8 +603,6 @@ serviceability/jvmti/SuspendWithObjectMonitorEnter/SuspendWithObjectMonitorEnter
 serviceability/jvmti/VMObjectAlloc/VMObjectAllocTest.java https://github.com/eclipse-openj9/openj9/issues/15994 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc03/fieldacc03.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
 serviceability/jvmti/events/FieldAccess/fieldacc04/fieldacc04.java https://github.com/eclipse-openj9/openj9/issues/16218 generic-all
-serviceability/jvmti/events/FramePop/ClearAllFramePops/ClearAllFramePops.java#platform https://github.com/eclipse-openj9/openj9/issues/21735 generic-all
-serviceability/jvmti/events/FramePop/ClearAllFramePops/ClearAllFramePops.java#virtual https://github.com/eclipse-openj9/openj9/issues/21735 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
`ClearAllFramePops.java` has been fixed by the below PR:
https://github.com/eclipse-openj9/openj9/pull/22479

Related: https://github.com/eclipse-openj9/openj9/issues/21735