### PR TITLE
Oct 25 aarch32 jdk8u testenv

### DIFF
--- a/testenv/testenv_arm32.properties
+++ b/testenv/testenv_arm32.properties
@@ -9,6 +9,6 @@ OPENJ9_SYSTEMTEST_BRANCH=master
 ADOPTOPENJDK_SYSTEMTEST_REPO=https://github.com/adoptium/aqa-systemtest.git
 ADOPTOPENJDK_SYSTEMTEST_BRANCH=master
 JDK8_REPO=https://github.com/adoptium/aarch32-jdk8u.git
-JDK8_BRANCH=dev
+JDK8_BRANCH=jdk8u472-b08-aarch32-20251022
 AQA_REQUIRED_TARGETS=sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,extended.perf
 


### PR DESCRIPTION
Upstream jdk8u arm32 tags have been pushed: https://github.com/adoptium/aarch32-jdk8u/tags
- [jdk8u472-b08-aarch32-20251022](https://github.com/adoptium/aarch32-jdk8u/releases/tag/jdk8u472-b08-aarch32-20251022)
- 