### PR TITLE
Correct Dynamic Queue logic for CLOUD_PROVIDER and Static node combinations

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -383,6 +383,12 @@ timestamps{
             println "Specified LABEL: ${LABEL}"
 
             stage('Queue') {
+                // Queue & provisioning logic:
+                //  - Construct the correct required "Provisioning LABEL" based on static (ci.role.test) or
+                //    dynamic (ci.agent.dynamic) requirement from the users params and the "Specified LABEL"
+                //  - Then do a "online" check for the resulting "Provisioning LABEL" in case ALL nodes are "Down/Disconnected"
+                //  - Then do the node("Provisioning LABEL") provision request to Jenkins
+
                 // If CLOUD_PROVIDER is set, use the supported virtual agent.
                 dynamicAgents = PLATFORM_MAP[params.PLATFORM]["DynamicAgents"] ? PLATFORM_MAP[params.PLATFORM]["DynamicAgents"] : []
                 println "dynamicAgents: ${dynamicAgents}"


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/6773

Concurrent tests with CLOUD_PROVIDER=azure, with 10 "static" nodes available:
- https://ci.adoptium.net/job/Test_openjdk21_hs_sanity.openjdk_x86-64_linux/363/console
  - All provisioned on 3 of the Static nodes
- https://ci.adoptium.net/view/Test_openjdk/job/Test_openjdk21_hs_extended.openjdk_x86-64_linux/207/console
  - 7 provisioned on the remaining Static nodes
  - 3 provisioned on Azure dynamic nodes: [test-linux-x64-d0f330](https://ci.adoptium.net/computer/test%2Dlinux%2Dx64%2Dd0f330/) [test-linux-x64-d0f331](https://ci.adoptium.net/computer/test%2Dlinux%2Dx64%2Dd0f331/) [test-linux-x64-d1d830](https://ci.adoptium.net/computer/test%2Dlinux%2Dx64%2Dd1d830/)
```
00:00:13.906  Specified LABEL: ci.role.test&&hw.arch.x86&&sw.os.linux&&!sw.tool.glibc.2_12
[Pipeline] stage
[Pipeline] { (Queue)
Did you forget the `def` keyword? WorkflowScript seems to be setting a field named dynamicAgents (to a value of type ArrayList) which could lead to memory leaks or other issues.
[Pipeline] echo
00:00:13.923  dynamicAgents: [azure, fyre, EBC]
[Pipeline] echo
00:00:13.925  Added dynamic agent, nodeLabel: 'hw.arch.x86&&sw.os.linux&&!sw.tool.glibc.2_12&&(ci.role.test||ci.agent.dynamic)', dynamicLabel: 'azure'
[Pipeline] echo
00:00:13.926  Provisioning LABEL: hw.arch.x86&&sw.os.linux&&!sw.tool.glibc.2_12&&(ci.role.test||ci.agent.dynamic)
[Pipeline] nodesByLabel
00:00:13.934  Found a total of 10 nodes with the 'hw.arch.x86&&sw.os.linux&&!sw.tool.glibc.2_12&&(ci.role.test||ci.agent.dynamic)' label
[Pipeline] node
00:00:28.937  Still waiting to schedule task
00:00:28.937  Waiting for next available executor on ‘[hw.arch.x86&&sw.os.linux&&!sw.tool.glibc.2_12&&(ci.role.test||ci.agent.dynamic)](https://ci.adoptium.net/label/hw.arch.x86&&sw.os.linux&&!sw.tool.glibc.2_12&&(ci.role.test%7C%7Cci.agent.dynamic)/)’
00:03:26.402  Running on [test-linux-x64-d0f330](https://ci.adoptium.net/computer/test%2Dlinux%2Dx64%2Dd0f330/) in /home/adoptopenjdk/workspace/Test_openjdk21_hs_extended.openjdk_x86-64_linux_testList_0
```

