### PR TITLE
Disabling TestHeadlessComponents on Mac due to consistent timeouts

### DIFF
--- a/functional/testHeadlessComponents/playlist.xml
+++ b/functional/testHeadlessComponents/playlist.xml
@@ -25,10 +25,27 @@
 				<impl>ibm</impl>
 			</disable>
 			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6647#issuecomment-3382932623</comment>
+				<platform>aarch64_mac</platform>
+				<impl>hotspot</impl>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/pull/6648#issuecomment-3397002761</comment>
+				<platform>x86-64_windows</platform>
+				<impl>hotspot</impl>
+				<version>8</version>
+			</disable>
+			<disable>
 				<comment>https://github.com/adoptium/aqa-tests/issues/5775</comment>
 				<platform>x86-64_mac</platform>
-				<version>8</version>
 				<impl>hotspot</impl>
+				<version>8</version>
+			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/pull/6616#issuecomment-3323705754</comment>
+				<platform>x86-64_mac</platform>
+				<impl>hotspot</impl>
+				<version>25</version>
 			</disable>
 		</disables>
 		<command>


### PR DESCRIPTION
...that cause job failure and conceal other test failures.

Testing here: https://ci.adoptium.net/job/Grinder/14992

Related to (but does not close): #5775 