### PR TITLE
AIX excludes for oct 25 release

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -230,6 +230,7 @@ java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.n
 java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
+java/nio/file/attribute/UserDefinedFileAttributeView/Basic.java https://bugs.openjdk.org/browse/JDK-8370316 aix-all
 
 ############################################################################ 
 
@@ -410,6 +411,17 @@ jdk/incubator/vector/IntMaxVectorTests.java https://github.com/adoptium/aqa-test
 jdk/incubator/vector/Short64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/ShortMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/Byte256VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
+jdk/incubator/vector/Int64VectorLoadStoreTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/Byte64VectorLoadStoreTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/Byte64VectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/ByteMaxVectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/Float64VectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/FloatMaxVectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/Int64VectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/IntMaxVectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/Short64VectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
+jdk/incubator/vector/ShortMaxVectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
 
 ############################################################################
 


### PR DESCRIPTION
AIX jdk25u excludes for:
- java/nio/file/attribute/UserDefinedFileAttributeView/Basic.java - https://github.com/adoptium/aqa-tests/issues/6590 - https://bugs.openjdk.org/browse/JDK-8370316
- jdk/incubator/vector/* - https://github.com/adoptium/aqa-tests/issues/6591 - https://bugs.openjdk.org/browse/JDK-8370244
- 