### PR TITLE
Exclude Float/Double128VectorTests for OpenJ9 jdk21+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -616,3 +616,7 @@ jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/ecl
 jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
+
+# jdk_vector
+jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all
+jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -621,3 +621,7 @@ jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/ecl
 jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
+
+# jdk_vector
+jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all
+jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all

--- a/openjdk/excludes/ProblemList_openjdk26-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk26-openj9.txt
@@ -637,3 +637,7 @@ jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 
 ############################################################################
+
+# jdk_vector
+jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all
+jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all

--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -637,3 +637,7 @@ jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 
 ############################################################################
+
+# jdk_vector
+jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all
+jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/23000