### PR TITLE
(v1.0.9) Unexclude OpenJ9 jdk25 tests for issue 22219

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -540,16 +540,11 @@ java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/TestFallbackLookup.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
 java/foreign/TestBufferStack.java https://github.com/eclipse-openj9/openj9/issues/21944 generic-all
-java/foreign/TestFill.java https://github.com/eclipse-openj9/openj9/issues/22219 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
-java/foreign/TestSegments.java https://github.com/eclipse-openj9/openj9/issues/22219 generic-all
-java/foreign/TestSegmentBulkOperationsContentHash.java https://github.com/eclipse-openj9/openj9/issues/22219 generic-all
-java/foreign/TestStringEncoding.java https://github.com/eclipse-openj9/openj9/issues/22219 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
 java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all
 java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all
 java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all
-java/foreign/TestVarArgs.java https://github.com/eclipse-openj9/openj9/issues/22219 generic-all
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 


### PR DESCRIPTION
java/foreign/TestFill.java
java/foreign/TestSegments.java
java/foreign/TestSegmentBulkOperationsContentHash.java
java/foreign/TestStringEncoding.java
java/foreign/TestVarArgs.java

Issue https://github.com/eclipse-openj9/openj9/issues/22219

Backport https://github.com/adoptium/aqa-tests/pull/6542