### PR TITLE
Ensure /tmp/.X11-unix is in place before starting weston

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -798,6 +798,7 @@ def runTest( ) {
 			if (env.SPEC.contains('linux') && !(LABEL.contains('ci.agent.dynamic') && CLOUD_PROVIDER == 'azure') && (BUILD_LIST != "external")) {
 				// Detect if Xvfb is on the machine, and if not use the wayland startup code (Initially for EL10)
 				if ( sh(script:"which Xvfb 2>&1", returnStatus:true) != 0 ) {
+					sh "mkdir -p -m 1777 /tmp/.X11-unix"
 					sh "weston --no-config --socket=wayland-vfb --backend=headless-backend.so --xwayland &"
 					env.DISPLAY = ":0"
 


### PR DESCRIPTION
`/tmp/` should be considered volatile and may be wiped at any point, for example on reboot.

Since `/tmp/.X11-unix` is required to be in place to avoid `weston` (used on EL10 to start an X11-compatibility session on Wayland systems) to start up otherwise a core dump occurs:
```
[15:20:26.798] failed to bind to /tmp/.X11-unix/X0: No such file or directory
Segmentation fault (core dumped)
```
This PR will ensure it is created with appropriate permissions to allow `weston` to start. 

Probably renders https://github.com/adoptium/infrastructure/pull/4069 irrelevant. Seen in https://github.com/adoptium/infrastructure/issues/3868#issuecomment-2884138589

Tested at https://ci.adoptium.net/job/Grinder/14604/ vs the failing version without this patch at https://ci.adoptium.net/job/Grinder/14601

FYI @aswinkr77