### PR TITLE
Exclude runtime/cds/NonJVMVariantLocation.java on mac_x64

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -467,8 +467,6 @@ runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium
 runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 #runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
-runtime/cds/TestDefaultArchiveLoading.java#coops_nocoh https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
-runtime/cds/TestDefaultArchiveLoading.java#nocoops_nocoh https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
 #runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
@@ -489,9 +487,6 @@ runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/bro
 runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-aarch64,linux-riscv64,linux-ppc64le
 runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
-runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
-runtime/cds/appcds/TransformInterfaceOfLambda.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
-runtime/cds/NonJVMVariantLocation.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
 ############################################################################
 
 # hotspot_serviceability

--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -491,6 +491,7 @@ runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tes
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
 runtime/cds/appcds/TransformInterfaceOfLambda.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/NonJVMVariantLocation.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
 ############################################################################
 
 # hotspot_serviceability

--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk25.txt
@@ -1,0 +1,127 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#############################################################################
+
+# hotspot_all
+
+############################################################################
+
+# hotspot_jre
+
+############################################################################
+
+# hotspot_runtime
+
+runtime/cds/TestDefaultArchiveLoading.java#coops_nocoh https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/TestDefaultArchiveLoading.java#nocoops_nocoh https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/appcds/TransformInterfaceOfLambda.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/NonJVMVariantLocation.java  https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+############################################################################
+
+# jdk_awt
+
+############################################################################
+
+# jdk_beans
+
+############################################################################
+
+# jdk_build
+
+############################################################################
+
+# jdk_compiler
+
+############################################################################
+
+# jdk_lang
+
+############################################################################
+
+# jdk_management
+
+############################################################################
+
+# jdk_jmx
+
+############################################################################
+
+# jdk_math
+
+############################################################################
+
+# jdk_net
+
+############################################################################
+
+# jdk_io
+
+############################################################################
+
+# jdk_nio
+############################################################################
+
+# jdk_rmi
+
+############################################################################
+
+# jdk_security
+
+############################################################################
+
+# jdk_security4
+
+############################################################################
+
+# jdk_sound
+
+############################################################################
+
+# jdk_swing
+
+############################################################################
+
+# jdk_text
+
+############################################################################
+
+# jdk_time
+
+############################################################################
+
+# jdk_tools
+############################################################################
+
+# jdk_jdi
+
+############################################################################
+
+# jdk_util
+
+############################################################################
+
+# svc_tools
+
+############################################################################
+
+# jdk_other
+
+
+############################################################################
+
+# jdk_imageio
+
+############################################################################
+
+# jdk_jfr


### PR DESCRIPTION
https://github.com/adoptium/adoptium-support/issues/937 macosx-x64

Close #6562