### PR TITLE
Excluded renaissance-naive-bayes test for all windows

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -266,12 +266,8 @@
 		<testCaseName>renaissance-naive-bayes</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/4714#issuecomment-3387878382</comment>
-				<platform>aarch64_windows</platform>
-			</disable>
-			<disable>
-				<comment>https://github.com/adoptium/aqa-tests/issues/6675</comment>
-				<platform>x86-32_windows</platform>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6701</comment>
+				<platform>.*windows.*</platform>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)naive-bayes.json$(Q) naive-bayes; \


### PR DESCRIPTION
Disabled the renaissance-naive-bayes test for all windows
Merged all excludes to one 

Closes : #[1712](https://github.ibm.com/runtimes/backlog/issues/1712)
Related :#[6701](https://github.com/adoptium/aqa-tests/issues/)