### PR TITLE
Exclude unsupported test on alpine-linux

### DIFF
--- a/openjdk/excludes/alpine/ProblemList_openjdk25_alpine.txt
+++ b/openjdk/excludes/alpine/ProblemList_openjdk25_alpine.txt
@@ -16,4 +16,4 @@ jdk/jshell/ExternalEditorTest.java https://github.com/adoptium/aqa-tests/issues/
 java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
 sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
-
+java/nio/file/DirectoryStream/SecureDS.java https://github.com/adoptium/aqa-tests/issues/6555 linux-all


### PR DESCRIPTION
java/nio/file/DirectoryStream/SecureDS.java

refer to https://github.com/adoptium/aqa-tests/issues/6555#issuecomment-3263769483