### PR TITLE
Add special jdk_valhalla and hotspot_valhalla targets for OpenJ9

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -151,12 +151,20 @@
 							</then>
 							<else>
 								<if>
-									<contains string="${SPEC}" substring="zos"/>
+									<equals arg1="${env.ORIGIN_JDK_VERSION}" arg2="Valhalla"/>
 									<then>
-										<property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}-zos"/>
+										<property name="jdkName" value="openj9-openjdk-jdk.valuetypes"/>
 									</then>
 									<else>
-										<property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}"/>
+										<if>
+											<contains string="${SPEC}" substring="zos"/>
+											<then>
+												<property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}-zos"/>
+											</then>
+											<else>
+												<property name="jdkName" value="openj9-openjdk-jdk${JDK_VERSION}"/>
+											</else>
+										</if>
 									</else>
 								</if>
 							</else>
@@ -242,9 +250,31 @@
 	</target>
 
 	<target name="dist" depends="getJtreg, getOpenjdk" description="generate the distribution">
-		<copy todir="${DEST}">
-			<fileset dir="${src}" includes="*.xml,**/ProblemList_openjdk${env.JDK_VERSION}*.txt,*.mk"/>
-		</copy>
+		<if>
+			<matches string="${JDK_IMPL}" pattern="openj9|ibm"/>
+			<then>
+				<if>
+					<equals arg1="${env.ORIGIN_JDK_VERSION}" arg2="Valhalla"/>
+					<then>
+						<copy todir="${DEST}">
+							<!-- When updating the problem list version also update
+							 PROBLEM_LIST_FILE for OpenJ9 in openjdk.mk -->
+							<fileset dir="${src}" includes="*.xml,**/ProblemList_openjdk26-openj9.txt,**/ProblemList_openjdkvalhalla-openj9.txt,*.mk"/>
+						</copy>
+					</then>
+					<else>
+						<copy todir="${DEST}">
+							<fileset dir="${src}" includes="*.xml,**/ProblemList_openjdk${env.JDK_VERSION}*.txt,*.mk"/>
+						</copy>
+					</else>
+				</if>
+			</then>
+			<else>
+				<copy todir="${DEST}">
+					<fileset dir="${src}" includes="*.xml,**/ProblemList_openjdk${env.JDK_VERSION}*.txt,*.mk"/>
+				</copy>
+			</else>
+		</if>
 	</target>
 
 	<target name="build">

--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -1,0 +1,263 @@
+############################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+############################################################################
+
+# To determine required OS exclusion string see http://hg.openjdk.java.net/code-tools/jtreg/file/6f00c63c0a98/src/share/classes/com/sun/javatest/regtest/config/OS.java
+
+############################################################################
+
+# jdk_valhalla - valhalla
+
+############################################################################
+valhalla/valuetypes/ArrayElementVarHandleTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/FlatVarHandleTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/IsIdentityClassTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/LayoutIterationTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/MethodHandleTest.java https://github.com/eclipse-openj9/openj9/issues/22648 generic-all
+valhalla/valuetypes/NullRestrictedArraysTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/NullRestrictedTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/ObjectMethods.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/RecursiveValueClass.java https://github.com/eclipse-openj9/openj9/issues/20497 generic-all
+valhalla/valuetypes/Reflection.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/StreamTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/SubstitutabilityTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/ValueClassTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+valhalla/valuetypes/WeakReferenceTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+
+############################################################################
+
+# jdk_valhalla - java/lang/invoke
+
+############################################################################
+java/lang/invoke/BigArityTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+java/lang/invoke/VarHandles/VarHandleTestAccessValue.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+java/lang/invoke/defineHiddenClass/BasicTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+java/lang/invoke/defineHiddenClass/PreviewHiddenClass.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+
+############################################################################
+
+# jdk_valhalla - java/lang/instrument/valhalla
+
+############################################################################
+
+############################################################################
+
+# hotspot_valhalla - runtime/valhalla
+
+############################################################################
+runtime/valhalla/inlinetypes/AnnotationsTests.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/ArrayQueryTest.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/ClassPrintLayoutDcmd.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/EmptyInlineTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/FlatArraysTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/FlattenableSemanticTest.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/InlineTypeArray.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/InlineTypeDensity.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/InlineTypeGetField.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/InlineWithJni.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/MonitorEnterTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/MonitorEnterTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/MonitorEnterTest.java#id1 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/MonitorEnterTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/PreloadCircularityTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/QuickeningTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/StaticFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/TestFieldNullability.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/TestJNIIsSameObject.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/ValuePreloadTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/ValueTearing.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/VolatileTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/classfileparser/TestIllegalLoadableDescriptors.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/classloading/BigClassTreeClassLoader.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/classloading/PreLoadCircularityTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/classloading/PreLoadFailuresDoNotImpactApplicationTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#CompressedOops https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#NoCompressedOops https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_0 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_1 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_3 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_4 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_5 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_6 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_7 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_atomic_flat_and_no_nullable_flat https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_atomic_flat_and_nullable_flat https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_no_atomic_flat_and_no_nullable_flat https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_no_atomic_flat_and_nullable_flat https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64bitsCompressedOops https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64bitsNoCompressedOops https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64bitsNoCompressedOopsNoCompressKlassPointers https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/verifier/RedefineStrictFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/verifier/StrictFields.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/verifier/StrictFinalInstanceFieldsTest.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/verifier/StrictStaticTests.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/verifier/UninitializedThisVerificationTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+
+############################################################################
+
+# hotspot_valhalla - serviceability/jvmti/valhalla
+
+############################################################################
+serviceability/jvmti/valhalla/FieldAccessModify/FieldAccessModify.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/ForceEarlyReturn/ValueForceEarlyReturn.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/GetClassFields/ValueGetClassFields.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/GetObjectMonitorUsage/ValueGetObjectMonitorUsage.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/GetObjectSize/ValueGetObjectSize.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/GetSetLocal/ValueGetSetLocal.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+
+############################################################################
+
+# hotspot_valhalla - compiler/valhalla
+
+############################################################################
+compiler/valhalla/inlinetypes/BlackholeTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/RepairStackWithBigFrame.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestAllocationMergeAndFolding.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java#default https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java#do https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java#do-no-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#AVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#AVF-nAVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-AVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#NVF-nAVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#all-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#all-flattening-di https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#all-flattening-restrict-profiling https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#default https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#nAVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrayNullMarkers.java#no-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestArrays.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestBasicFunctionality.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestBufferTearing.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestC1.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestC2CCalls.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestC2CCalls.java#default https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestC2CCalls.java#no-bimorphic https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestC2CCalls.java#no-bimorphic-no-prof https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestC2CCalls.java#no-bimorphic-no-prof2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestC2CCalls.java#no-bimorphic2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestCallingConvention.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestCallingConventionC1.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java#default https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java#no-TLAB https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java#no-mono https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java#no-mono-AII https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java#no-mono-no-FF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java#no-mono-no-FF-AII https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java#no-mono-no-field https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java#no-mono-no-field-AII https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#AVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#AVF-nAVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#NVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#NVF-AVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#NVF-nAVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#all-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#all-flattening-di https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#all-flattening-no-pass-fields https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#all-flattening-pass-args https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#all-flattening-pass-fields https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#all-flattening-return-fields https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#nAVF https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#no-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFieldNullMarkers.java#noFlags https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFlatArrayThreshold.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java#id1 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestGenerated.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestGetfieldChains.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestInlineFieldNonFlattened.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestIntrinsics.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestJNICalls.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestLWorld.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestLWorldProfiling.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestLarvalState.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestMemBars.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestMethodHandles.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestMismatchHandling.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestNewAcmp.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestNullableArrays.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestNullableInlineTypes.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOnStackReplacement.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java#c1 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java#c1-no-preload https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java#c1-stress-cc https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java#c2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java#c2-no-preload https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java#c2-stress-cc https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java#int https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java#int-no-preload https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestOopsInReturnConvention.java#int-stress-cc https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java#c2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java#c2-no-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java#default https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java#no-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java#xcomp https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java#xcomp-c2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java#xcomp-c2-no-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java#xcomp-no-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnloadedReturnTypes.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestUnresolvedInlineClass.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueClasses.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#CompileonlyTest https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#DeoptimizeALot https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#DontInlineHelper https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#DontInlineMyAbstractInit https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#DontInlineMyValueInit https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#DontInlineObjectInit https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#DontInlineObjectInitDeoptimizeALot https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInlining https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInliningCompileOnlyTest https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInliningDontInlineMyAbstractInit https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInliningDontInlineMyValueInit https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInliningDontInlineObjectInit https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#StressIncrementalInliningOnStackReplacement https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueConstruction.java#Xbatch https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestValueRematDuringTypeSharpening.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#ci https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#ci-test https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#ci-test-di https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#ci-test-di-exclude-helper https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#ci-test-di-helper https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#co-di https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#default https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-ci https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-di https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test-di https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test-di-exclude-helper https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test-di-helper https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+compiler/valhalla/inlinetypes/bootstrap/TestBootClassloader.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -207,9 +207,16 @@ TEST_VARIATION_JIT_PREVIEW:=
 TEST_VARIATION_JIT_AGGRESIVE:=
 TIMEOUT_HANDLER:=
 
-# if JDK_IMPL is openj9 or ibm
+# if JDK_IMPL is openj9 or ibm. 
+# When updating the PROBLEM_LIST_FILE for Project Valhalla also update it
+# in the build.xml dist target.
 ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
-	PROBLEM_LIST_FILE:=excludes/ProblemList_openjdk$(JDK_VERSION)-openj9.txt
+	ifneq ($(filter Valhalla, $(JDK_VERSION)),)
+		PROBLEM_LIST_FILE:=excludes/ProblemList_openjdk26-openj9.txt
+		PROBLEM_LIST_FILE_VALHALLA:=excludes/ProblemList_openjdkvalhalla-openj9.txt
+	else
+		PROBLEM_LIST_FILE:=excludes/ProblemList_openjdk$(JDK_VERSION)-openj9.txt
+	endif
 	PROBLEM_LIST_DEFAULT:=excludes/ProblemList_openjdk11-openj9.txt
 	TEST_VARIATION_DUMP:=-Xdump:system:none -Xdump:heap:none -Xdump:system:events=gpf+abort+traceassert+corruptcache
 	TEST_VARIATION_JIT_PREVIEW:=-XX:-JITServerTechPreviewMessage

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -15,6 +15,72 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../TKG/resources/playlist.xsd">
 	<include>openjdk.mk</include>
 	<test>
+		<testCaseName>jdk_valhalla</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>-XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+			$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) \
+			-vmoptions:$(Q)-Xmx512m --patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
+			--enable-preview $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+			$(TIMEOUT_HANDLER) \
+			-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+			-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+			-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+			-exclude:$(Q)$(JTREG_JDK_TEST_DIR)$(D)ProblemList.txt$(Q) \
+			-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+			-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE_VALHALLA)$(Q) \
+			${FEATURE_PROBLEM_LIST_FILE} \
+			${VENDOR_PROBLEM_LIST_FILE} \
+			$(Q)$(JTREG_JDK_TEST_DIR):jdk_valhalla$(Q); \
+			$(TEST_STATUS)
+		</command>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>hotspot_valhalla</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+			<variation>-XX:ValueTypeFlatteningThreshold=99999 -XX:+EnableArrayFlattening</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+			$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) \
+			-vmoptions:$(Q)-Xmx512m --patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
+			--enable-preview -Djdk.debug=release $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+			$(TIMEOUT_HANDLER) \
+			-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+			-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+			-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+			-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \
+			-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+			-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE_VALHALLA)$(Q) \
+			${FEATURE_PROBLEM_LIST_FILE} \
+			${VENDOR_PROBLEM_LIST_FILE} \
+			$(Q)$(JTREG_HOTSPOT_TEST_DIR):hotspot_valhalla$(Q); \
+			$(TEST_STATUS)
+		</command>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+		<levels>
+			<level>special</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>jdk_custom</testCaseName>
 		<command>$(JAVA_COMMAND) -Xmx512m $(APPLICATION_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
 	$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \

--- a/scripts/disabled_tests/exclude_parser.py
+++ b/scripts/disabled_tests/exclude_parser.py
@@ -54,7 +54,7 @@ class ExcludeFileInfo:
     path: os.PathLike
     lines: List['TestExclusionRawLine']
 
-    FILE_PATTERN: ClassVar = re.compile(r'ProblemList_openjdk(?P<jdk_version>\d+)-?(?P<jdk_impl>.*).txt')
+    FILE_PATTERN: ClassVar = re.compile(r'ProblemList_openjdk(?P<jdk_version>(\d+|valhalla))-?(?P<jdk_impl>.*).txt')
 
     @classmethod
     def get_jdk_info(cls, exclude_path):


### PR DESCRIPTION
Grinder running the new targets: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/56504/

@hangshao0 do the command line variations look okay to you?
@AditiS11 the ProblemList file contains known test failures that are excluded from the run. Are there any tests you fixed recently that shouldn't be on the list I missed?