### PR TITLE
Enable the balanced GC mode for system tests.

### DIFF
--- a/system/lambdaLoadTest/playlist.xml
+++ b/system/lambdaLoadTest/playlist.xml
@@ -32,6 +32,8 @@
 		</disables>
 		<variations>
 			<variation>Mode110</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
 			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=LambdaLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
@@ -158,6 +160,8 @@
 		</disables>
 		<variations>
 			<variation>Mode110</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
 			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=ParallelStreamsLoadTest; \

--- a/system/mathLoadTest/playlist.xml
+++ b/system/mathLoadTest/playlist.xml
@@ -36,6 +36,8 @@
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
@@ -59,6 +61,8 @@
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -50,6 +50,8 @@
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
@@ -331,6 +333,8 @@
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
 			<variation>Mode650</variation>
 			<variation>Mode1000</variation>
 		</variations>
@@ -543,6 +547,8 @@
 		</disables>
 		<variations>
 			<variation>Mode110</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
 			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args-execute-initial=$(Q)-Xdisableexcessivegc$(Q) -test=HeapHogLoadTest -test-args=$(Q)timeLimit=5m$(Q); \
@@ -569,6 +575,8 @@
 		</disables>
 		<variations>
 			<variation>Mode110</variation>
+			<variation>Mode501</variation>
+			<variation>Mode551</variation>
 			<variation>Mode610</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -java-args-execute-initial=$(Q)-Xnoclassgc$(Q) -test=ObjectTreeLoadTest -test-args=$(Q)timeLimit=5m$(Q); \


### PR DESCRIPTION
- MathLoadTest_bigdecimal_5m
- ParallelStreamsLoadTest_J9
- HeapHogLoadTest_5m
- DBBLoadTest_5m
- LambdaLoadTest_J9_5m
- MathLoadTest_autosimd_5m
- MiniMix_5m
- ObjectTreeLoadTest_5m

Signed-off-by:Amrutha Kanhirathingal <Amrutha.Kanhirathingal@ibm.com>