### PR TITLE
Create weston XDG_RUNTIME_DIR tmp symlink to avoid long path

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -817,7 +817,7 @@ def runTest( ) {
 				// Detect if Xvfb is on the machine, and if not use the wayland startup code (Initially for EL10)
 				if ( sh(script:"which Xvfb 2>&1", returnStatus:true) != 0 ) {
 					// XDG_RUNTIME_DIR is limited to 108 chars, so create a short tmp symlink
-					def tmp_wayland = sh(script: 'wayland-$(id -u)', returnStdout: true).trim()
+					def tmp_wayland = sh(script: 'echo wayland-$(id -u)', returnStdout: true).trim()
 					echo "Creating temporary wayland path and symlink /tmp/${tmp_wayland}"
 					sh "rm -rf /tmp/${tmp_wayland} && mkdir -pm 0700 /tmp/${tmp_wayland}"
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/6780

Use a short tmp path for XDG_RUNTIME_DIR when using weston to avoid 108 char limit

Test: https://ci.adoptium.net/job/Test_openjdk21_hs_extended.openjdk_x86-64_linux_testList_7/14/ - SUCCESS

