### PR TITLE
Unexclude DefineClassDirectByteBuffer for OpenJ9 jdk26

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk26-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk26-openj9.txt
@@ -42,7 +42,6 @@ java/lang/annotation/loaderLeak/Main.java https://github.com/eclipse-openj9/open
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
 java/lang/Class/GetModuleTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/ClassLoader/Assert.java https://github.com/eclipse-openj9/openj9/issues/6668 macosx-x64
-java/lang/ClassLoader/defineClass/DefineClassDirectByteBuffer.java https://github.com/eclipse-openj9/openj9/issues/22861 generic-all
 java/lang/ClassLoader/EndorsedDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all
 java/lang/ClassLoader/ExtDirs.java https://github.com/eclipse-openj9/openj9/issues/3055 generic-all
 java/lang/ClassLoader/LibraryPathProperty.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/22861
Fixed via https://github.com/eclipse-openj9/openj9/pull/22882