### PR TITLE
Exclude ComplexURITest test on JDK21 x64 macos

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -460,6 +460,7 @@ runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/564
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
+runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5920 windows-aarch64
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all


### PR DESCRIPTION
A consistent failure on JDK21 x64 macos, see https://github.com/adoptium/aqa-tests/issues/6578#issuecomment-3366221536. I see it is excluded on JDK24 and 25 so I recommend it be excluded on JDK21 x64 too. The issue link https://github.com/adoptium/adoptium-support/issues/937 is the same issue that is used to justify its exclusion on JDK24 and 25