### PR TITLE
Exclude JDK8 tests which fail on EL9/10 due to NSS patches

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -240,12 +240,15 @@ java/security/KeyPairGenerator/SolarisShortDSA.java https://github.com/adoptium/
 java/security/MessageDigest/TestDigestIOStream.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 javax/xml/crypto/dsig/LineFeedOnlyTest.java https://github.com/adoptium/aqa-tests/issues/2356 windows-all
 sun/security/pkcs11/KeyStore/SecretKeysBasic.sh https://bugs.openjdk.java.net/browse/JDK-8189603 linux-all,macosx-all,windows-all
+sun/security/pkcs11/Provider/Login.sh https://github.com/adoptium/infrastructure/issues/3868#issuecomment-3224931443 linux-all
+sun/security/pkcs11/Secmod/AddPrivateKey.java https://github.com/adoptium/infrastructure/issues/3868#issuecomment-3224931443 linux-all
 sun/security/pkcs11/Signature/TestDSAKeyLength.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
 sun/security/pkcs11/ec/TestECDH.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
 sun/security/pkcs11/ec/TestECDSA.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
 sun/security/pkcs11/ec/TestECGenSpec.java https://github.com/adoptium/aqa-tests/issues/70 linux-all
 sun/security/pkcs11/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/issues/68 linux-all
 sun/security/rsa/TestCACerts.java https://github.com/adoptium/aqa-tests/issues/68 generic-all
+sun/security/tools/keytool/autotest.sh https://github.com/adoptium/infrastructure/issues/3868#issuecomment-3224931443 linux-all
 com/sun/crypto/provider/Mac/MacClone.java https://bugs.openjdk.java.net/browse/JDK-7087021 solaris-all
 javax/net/ssl/ciphersuites/DisabledAlgorithms.java https://github.com/adoptium/aqa-tests/issues/5915 solaris-x64
 javax/net/ssl/ServerName/BestEffortOnLazyConnected.java https://bugs.openjdk.org/browse/JDK-8155049 solaris-x64


### PR DESCRIPTION
Using https://github.com/adoptium/infrastructure/issues/3868#issuecomment-3224931443 as a reference for these. There are three tests in JDK8 which fail on EL10 distributions such as CentOS-Stream10, UBI10 and RHEL10. Two of them also fail on EL9-based distributions (`AddPrivateKey` is the one that passes there). Since we have no mechanism for excluding particular distributions I am proposing removing these tests from all Linux runs in order to avoid failures.

Other viable options:
- Exclude only for temurin

It is likely that the issue referenced above will be closed shortly after this PR is merged - I trust that is acceptable here.

These are believed to fail due to algorithms being restricted in patches to the version of NSS included in those distributions. Recent versions of other distributions (Ubuntu 25.10/Debian13) do not fail.