### PR TITLE
(v1.0.10) [JDK25] Re-enable StructuredTaskScope/StructuredThreadDumpTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -468,7 +468,6 @@ java/util/concurrent/forkjoin/FJExceptionTableLeak.java https://github.com/eclip
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java https://github.com/eclipse-openj9/openj9/issues/7125 macosx-all,linux-all,aix-all
 java/util/concurrent/locks/Lock/OOMEInAQS.java https://github.com/eclipse-openj9/openj9/issues/16659 generic-all
 java/util/concurrent/StructuredTaskScope/StructuredTaskScopeTest.java#virtual https://github.com/eclipse-openj9/openj9/issues/21824 aix-all,linux-ppc64le
-java/util/concurrent/StructuredTaskScope/StructuredThreadDumpTest.java https://github.com/eclipse-openj9/openj9/issues/22220 generic-all
 java/util/concurrent/SynchronousQueue/Fairness.java https://github.com/eclipse-openj9/openj9/issues/18771 generic-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
 java/util/logging/CheckZombieLockTest.java https://bugs.openjdk.java.net/browse/JDK-8148972 macosx-all,linux-all


### PR DESCRIPTION
Depends on
- https://github.com/eclipse-openj9/openj9/pull/22603
- https://github.com/eclipse-openj9/openj9/pull/22604
- https://github.com/eclipse-openj9/openj9/pull/22605