### PR TITLE
Using adoptium test.dependency job for any Domain naming with "adoptium-team"

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1185,9 +1185,9 @@ def getCustomUrl() {
 	def jenkinsDomain = getJenkinsDomain()
 	if (jenkinsDomain.contains("hyc-runtimes")) {
 		jenkinsDomain = "openj9-jenkins.osuosl.org"
-	} else if (jenkinsDomain.contains("temurin-compliance")) {
-                jenkinsDomain = "ci.adoptium.net"
-        }
+	} else if (jenkinsDomain.contains("temurin-compliance") || jenkinsDomain.contains("adoptium-team")) {
+		jenkinsDomain = "ci.adoptium.net"
+	}
 
 	def customUrl = "https://${jenkinsDomain}/job/test.getDependency/lastSuccessfulBuild/artifact/"
 	echo "Custom URL: ${customUrl}"


### PR DESCRIPTION
Use adoptium test.dependancy job for private or testing jenkins server naming with "adoptium-team". No need to create or maintain a separate test.dependency job for those server. 