### PR TITLE
Remove all possible dup failed testcases before adding to custom target

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1380,29 +1380,17 @@ def getFailedAndCustomizedTest(String paths="") {
 							failedTestCasesInfo = failedTestCasesInfo.substring(0, failedTestCasesInfo.indexOf('Test results:'))
 							failedTestCasesInfo = failedTestCasesInfo.split("\\n").join(" ").replaceAll("TEST: ", "")
 							if (failedtest.startsWith("jdk_")) {
-								if (!jdkFailedTestCaseList.contains(failedTestCasesInfo)) {
-									jdkFailedTestCaseList += "${failedTestCasesInfo} "
-								}
+								jdkFailedTestCaseList = mergeTestCasesWithoutDup(jdkFailedTestCaseList, failedTestCasesInfo)
 							} else if (failedtest.startsWith("jck-runtime") || failedtest.startsWith("jckruntime")) {
-								if (!jckRuntimeFailedTestCaseList.contains(failedTestCasesInfo)) {
-									jckRuntimeFailedTestCaseList += "${failedTestCasesInfo} "
-								}
+								jckRuntimeFailedTestCaseList = mergeTestCasesWithoutDup(jckRuntimeFailedTestCaseList, failedTestCasesInfo)
 							} else if (failedtest.startsWith("jck-compiler") || failedtest.startsWith("jckcompiler")) {
-								if (!jckCompilerFailedTestCaseList.contains(failedTestCasesInfo)) {
-									jckCompilerFailedTestCaseList += "${failedTestCasesInfo} "
-								}
+								jckCompilerFailedTestCaseList = mergeTestCasesWithoutDup(jckCompilerFailedTestCaseList, failedTestCasesInfo)
 							} else if (failedtest.startsWith("jck-devtools") || failedtest.startsWith("jckdevtools")) {
-								if (!jckDevtoolsFailedTestCaseList.contains(failedTestCasesInfo)) {
-									jckDevtoolsFailedTestCaseList += "${failedTestCasesInfo} "
-								}
+								jckDevtoolsFailedTestCaseList = mergeTestCasesWithoutDup(jckDevtoolsFailedTestCaseList, failedTestCasesInfo)
 							} else if (failedtest.startsWith("langtools_")){
-								if (!langtoolsFailedTestCaseList.contains(failedTestCasesInfo)) {
-									langtoolsFailedTestCaseList += "${failedTestCasesInfo} "
-								}
+								langtoolsFailedTestCaseList = mergeTestCasesWithoutDup(langtoolsFailedTestCaseList, failedTestCasesInfo)
 							} else {
-								if (!hotspotFailedTestCaseList.contains(failedTestCasesInfo)) {
-									hotspotFailedTestCaseList += "${failedTestCasesInfo} "
-								}
+								hotspotFailedTestCaseList = mergeTestCasesWithoutDup(hotspotFailedTestCaseList, failedTestCasesInfo)
 							}
 						}
 					}
@@ -1446,6 +1434,13 @@ def getFailedAndCustomizedTest(String paths="") {
 		}
 	}
 	return null
+}
+
+def mergeTestCasesWithoutDup(String knownTestCases, String newTestCases) {
+	def knownTestCasesList = knownTestCases.split(/\s+/)
+	def newTestCasesList = newTestCases.split(/\s+/)
+	def filterednewTestCases = newTestCasesList.findAll { !(it in knownTestCasesList) }
+	return ( knownTestCases + " " + filterednewTestCases.join(" "))
 }
 
 def addFailedTestsGrinderLink(paths="") {


### PR DESCRIPTION
Fix #6575 

Go through all failed test cases only add non-duplicate ones.