### PR TITLE
Exclude CookieHandler on all platforms JDK25

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -112,7 +112,7 @@ jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openj
 
 # jdk_net
 
-java/net/CookieHandler/B6644726.java https://bugs.openjdk.org/browse/JDK-8365811 macosx-all
+java/net/CookieHandler/B6644726.java https://bugs.openjdk.org/browse/JDK-8365811 generic-all
 java/net/Inet4Address/PingThis.java https://github.com/adoptium/infrastructure/issues/1127 aix-all
 java/net/InetAddress/BadDottedIPAddress.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/net/InetAddress/CachedUnknownHostName.java https://github.com/adoptium/aqa-tests/issues/593 linux-all


### PR DESCRIPTION
Test was excluded for Macos x64 and aarch64 but is also failing for all platforms on JDK25, seen in this current release triage https://github.com/adoptium/aqa-tests/issues/6685

Will cherry pick into the release branch after this is merged