### PR TITLE
Exclude MauveSingleThrdLoad_J9, MauveSingleInvocLoad_J9 jdk17, 21, 26+

### DIFF
--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -11,6 +11,14 @@
 				<impl>ibm</impl>
 				<version>8</version>
 			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/22912</comment>
+				<version>[17, 21]</version>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/22912</comment>
+				<version>26+</version>
+			</disable>
 		</disables>
 		<variations>
 			<variation>Mode110</variation>
@@ -76,6 +84,14 @@
 				<comment>automation/issues/474</comment>
 				<impl>ibm</impl>
 				<version>8</version>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/22912</comment>
+				<version>[17, 21]</version>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/22912</comment>
+				<version>26+</version>
 			</disable>
 		</disables>
 		<variations>


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/22912

jdk26 grinder showing disabled tests
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/4845/