### PR TITLE
(v1.0.10) Set minimal parallel to 6 for sanity.functional on Openj9 windows (#6604)

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -245,11 +245,21 @@ def setupParallelEnv() {
 					echo "Regenerate parallel list with NUM_MACHINES=${MAX_NUM_MACHINES}."
 					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=${MAX_NUM_MACHINES} TEST_TIME="
 					NUM_LIST = genParallelList(PARALLEL_OPTIONS)
-				} else if (NUM_LIST < 6 && (env.JDK_IMPL == "openj9" || env.JDK_IMPL == "ibm") && (TARGET == "extended.jck" || TARGET == "special.system")) {
-					echo "NUM_LIST value ${NUM_LIST} may not be calculated based on the actual execution time."
-					echo "Regenerate parallel list with NUM_MACHINES=6 for TARGET ${TARGET}."
-					PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=6 TEST_TIME="
-					NUM_LIST = genParallelList(PARALLEL_OPTIONS)
+				} else if (env.JDK_IMPL == "openj9" || env.JDK_IMPL == "ibm") {
+					if (TARGET == "extended.jck" || TARGET == "special.system") {
+						if (NUM_LIST < 6) {
+							echo "NUM_LIST value ${NUM_LIST} may not be calculated based on the actual execution time."
+							echo "Regenerate parallel list with NUM_MACHINES=6 for TARGET ${TARGET}."
+							PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=6 TEST_TIME="
+							NUM_LIST = genParallelList(PARALLEL_OPTIONS)
+						}
+					} else if (TARGET == "sanity.functional" && PLATFORM.contains('windows')) {
+						if (NUM_LIST < 6) {
+							echo "Regenerate parallel list with NUM_MACHINES=6 for TARGET ${TARGET} due to long running tests (runtimes/automation/issues/654)."
+							PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=6 TEST_TIME="
+							NUM_LIST = genParallelList(PARALLEL_OPTIONS)
+						}
+					}
 				} else if (NUM_LIST == 1 && env.JDK_IMPL == "hotspot" && (TARGET.contains("openjdk") || TARGET.contains("system"))) {
 					int FORCE_NUM_MACHINES = Math.min(3, MAX_NUM_MACHINES);
 					echo "NUM_LIST=1, Fall back to regenerate parallel lists with NUM_MACHINES=${FORCE_NUM_MACHINES}."


### PR DESCRIPTION


related: runtimes/automation/issues/654

cherry-pick: #6604