### PR TITLE
Correct compile custom default

### DIFF
--- a/jck/jck.mk
+++ b/jck/jck.mk
@@ -12,7 +12,7 @@
 # limitations under the License.
 ##############################################################################
 JCKRUNTIME_CUSTOM_TARGET ?= api/java_math/BigInteger
-JCKCOMPILER_CUSTOM_TARGET ?= api/javax_lang/model/element/index.html
+JCKCOMPILER_CUSTOM_TARGET ?= api/javax_lang/model/element/Element
 JCKDEVTOOLS_CUSTOM_TARGET ?= java2schema/CustomizedMapping/classes/XmlRootElement/name/Name001.html
 JCKINTERACTIVESAWT_CUSTOM_TARGET ?= api/java_awt/interactive/ButtonTests.html
 JCKINTERACTIVESSWING_CUSTOM_TARGET ?= api/javax_swing/interactive/CopyPasteImageTests.html


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/6819

Update default compiler custom target to be valid for jdk8->jdk25
