### PR TITLE
(v1.0.11) Exclude MauveSingleThrdLoad_J9, MauveSingleInvocLoad_J9 also on 25

### DIFF
--- a/system/mauveLoadTest/playlist.xml
+++ b/system/mauveLoadTest/playlist.xml
@@ -13,11 +13,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/22912</comment>
-				<version>[17, 21]</version>
-			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/22912</comment>
-				<version>26+</version>
+				<version>17+</version>
 			</disable>
 		</disables>
 		<variations>
@@ -92,11 +88,7 @@
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/22912</comment>
-				<version>[17, 21]</version>
-			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/22912</comment>
-				<version>26+</version>
+				<version>17+</version>
 			</disable>
 		</disables>
 		<variations>


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/22912

Port of https://github.com/adoptium/aqa-tests/pull/6840