### PR TITLE
Exclude java/lang/Thread/virtual/KlassInit on OpenJ9 jdk26

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk26-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk26-openj9.txt
@@ -129,6 +129,11 @@ java/lang/Thread/UncaughtExceptions.sh https://github.com/eclipse-openj9/openj9/
 java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/17399 generic-all
 java/lang/Thread/virtual/Collectable.java https://github.com/eclipse-openj9/openj9/issues/18463 windows-all
 java/lang/Thread/virtual/JfrEvents.java https://github.com/eclipse-openj9/openj9/issues/20166 generic-all
+java/lang/Thread/virtual/KlassInit.java#default https://github.com/eclipse-openj9/openj9/issues/22936 generic-all
+java/lang/Thread/virtual/KlassInit.java#Xcomp https://github.com/eclipse-openj9/openj9/issues/22936 generic-all
+java/lang/Thread/virtual/KlassInit.java#Xcomp-noTieredCompilation https://github.com/eclipse-openj9/openj9/issues/22936 generic-all
+java/lang/Thread/virtual/KlassInit.java#Xcomp-TieredStopAtLevel1 https://github.com/eclipse-openj9/openj9/issues/22936 generic-all
+java/lang/Thread/virtual/KlassInit.java#Xint https://github.com/eclipse-openj9/openj9/issues/22936 generic-all
 java/lang/Thread/virtual/Starvation.java https://github.com/eclipse-openj9/openj9/issues/21957 aix-all,linux-ppc64le
 java/lang/Thread/virtual/ThreadAPI.java#default https://github.com/eclipse-openj9/openj9/issues/22029 windows-all
 java/lang/Thread/virtual/ThreadAPI.java#no-vmcontinuations https://github.com/eclipse-openj9/openj9/issues/22029 windows-all


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/22936