### PR TITLE
Add -k option to curl in get.sh for AIX 7.1

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -322,7 +322,7 @@ getBinaryOpenjdk()
 					download_api_url_base=(${download_api_url_base//\/artifactory\//\/artifactory\/api\/storage\/})
 				fi
 				echo "use artifactory API to get the jdk and/or test images: ${download_api_url_base}"
-				download_urls=$(curl ${curl_options} ${download_api_url_base} | grep -E '.*\.tar\.gz"|.*\.zip"' | grep -E 'testimage|jdk|jre'| sed 's/.*"uri" : "\([^"]*\)".*/\1/')
+				download_urls=$(curl -k ${curl_options} ${download_api_url_base} | grep -E '.*\.tar\.gz"|.*\.zip"' | grep -E 'testimage|jdk|jre'| sed 's/.*"uri" : "\([^"]*\)".*/\1/')
 				arr=(${download_urls/ / })
 				download_url=()
 				download_url_base=(${download_url_base//\/ui\/native\//\/artifactory\/})


### PR DESCRIPTION
- Add -k option to curl for AIX 7.1 machines

related:https://github.ibm.com/runtimes/infrastructure/issues/11167