### PR TITLE
Change RunWrapper.getRawBuild().getNumber() to use public RunWrapper.getNumber()

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1650,8 +1650,7 @@ def archiveChildJobTap(childJobs, originalStatus = 'SUCCESS') {
 			sortByProjectName(jobList)
 			jobList.each {
 				cjob ->
-					def jobInvocation = cjob.getRawBuild()
-					def buildId = jobInvocation.getNumber()
+					def buildId = cjob.getNumber()
 					def name = cjob.getProjectName()
 					def childResult = cjob.getCurrentResult()
 					echo "${name} #${buildId} completed with status ${childResult}"

--- a/buildenv/jenkins/perfPipeline.groovy
+++ b/buildenv/jenkins/perfPipeline.groovy
@@ -123,7 +123,7 @@ def generateChildJobViaAutoGen(newJobName) {
 def aggregateLogs(run, runtimes) {
         def json 
         node("ci.role.test&&hw.arch.x86&&sw.os.linux") {
-                def buildId  = run.getRawBuild().getNumber()
+                def buildId  = run.getNumber()
                 def name = run.getProjectName()
                 def result = run.getCurrentResult()
 


### PR DESCRIPTION
Jenkins  RunWrapper.getRawBuild() uses the "internal" Jenkins Run object, which exposes potentially unsecure fields and requires "Script Approval".
The public RunWrapper interface already provides getNumber() which was the only use of this class.

Test build: https://ci.adoptium.net/job/Test_openjdk25_hs_special.openjdk_s390x_linux/30/
Build number retrieved successfully:
```
15:07:07  Test_openjdk25_hs_special.openjdk_s390x_linux_testList_0 #19 completed with status UNSTABLE
```

