### PR TITLE
Excluding Win8365790Test.java on windows for jdk17 and jdk21

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -289,7 +289,7 @@ tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/i
 tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/Win8282351Test.java https://github.com/adoptium/infrastructure/issues/2885 windows-all
-tools/jpackage/windows/Win8365790Test.java https://github.com/adoptium/aqa-tests/issues/6839 windows-all
+tools/jpackage/windows/Win8365790Test.java https://bugs.openjdk.org/browse/JDK-8376188 windows-all
 tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
 tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 generic-all
 tools/jlink/JLinkReproducibleTest.java https://bugs.openjdk.java.net/browse/JDK-8217166 aix-all

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -310,7 +310,7 @@ tools/jpackage/windows/WinShortcutPromptTest.java https://github.com/adoptium/in
 tools/jpackage/windows/WinShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/windows/Win8365790Test.java https://github.com/adoptium/aqa-tests/issues/6839 windows-all
+tools/jpackage/windows/Win8365790Test.java https://bugs.openjdk.org/browse/JDK-8376188 windows-all
 tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 windows-x86,linux-arm
 tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
 tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-ppc64


### PR DESCRIPTION
Connected to (but does not resolve) https://github.com/adoptium/aqa-tests/issues/6839