### PR TITLE
Update renaissance exclusion list for win_aarch64

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -256,6 +256,12 @@
 	</test>
 	<test>
 		<testCaseName>renaissance-naive-bayes</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4714#issuecomment-3387878382</comment>
+				<platform>aarch64_windows</platform>
+			</disable>
+		</disables>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)naive-bayes.json$(Q) naive-bayes; \
 		$(TEST_STATUS)</command>
 		<levels>


### PR DESCRIPTION
As mentioned in: https://github.com/adoptium/aqa-tests/issues/4714, https://github.com/adoptium/aqa-tests/issues/4129

Essentially the same PR as: https://github.com/adoptium/aqa-tests/pull/6657