### PR TITLE
Restore wildcard in ProblemList pattern

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -243,7 +243,7 @@
 
 	<target name="dist" depends="getJtreg, getOpenjdk" description="generate the distribution">
 		<copy todir="${DEST}">
-			<fileset dir="${src}" includes="*.xml,**/ProblemList_openjdk${env.JDK_VERSION}.txt,*.mk"/>
+			<fileset dir="${src}" includes="*.xml,**/ProblemList_openjdk${env.JDK_VERSION}*.txt,*.mk"/>
 		</copy>
 	</target>
 


### PR DESCRIPTION
Inadvertently removed by #6472.

Downstream testing is failing, e.g. https://openj9-jenkins.osuosl.org/job/Test_openjdk21_j9_sanity.openjdk_aarch64_mac_Personal/252.