### PR TITLE
Use LIBPATH Environment Variable to Run Serviceability JVMTI Tests

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -189,6 +189,9 @@ ifneq ($(JDK_VERSION),8)
 		# else if JDK_IMPL is openj9 or ibm
 		else ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
 			JVM_NATIVE_OPTIONS := -nativepath:"$(TESTIMAGE_PATH)$(D)openj9"
+			ifeq ($(OS),OS/390)
+			  ZOS_ONLY_NATIVE_LIBPATH := -e LIBPATH=$(TESTIMAGE_PATH)$(D)hotspot$(D)jtreg$(D)native
+			endif
 		endif
 	endif
 endif

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -606,7 +606,7 @@
 			<variation>Mode1000</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -Xmx512m $(APPLICATION_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
-	$(JTREG_BASIC_OPTIONS) -nativepath:"$(TESTIMAGE_PATH)/hotspot/jtreg/native" -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	$(JTREG_BASIC_OPTIONS) -nativepath:"$(TESTIMAGE_PATH)/hotspot/jtreg/native" ${ZOS_ONLY_NATIVE_LIBPATH} -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
 	$(TIMEOUT_HANDLER) \
 	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
 	-r $(Q)$(TEST_RESROOT)$(D)report$(Q) \


### PR DESCRIPTION
Use LIBPATH environment variable option to run serviceability jvmti tests 

Signed-off-by: Darshan N [Darshan.N3@ibm.com](mailto:Darshan.N3@ibm.com)