### PR TITLE
(v1.0.9) Run AIX tests for jdk25+ with the 17.1 C++ Runtime (#6568)

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -331,13 +331,18 @@ timestamps{
                 LABEL = params.LABEL
             } else {
                 LABEL = PLATFORM_MAP[params.PLATFORM]["LABEL"]
-                    if (params.BUILD_LIST.contains("perf")) {
-                        def perfLabel = LABEL.minus("ci.role.test&&").concat("&&ci.role.perf")
-                        if (areNodesWithLabelOnline(perfLabel)) {
+                if (params.BUILD_LIST.contains("perf")) {
+                    def perfLabel = LABEL.minus("ci.role.test&&").concat("&&ci.role.perf")
+                    if (areNodesWithLabelOnline(perfLabel)) {
                         LABEL = perfLabel
-                        }
                     }
                 }
+                if (PLATFORM == "ppc64_aix" && params.JDK_IMPL == "openj9" && env.JENKINS_URL.contains("hyc-runtimes")) {
+                    if (!params.JDK_VERSION.isInteger() || params.JDK_VERSION.toInteger() >= 25) {
+                        LABEL += "&&sw.tool.c++runtime.17_1"
+                    }
+                }
+            }
 
             // Temporarily support both FIPS and FIPS140_2, remove FIPS in the next step
             if (params.TEST_FLAG) {


### PR DESCRIPTION
Cherry pick https://github.com/adoptium/aqa-tests/pull/6568