### PR TITLE
Utilise containers in Azure dynamic VMs for AQA runs

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -791,9 +791,11 @@ def runTest( ) {
 		}
 		for (int i = 1; i <= ITERATIONS; i++) {
 			echo "ITERATION: ${i}/${ITERATIONS}"
-			if (env.SPEC.contains('linux') && !(LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') && (BUILD_LIST != "external")) {
+			if (env.SPEC.contains('linux') && (BUILD_LIST != "external")) {
 				// Detect if Xvfb is on the machine, and if not use the wayland startup code (Initially for EL10)
 				if ( sh(script:"which Xvfb 2>&1", returnStatus:true) != 0 ) {
+					env.XDG_RUNTIME_DIR = env.WORKSPACE + "/.xdg-runtime"
+					sh "mkdir -pm 0700 " + env.XDG_RUNTIME_DIR
 					sh "weston --no-config --socket=wayland-vfb --backend=headless-backend.so --xwayland &"
 					env.DISPLAY = ":0"
 

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -105,8 +105,14 @@ def setupEnv() {
 	env.EXIT_FAILURE = params.EXIT_FAILURE ? params.EXIT_FAILURE : false
 	env.EXIT_SUCCESS = params.EXIT_SUCCESS ? params.EXIT_SUCCESS : false
 	NUM_MACHINES = params.NUM_MACHINES ? params.NUM_MACHINES.toInteger() : 1
-	env.LIB_DIR = JOB_NAME.contains("SmokeTests") ? "${WORKSPACE}/../../../../../externalDependency/lib" : "${WORKSPACE}/../../externalDependency/lib"
-	env.SYSTEM_LIB_DIR = JOB_NAME.contains("SmokeTests") ? "${WORKSPACE}/../../../../../externalDependency/system_lib" : "${WORKSPACE}/../../externalDependency/system_lib"
+	if (CLOUD_PROVIDER == 'azure') {
+		// Needs to be inside the workspace as the docker container won't have permissions to write to higher level directories
+		env.LIB_DIR = "${WORKSPACE}/externalDependency/lib"
+		env.SYSTEM_LIB_DIR = "${WORKSPACE}/externalDependency/system_lib"
+	} else {
+		env.LIB_DIR = JOB_NAME.contains("SmokeTests") ? "${WORKSPACE}/../../../../../externalDependency/lib" : "${WORKSPACE}/../../externalDependency/lib"
+		env.SYSTEM_LIB_DIR = JOB_NAME.contains("SmokeTests") ? "${WORKSPACE}/../../../../../externalDependency/system_lib" : "${WORKSPACE}/../../externalDependency/system_lib"
+	}
 	env.OPENJCEPLUS_GIT_REPO = params.OPENJCEPLUS_GIT_REPO ?: "https://github.com/ibmruntimes/OpenJCEPlus.git"
 	env.OPENJCEPLUS_GIT_BRANCH = params.OPENJCEPLUS_GIT_BRANCH ?: "semeru-java${params.JDK_VERSION}"
 	env.PARALLEL = env.PARALLEL ? params.PARALLEL : "None"

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -540,8 +540,8 @@ def runTest() {
         jenkinsfile = load "${WORKSPACE}/aqa-tests/buildenv/jenkins/JenkinsfileBase"
         if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER.equals('azure')) {
             // Set dockerimage for azure agent. Fyre has stencil to setup the right environment
-            docker.image('ghcr.io/adoptium/test-containers:ubuntu2204').pull()
-            docker.image('ghcr.io/adoptium/test-containers:ubuntu2204').inside {
+            docker.image('ghcr.io/adoptium/test-containers:ubi10').pull()
+            docker.image('ghcr.io/adoptium/test-containers:ubi10').inside {
                 jenkinsfile.testBuild()
             }
         } else if (dockerAgentLabel.equals('default') && LABEL.contains('&&sw.tool.docker') && SPEC.equals('linux_riscv64')) {

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -540,8 +540,8 @@ def runTest() {
         jenkinsfile = load "${WORKSPACE}/aqa-tests/buildenv/jenkins/JenkinsfileBase"
         if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER.equals('azure')) {
             //Set dockerimage for azure agent. Fyre has stencil to setup the right environment
-            docker.image('adoptopenjdk/centos7_build_image').pull()
-            docker.image('adoptopenjdk/centos7_build_image').inside {
+            docker.image('ghcr.io/adoptium/test-containers:ubuntu2204').pull()
+            docker.image('ghcr.io/adoptium/test-containers:ubuntu2204').inside {
                 jenkinsfile.testBuild()
             }
         } else if (dockerAgentLabel.equals('default') && LABEL.contains('&&sw.tool.docker') && SPEC.equals('linux_riscv64')) {

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -538,8 +538,12 @@ def runTest() {
             sh "cat ${javaSecurityFile}"
         }
         jenkinsfile = load "${WORKSPACE}/aqa-tests/buildenv/jenkins/JenkinsfileBase"
-        if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER.equals('azure')) {
-            //Set dockerimage for azure agent. Fyre has stencil to setup the right environment
+        // Check the node for full set of labels
+        def JobHelper = library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+        def labels = JobHelper.getLabels(NODE_NAME)
+
+        if (LABEL.contains('ci.agent.dynamic') && labels.contains('dynamicAzure')) {
+            // Set dockerimage for azure agent. Fyre has stencil to setup the right environment
             docker.image('ghcr.io/adoptium/test-containers:ubuntu2204').pull()
             docker.image('ghcr.io/adoptium/test-containers:ubuntu2204').inside {
                 jenkinsfile.testBuild()

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -538,11 +538,7 @@ def runTest() {
             sh "cat ${javaSecurityFile}"
         }
         jenkinsfile = load "${WORKSPACE}/aqa-tests/buildenv/jenkins/JenkinsfileBase"
-        // Check the node for full set of labels
-        def JobHelper = library(identifier: 'openjdk-jenkins-helper@master').JobHelper
-        def labels = JobHelper.getLabels(NODE_NAME)
-
-        if (LABEL.contains('ci.agent.dynamic') && labels.contains('dynamicAzure')) {
+        if (LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER.equals('azure')) {
             // Set dockerimage for azure agent. Fyre has stencil to setup the right environment
             docker.image('ghcr.io/adoptium/test-containers:ubuntu2204').pull()
             docker.image('ghcr.io/adoptium/test-containers:ubuntu2204').inside {


### PR DESCRIPTION
Initial implementation of https://github.com/adoptium/aqa-tests/issues/5684

This PR is designed to allow dynamic containers, provisioned with Azure, to be used for AQA jobs. It spins up a system with docker installed (defined by the [Azure VM agents plugin](https://plugins.jenkins.io/azure-vm-agents) config) and then pulls down a docker image (currently UBI10) and runs a job on it. This behaviour is triggered by setting the parameter `CLOUD_PROVIDER`=`azure` in the Test jobs.

This also makes a small modification to the `weston` support in EL10 distributions to allow a dynamic `XDG_RUNTIME_DIR` to be used (within the jenkins workspace) so that it does not haver to be in a fixed, reusable location on the machine. FYI @llxia @AdamBrousseau as it would be good to have your confirmation that this does not break anything on your side for EL10.

In the future it is envisioned that this will allow support for different distributions (at the moment we have ubi10, ubuntu2204 and ubuntu2404 on the ghcr.io registry. It is also likely that we will change the address from `ghcr.io/adoptium/test-containers` to something else in the future to avoid confusion with other products of a similar name :-)