### PR TITLE
Enable strict fields verifier tests for OpenJ9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -125,13 +125,6 @@ runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_COOP
 runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_NCOOP_CCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_NCOOP_CCP_COH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_NCOOP_NCCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/verifier/RedefineStrictFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/verifier/StrictFields.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/verifier/StrictFinalInstanceFieldsTest.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/verifier/StrictStaticTests.java#C1only https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/verifier/StrictStaticTests.java#C2only https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/verifier/StrictStaticTests.java#default https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/verifier/UninitializedThisVerificationTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
This does not enable [StrictInstanceFieldsTest.java and StrictStaticFieldsTest.java ](https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/blob/openj9/test/hotspot/jtreg/ProblemList.txt#L145-L147)which are disabled because they require an updated jtreg version. I verified locally that they are passing.

Related to https://github.com/eclipse-openj9/openj9/issues/21884

Depends on
- https://github.com/eclipse-openj9/openj9/pull/23131
- https://github.com/eclipse-openj9/openj9/pull/22849 to see correct verifier messages in test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictFields.java
- https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/24