### PR TITLE
Exclude perf test renaissance-naive-bayes on 32bit Windows

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -261,6 +261,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/4714#issuecomment-3387878382</comment>
 				<platform>aarch64_windows</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6675</comment>
+				<platform>x86-32_windows</platform>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)naive-bayes.json$(Q) naive-bayes; \
 		$(TEST_STATUS)</command>


### PR DESCRIPTION
Because the hadoop.dll supplied in the renaissance jar is incompatible with 32bit Windows.

Cherry-picked from https://github.com/adoptium/aqa-tests/pull/6676