### PR TITLE
openjdk: add hotspot_vmTestbase_vm_metaspace target

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -795,6 +795,32 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>hotspot_vmTestbase_vm_metaspace</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JVM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(JTREG_HOTSPOT_TEST_DIR):vmTestbase_vm_metaspace$(Q); \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_awt</testCaseName>
 		<disables>
 			<disable>


### PR DESCRIPTION
Adds hotspot [vmTestbase_vm_metaspace](https://github.com/zzambers/jdk11u-dev/blob/168024359375be044ec76c6c7a0781ddec1db689/test/hotspot/jtreg/TEST.groups#L459) target to openjdk tests.

(VM testbase tests were [opensourced](https://bugs.openjdk.org/browse/JDK-8199257) in jdk11, but many are missing in aqa-tests.)

**Testing:**
**jdk11:** [RESULTS](https://ci.adoptium.net/job/Grinder/15253/)
x86-64_linux, aarch64_linux, s390x_linux, x86-64_windows, x86-32_windows, x86-64_mac, ppc64_aix: **OK**

**jdk17:** [RESULTS](https://ci.adoptium.net/job/Grinder/15270/)
x86-64_linux, aarch64_linux, x86-64_windows, x86-64_mac, ppc64_aix: **OK**

**jdk21:** [RESULTS](https://ci.adoptium.net/job/Grinder/15282/)
x86-64_linux, s390x_linux, x86-64_windows, x86-64_mac: **OK**

**jdk25**
TBD, openjdk testing on jdk 25 seems currently [broken](https://ci.adoptium.net/job/Grinder/15293/console) due to jtreg version requirement:
```
19:20:01  TESTING:
19:20:01  Error: The testsuite at /home/jenkins/workspace/Grinder/aqa-tests/openjdk/openjdk-jdk/test/hotspot/jtreg requires jtreg version 8+2 or higher and this is jtreg version 7.5.1-dev+1.
```

**EDIT:** jdk25 works now:

**jdk25:** [RESULTS](https://ci.adoptium.net/job/Grinder/15324/)
x86-64_linux,riscv64_linux,x86-64_windows,x86-64_mac,ppc64_aix: **OK**


Fixes: https://github.com/adoptium/aqa-tests/issues/6712