### PR TITLE
Disable dacapo-pmd and dacapo-jython on x86-32_windows

### DIFF
--- a/perf/dacapo/playlist.xml
+++ b/perf/dacapo/playlist.xml
@@ -95,7 +95,7 @@
                         <disable>
                                 <comment>https://github.com/adoptium/aqa-tests/issues/4858#issuecomment-2968494739</comment>
                                 <version>8</version>
-                                <platform>x86-64_windows</platform>
+                                <platform>x86-64_windows|x86-32_windows</platform>
                         </disable>
                 </disables>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)dacapo.jar$(Q) jython; \
@@ -142,7 +142,7 @@
                 <disables>
                         <disable>
                                 <comment>https://github.com/adoptium/aqa-tests/issues/4858#issuecomment-2968494739</comment>
-                                <platform>x86-64_windows</platform>
+                                <platform>x86-64_windows|x86-32_windows</platform>
                         </disable>
                         <disable>
                                 <comment>https://github.com/adoptium/aqa-tests/issues/6563</comment>


### PR DESCRIPTION
related: https://github.com/eclipse-openj9/openj9/issues/22663 and https://github.com/eclipse-openj9/openj9/issues/22662