### PR TITLE
[v1.0.10-release]- Disable perf renaissance-db-shootout on jdk11u arm linux for Eclipse temurin

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -77,6 +77,14 @@
 	</test>
 	<test>
 		<testCaseName>renaissance-db-shootout</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6669</comment>
+				<vendor>eclipse</vendor>
+				<platform>arm_linux</platform>
+				<version>11</version>
+			</disable>
+		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)db-shootout.json$(Q) db-shootout; \
 		$(TEST_STATUS)</command>
 		<!-- Issue https://github.com/renaissance-benchmarks/renaissance/issues/210 -->


### PR DESCRIPTION
Cherry pick PR https://github.com/adoptium/aqa-tests/pull/6670
