### PR TITLE
Set -Djdk.rmi.ssl.client.enableEndpointIdentification=false for IBM

### DIFF
--- a/system/jlm/playlist.xml
+++ b/system/jlm/playlist.xml
@@ -282,8 +282,8 @@
 			</disable>
 		</disables>
 		<variations>
-			<variation>Mode110</variation>
-			<variation>Mode610</variation>
+			<variation>Mode110 -Djdk.rmi.ssl.client.enableEndpointIdentification=false</variation>
+			<variation>Mode610 -Djdk.rmi.ssl.client.enableEndpointIdentification=false</variation>
 		</variations>
 		<command>$(SYSTEMTEST_CMD_TEMPLATE) -test=TestIBMJlmRemoteClassAuth; \
 	$(TEST_STATUS)</command>


### PR DESCRIPTION
TestIBMJlmRemoteClassAuth was missed from
https://github.com/adoptium/aqa-tests/pull/6845

Issue https://github.com/adoptium/aqa-tests/issues/6835