### PR TITLE
Add sleep and retry for cleanWs

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1754,18 +1754,28 @@ def getGitRepoBranch(ownerBranch, defaultOwnerBranch, repo) {
 }
 
 def forceCleanWS() {
-	try {
-		cleanWs disableDeferredWipeout: true, deleteDirs: true
-	} catch (Exception e) {
-		echo 'Exception: ' + e.toString()
-		//cleanWs has issue to delete workspace that contains non-ASCII filename in TKG output https://issues.jenkins.io/browse/JENKINS-33478
-		//cannot delete workspace directly. Otherwise, Jenkins job will abort due to missing workspace
-		dir (env.WORKSPACE) {
-			echo "Force clean Workspace at $pwd"
-			sh "rm -rf aqa-tests/TKG"
+	def retry_count = 0
+	def max_retries = 3
+	def sleep_time = 30
+	retry(max_retries) {
+		try {
+			if (retry_count > 0) {
+				echo "Retrying cleanWs attempt ${retry_count + 1}/${max_retries} after ${sleep_time} seconds sleep..."
+				sleep(sleep_time)
+			}
+			retry_count++
+			cleanWs disableDeferredWipeout: true, deleteDirs: true
+		} catch (Exception e) {
+			echo 'Exception: ' + e.toString()
+			//cleanWs has issue to delete workspace that contains non-ASCII filename in TKG output https://issues.jenkins.io/browse/JENKINS-33478
+			//cannot delete workspace directly. Otherwise, Jenkins job will abort due to missing workspace
+			dir (env.WORKSPACE) {
+				echo "Force clean Workspace at $pwd"
+				sh "rm -rf aqa-tests/TKG"
+			}
+			// call cleanWs() again
+			cleanWs disableDeferredWipeout: true, deleteDirs: true
 		}
-		// call cleanWs() again
-		cleanWs disableDeferredWipeout: true, deleteDirs: true
 	}
 }
 

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -663,18 +663,28 @@ def checkErrors(errorList) {
 
 
 def forceCleanWS() {
-    try {
-        cleanWs disableDeferredWipeout: true, deleteDirs: true
-    } catch (Exception e) {
-        echo 'Exception: ' + e.toString()
-        //cleanWs has issue to delete workspace that contains non-ASCII filename in TKG output https://issues.jenkins.io/browse/JENKINS-33478
-        //cannot delete workspace directly. Otherwise, Jenkins job will abort due to missing workspace
-        dir (env.WORKSPACE) {
-            echo "Force clean Workspace at $pwd"
-            sh "rm -rf aqa-tests/TKG"
+    def retry_count = 0
+    def max_retries = 3
+    def sleep_time = 30
+    retry(max_retries) {
+        try {
+            if (retry_count > 0) {
+                echo "Retrying cleanWs attempt ${retry_count + 1}/${max_retries} after ${sleep_time} seconds sleep..."
+                sleep(sleep_time)
+            }
+            retry_count++
+            cleanWs disableDeferredWipeout: true, deleteDirs: true
+        } catch (Exception e) {
+            echo 'Exception: ' + e.toString()
+            //cleanWs has issue to delete workspace that contains non-ASCII filename in TKG output https://issues.jenkins.io/browse/JENKINS-33478
+            //cannot delete workspace directly. Otherwise, Jenkins job will abort due to missing workspace
+            dir (env.WORKSPACE) {
+                echo "Force clean Workspace at $pwd"
+                sh "rm -rf aqa-tests/TKG"
+            }
+            // call cleanWs() again
+            cleanWs disableDeferredWipeout: true, deleteDirs: true
         }
-        // call cleanWs() again
-        cleanWs disableDeferredWipeout: true, deleteDirs: true
     }
 }
 


### PR DESCRIPTION
This PR adds sleep and retry functionality to the forceCleanWS() function to handle Windows-specific issues where processes may still be shutting down when workspace cleanup is attempted.
Changes Made

Added retry mechanism with 3 attempts and 30-second sleep between retries
Preserved existing exception handling and fallback logic
Added logging for retry attempts
Follows the same retry pattern used in runTest() function

Fixes https://github.com/adoptium/aqa-tests/issues/6611