### PR TITLE
(1.0.9)  Unexclude OpenJ9 jdk25 tests for issue 21944

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -539,7 +539,6 @@ java/foreign/stackwalk/TestStackWalk.java#default_gc https://github.com/eclipse-
 java/foreign/stackwalk/TestStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/TestFallbackLookup.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
-java/foreign/TestBufferStack.java https://github.com/eclipse-openj9/openj9/issues/21944 generic-all
 java/foreign/TestIllegalLink.java https://github.com/eclipse-openj9/openj9/issues/14002 generic-all
 java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/openj9/issues/14828 generic-all
 java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all


### PR DESCRIPTION
java/foreign/TestBufferStack.java

Issue eclipse-openj9/openj9#21944