### PR TITLE
(v1.0.9) Exclude java/net/CookieHandler/B6644726.java in v1.0.9-release branch on all platforms

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -177,6 +177,7 @@ java/net/vthread/BlockingSocketOps.java#direct-register https://github.com/adopt
 java/net/vthread/BlockingSocketOps.java#default https://github.com/adoptium/aqa-tests/issues/4440 aix-all
 java/nio/channels/vthread/BlockingChannelOps.java#default https://github.com/adoptium/aqa-tests/issues/4440 aix-all
 java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github.com/adoptium/aqa-tests/issues/4440 aix-all
+java/net/CookieHandler/B6644726.java https://bugs.openjdk.org/browse/JDK-8365811 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Fixes #6557 

Exclude in release branch (where it is failing), fix for https://bugs.openjdk.org/browse/JDK-8365811 is available in master, so no need to exclude there.