### PR TITLE
[v1.0.10-release] - Oct 2025 release mac x64 exclude for runtime/cds/NonJVMVariantLocation.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -485,8 +485,8 @@ runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-833755
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/infrastructure/issues/3984 macosx-aarch64, linux-riscv64, linux-ppc64le
-runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-aarch64,linux-riscv64,linux-ppc64le
+# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/infrastructure/issues/3984 macosx-all, linux-riscv64, linux-ppc64le
+runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
 runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64


### PR DESCRIPTION
Exclude runtime/cds/NonJVMVariantLocation.java as requires CDS for x64 Mac
