### PR TITLE
Exclude Double/Float128VectorTests on x64 jdk21+ OpenJ9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -616,3 +616,7 @@ jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/ecl
 jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
+
+# jdk_vector
+jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 linux-x64,macosx-x64,windows-x64
+jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 linux-x64,macosx-x64,windows-x64

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -622,3 +622,7 @@ jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/ecl
 jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
+
+# jdk_vector
+jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 linux-x64,macosx-x64,windows-x64
+jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 linux-x64,macosx-x64,windows-x64

--- a/openjdk/excludes/ProblemList_openjdk26-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk26-openj9.txt
@@ -636,3 +636,7 @@ jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 
 ############################################################################
+
+# jdk_vector
+jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 linux-x64,macosx-x64,windows-x64
+jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 linux-x64,macosx-x64,windows-x64

--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -636,3 +636,7 @@ jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 
 ############################################################################
+
+# jdk_vector
+jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 linux-x64,macosx-x64,windows-x64
+jdk/incubator/vector/Float128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/23000 linux-x64,macosx-x64,windows-x64


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/23000