### PR TITLE
fix: prevent duplicate execution of testenvSettings.sh when DYNAMIC_COMPILE=false

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -6,7 +6,7 @@ import org.tap4j.model.TestSet;
 def makeTest(testParam) {
 	String tearDownCmd = "$RESOLVED_MAKE; \$MAKE -f ./aqa-tests/TKG/testEnv.mk testEnvTeardown"
 	// Note: keyword source cannot be used in Jenkins script. Therefore, using "." instead.
-    // When DYNAMIC_COMPILE=false, do not source testenvSettings.sh.  Only
+    // When DYNAMIC_COMPILE=false, do not source testenvSettings.sh (to avoid calling it twice). Only
     // source the settings when env.DYNAMIC_COMPILE is true.
 	String makeTestCmd = "$RESOLVED_MAKE;cd ./aqa-tests/TKG; \$MAKE $testParam"
 	if (env.DYNAMIC_COMPILE) {


### PR DESCRIPTION
# Jenkins pipeline behavior (single-source of testenvSettings.sh)

- Avoid re-sourcing testenvSettings.sh from [JenkinsfileBase](vscode-file://vscode-app/snap/code/214/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in non-dynamic compile scenarios to prevent double-sourcing when [compile.sh](vscode-file://vscode-app/snap/code/214/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) already sources it.

- Implement the change using a Groovy boolean conditional for DYNAMIC_COMPILE (i.e., if (params.DYNAMIC_COMPILE)), defaulting to NOT sourcing in the makeTestCmd command.

- Ensures testenvSettings.sh is only sourced by Jenkins if DYNAMIC_COMPILE is enabled; otherwise it runs once under [compile.sh](vscode-file://vscode-app/snap/code/214/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Closes #5297
