### PR TITLE
Exclude CookieHandler/B6644726 JDK24 and JDK25 Macos

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -112,6 +112,7 @@ jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openj
 
 # jdk_net
 
+java/net/CookieHandler/B6644726.java https://bugs.openjdk.org/browse/JDK-8365811 macosx-all
 java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
 java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all

--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -112,6 +112,7 @@ jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openj
 
 # jdk_net
 
+java/net/CookieHandler/B6644726.java https://bugs.openjdk.org/browse/JDK-8365811 macosx-all
 java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
 java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all


### PR DESCRIPTION
Known upstream issue https://bugs.openjdk.org/browse/JDK-8365811. Last release triage recommended this issue be excluded https://github.com/adoptium/aqa-tests/issues/6555#issuecomment-3263758389