### PR TITLE
Update runTests.sh to not check pid when testcase was not started as was Skipped

### DIFF
--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -345,9 +345,11 @@ for i in "${active_versions[@]}"; do
               sleep $SLEEP_TIME
             fi
 
-            # Check testcase started successfully.
-            ps -p $test_pid
-            rc=$?
+            # Check testcase started successfully if not Skipped.
+            if [[ $skipped == false ]]; then
+              ps -p $test_pid
+              rc=$?
+            fi
             if [[ $skipped == true ]] || [[ $rc != 0 ]]; then
               if [[ $skipped == false ]]; then
                 echo "ERROR: Test class failed prior to playback."


### PR DESCRIPTION
When running arctic interactives runTests.sh was checking the testcase "pid" was started for Skipped tests, resulting in stderr noisy output, eg:
```
16:01:36  Skipping: api/java_awt interactive/....
16:01:36  error: process ID out of range
16:01:36  
16:01:36  Usage:
16:01:36   ps [options]
16:01:36  
16:01:36   Try 'ps --help <simple|list|output|threads|misc|all>'
16:01:36    or 'ps --help <s|l|o|t|m|a>'
16:01:36   for additional help text.
16:01:36  
16:01:36  For more details see ps(1).
```
