### PR TITLE
Enable MiniMix_extended_3h on plinux and zlinux

### DIFF
--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -186,7 +186,7 @@
 			<disable>
 				<comment>https://github.ibm.com/runtimes/backlog/issues/597</comment>
 				<variation>Mode150-CS</variation>
-				<platform>^(?!x86-64_linux$).*</platform>
+				<platform>^(?!(x86-64_linux|ppc64le_linux|s390x_linux)$).*</platform>
 			</disable>
 		 </disables>
 		<variations>


### PR DESCRIPTION
- Enable MiniMix_extended_3h test on plinux and zlinux.

related:https://github.ibm.com/runtimes/backlog/issues/597