### PR TITLE
JDK25 enables getEnclosingMethod/BadEnclosingMethodTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -40,7 +40,6 @@ java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/eclipse-openj9
 java/lang/annotation/AnnotationsInheritanceOrderRedefinitionTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/annotation/loaderLeak/Main.java https://github.com/eclipse-openj9/openj9/issues/6701 generic-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
-java/lang/Class/getEnclosingMethod/BadEnclosingMethodTest.java https://github.com/eclipse-openj9/openj9/issues/21732 generic-all
 java/lang/Class/GetModuleTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/ClassLoader/Assert.java https://github.com/eclipse-openj9/openj9/issues/6668 macosx-x64
 java/lang/ClassLoader/EndorsedDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all


### PR DESCRIPTION
JDK25 enables `getEnclosingMethod/BadEnclosingMethodTest.java`

related to https://github.com/eclipse-openj9/openj9/issues/21732

Signed-off-by: Jason Feng <fengj@ca.ibm.com>