### PR TITLE
Remove archiving of cvsclient

### DIFF
--- a/buildenv/jenkins/getDependency
+++ b/buildenv/jenkins/getDependency
@@ -25,7 +25,6 @@ def testBuild() {
 				sh 'git clone https://github.com/adoptium/STF'
 				sh 'ant -f ./aqa-systemtest/openjdk.build/build.xml -Djava.home=${WORKSPACE}/j2sdk-image/jre -Dprereqs_root=${WORKSPACE}/systemtest_prereqs configure'
 				sh 'ant -f ./aqa-systemtest/openjdk.test.mauve/build.xml -Djava.home=${WORKSPACE}/j2sdk-image/jre -Dprereqs_root=${WORKSPACE}/systemtest_prereqs configure'
-				archiveArtifacts '**/systemtest_prereqs/cvsclient/org-netbeans-lib-cvsclient.jar'
 				archiveArtifacts '**/systemtest_prereqs/mauve/mauve.jar'
 				archiveArtifacts '**/systemtest_prereqs/junit/junit.jar'
 				archiveArtifacts '**/systemtest_prereqs/junit/hamcrest-core.jar'


### PR DESCRIPTION
Fixes #6637 

cvsclient is no longer needed (was previously used to fetch mauve src code)