### PR TITLE
Restrict jdk_valhalla and hotspot_valhalla versions

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -36,6 +36,9 @@
 			$(Q)$(JTREG_JDK_TEST_DIR):jdk_valhalla$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<versions>
+			<version>Valhalla</version>
+		</versions>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>
@@ -69,6 +72,9 @@
 			$(Q)$(JTREG_HOTSPOT_TEST_DIR):hotspot_valhalla$(Q); \
 			$(TEST_STATUS)
 		</command>
+		<versions>
+			<version>Valhalla</version>
+		</versions>
 		<impls>
 			<impl>openj9</impl>
 			<impl>ibm</impl>


### PR DESCRIPTION
Special OpenJDK targets jdk_valhalla and hotspot_valhalla should only be run for Valhalla version.

Fixes: https://github.com/eclipse-openj9/openj9/issues/23077

https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/56840/