### PR TITLE
Set parent job status to ABORTED if one of the parallel branches status is ABORTED

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1584,6 +1584,9 @@ def triggerRerunJob (String originalStatus, Map rerunTestJobParams = null) {
 					def rerunResults = archiveChildJobTap(childJobs, originalStatus)
 					if (env.JDK_IMPL == "openj9" || env.JDK_IMPL == "ibm") {
 						currentBuild.result = originalStatus
+					} else if ( originalStatus == 'ABORTED') { 
+						// Set job status to the worst result among its parallel branches including rerun branch.
+						currentBuild.result = originalStatus
 					} else {
 						currentBuild.result = rerunResults.jobStatus
 					}


### PR DESCRIPTION
Fix #6580 

ABORTED jobs won't be triggered rerun automatically. It's possible that TAP file is not generated or archived, which can cause unstable rerun job doesn't have failed testcases of aborted job at all. This avoids parent job status is wrongly marked as SUCCESS due to the SUCCESS status of rerun job.