### PR TITLE
Hardcoding jck-runtime-lang-CONV to use concurrency 1

### DIFF
--- a/jck/runtime.lang/playlist.xml
+++ b/jck/runtime.lang/playlist.xml
@@ -97,7 +97,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(GEN_JTB_GENERIC) tests=lang/CONV testsuite=RUNTIME; \
+		<command>$(GEN_JTB_GENERIC) tests=lang/CONV testsuite=RUNTIME concurrency=1; \
 		$(EXEC_RUNTIME_TEST); \
 		$(TEST_STATUS) ; \
 		$(GEN_SUMMARY_GENERIC) tests=lang/CONV testsuite=RUNTIME


### PR DESCRIPTION
Because the test is memory-heavy per-thread, and multiple threads can lead to OOMs.

Resolves #6631 