### PR TITLE
Correct arctic runtests.sh backslash escape

### DIFF
--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -45,19 +45,19 @@ setupLinuxEnv() {
 
 	# Ensure consistent colors
 	sed -i 's/BorderColor.*$/BorderColor "slategrey"/g' $HOME/.twmrc
-	sed -i 's/DefaultBackground.*$/DefaultBackground "rgb:2\\/a\\/9"/g' $HOME/.twmrc
+	sed -i 's/DefaultBackground.*$/DefaultBackground "rgb:2\/a\/9"/g' $HOME/.twmrc
 	sed -i 's/DefaultForeground.*$/DefaultForeground "gray85"/g' $HOME/.twmrc
-	sed -i 's/TitleBackground.*$/TitleBackground "rgb:2\\/a\\/9"/g' $HOME/.twmrc
+	sed -i 's/TitleBackground.*$/TitleBackground "rgb:2\/a\/9"/g' $HOME/.twmrc
 	sed -i 's/TitleForeground.*$/TitleForeground "gray85"/g' $HOME/.twmrc
-	sed -i 's/MenuBackground.*$/MenuBackground "rgb:2\\/a\\/9"/g' $HOME/.twmrc
+	sed -i 's/MenuBackground.*$/MenuBackground "rgb:2\/a\/9"/g' $HOME/.twmrc
 	sed -i 's/MenuForeground.*$/MenuForeground "gray85"/g' $HOME/.twmrc
 	sed -i 's/MenuBorderColor.*$/MenuBorderColor "slategrey"/g' $HOME/.twmrc
 	sed -i 's/MenuTitleBackground.*$/MenuTitleBackground "gray70"/g' $HOME/.twmrc
-	sed -i 's/MenuTitleForeground.*$/MenuTitleForeground "rgb:2\\/a\\/9"/g' $HOME/.twmrc
-	sed -i 's/IconBackground.*$/IconBackground "rgb:2\\/a\\/9"/g' $HOME/.twmrc
+	sed -i 's/MenuTitleForeground.*$/MenuTitleForeground "rgb:2\/a\/9"/g' $HOME/.twmrc
+	sed -i 's/IconBackground.*$/IconBackground "rgb:2\/a\/9"/g' $HOME/.twmrc
 	sed -i 's/IconForeground.*$/IconForeground "gray85"/g' $HOME/.twmrc
 	sed -i 's/IconBorderColor.*$/IconBorderColor "gray85"/g' $HOME/.twmrc
-	sed -i 's/IconManagerBackground.*$/IconManagerBackground "rgb:2\\/a\\/9"/g' $HOME/.twmrc
+	sed -i 's/IconManagerBackground.*$/IconManagerBackground "rgb:2\/a\/9"/g' $HOME/.twmrc
 	sed -i 's/IconManagerForeground.*$/IconManagerForeground "gray85"/g' $HOME/.twmrc
 
 	# Start twm


### PR DESCRIPTION
The linux setup twmrc sed commands in runtests.sh had incorrect backslash escapes, resulting in:
```
[2025-10-29T17:03:40.028Z] sed: -e expression #1, char 51: unknown option to `s'
[2025-10-29T17:03:40.028Z] sed: -e expression #1, char 47: unknown option to `s'
[2025-10-29T17:03:40.028Z] sed: -e expression #1, char 45: unknown option to `s'
[2025-10-29T17:03:40.597Z] sed: -e expression #1, char 55: unknown option to `s'
[2025-10-29T17:03:40.597Z] sed: -e expression #1, char 45: unknown option to `s'
[2025-10-29T17:03:40.597Z] sed: -e expression #1, char 59: unknown option to `s'
```

Since the sed string is in single 's, it does not need the double backslash:
```
sed -i 's/IconManagerBackground.*$/IconManagerBackground "rgb:2\\/a\\/9"/g' $HOME/.twmrc
```
should be:
```
sed -i 's/IconManagerBackground.*$/IconManagerBackground "rgb:2\/a\/9"/g' $HOME/.twmrc
```

