### PR TITLE
Exclude Double/Float128VectorTests on x64 only, OpenJ9 jdk21+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -616,7 +616,3 @@ jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/ecl
 jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
-
-# jdk_vector
-jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all
-jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -621,7 +621,3 @@ jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/ecl
 jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
-
-# jdk_vector
-jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all
-jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all

--- a/openjdk/excludes/ProblemList_openjdk26-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk26-openj9.txt
@@ -637,7 +637,3 @@ jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 
 ############################################################################
-
-# jdk_vector
-jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all
-jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all

--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -637,7 +637,3 @@ jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 
 ############################################################################
-
-# jdk_vector
-jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all
-jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 generic-all

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -3025,6 +3025,12 @@
 	</test>
 	<test>
 		<testCaseName>jdk_vector_float128_j9</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/23000</comment>
+				<platform>x86-64_.*</platform>
+			</disable>
+		</disables>				
 		<variations>
 			<variation>-Xjit:{*Float128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
 		</variations>
@@ -3061,6 +3067,12 @@
 	</test>
 	<test>
 		<testCaseName>jdk_vector_double128_j9</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/23000</comment>
+				<platform>x86-64_.*</platform>
+			</disable>
+		</disables>				
 		<variations>
 			<variation>-Xjit:{*Double128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,disableSuffixLogs,verbose={vectorAPI}</variation>
 		</variations>


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/23000
Related to https://github.com/adoptium/aqa-tests/pull/6797