### PR TITLE
Exclude new Valhalla tests not compatible with J9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -51,6 +51,7 @@ java/lang/invoke/defineHiddenClass/PreviewHiddenClass.java https://github.com/ec
 # hotspot_valhalla - runtime/valhalla
 
 ############################################################################
+runtime/valhalla/inlinetypes/AcmpTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/ArrayQueryTest.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/ClassPrintLayoutDcmd.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/EmptyInlineTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
@@ -76,7 +77,8 @@ runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java#id0 https://github
 runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java#id1 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java#id2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/TestJNIIsSameObject.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/TestJNIIsSameObject.java#id0 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/TestJNIIsSameObject.java#id1 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/ValuePreloadTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/ValueTearing.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/VolatileTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
@@ -87,34 +89,6 @@ runtime/valhalla/inlinetypes/classloading/BigClassTreeClassLoader.java https://g
 runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/classloading/PreLoadCircularityTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/classloading/PreLoadFailuresDoNotImpactApplicationTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_COOP_CCP_COH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_COOP_CCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_NCOOP_CCP_COH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_NCOOP_CCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_NCOOP_NCCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_COOP_CCP_COH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_COOP_CCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_NCOOP_CCP_COH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_NCOOP_CCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_NCOOP_NCCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_0 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_1 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_3 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_4 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_5 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_6 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_7 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_atomic_flat_and_no_nullable_flat https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_atomic_flat_and_nullable_flat https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_no_atomic_flat_and_no_nullable_flat https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_no_atomic_flat_and_nullable_flat https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_COOP_CCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_COOP_CCP_COH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_NCOOP_CCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_NCOOP_CCP_COH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_NCOOP_NCCP_NCOH https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 
 ############################################################################
 
@@ -137,7 +111,6 @@ serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java https://github.com/ecl
 # hotspot_valhalla - compiler/valhalla
 
 ############################################################################
-runtime/valhalla/inlinetypes/AcmpTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 compiler/valhalla/inlinetypes/BlackholeTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 compiler/valhalla/inlinetypes/PutFlatValueWithoutUseArrayFlattening.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 compiler/valhalla/inlinetypes/RepairStackWithBigFrame.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
@@ -249,15 +222,7 @@ compiler/valhalla/inlinetypes/TestValueRematDuringTypeSharpening.java https://gi
 # These tests can't be run with OpenJ9 and should be permanently excluded.
 
 ############################################################################
-runtime/valhalla/inlinetypes/AnnotationsTests.java n/a generic-all
 compiler/valhalla/inlinetypes/CorrectlyRestoreRfp.java n/a generic-all
-runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#parallel n/a generic-all
-runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#g1 n/a generic-all
-runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#serial n/a generic-all
-runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id0 n/a generic-all
-runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id1 n/a generic-all
-runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id2 n/a generic-all
-runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id3 n/a generic-all
 compiler/valhalla/inlinetypes/TestAllocationMergeAndFolding.java#id0 n/a generic-all
 compiler/valhalla/inlinetypes/TestAllocationMergeAndFolding.java#id2 n/a generic-all
 compiler/valhalla/inlinetypes/TestAllocationMergeAndFolding.java#id1 n/a generic-all
@@ -356,7 +321,45 @@ compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test n/a generic-
 compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test-di n/a generic-all
 compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test-di-exclude-helper n/a generic-all
 compiler/valhalla/inlinetypes/TestVirtualThreads.java#xcomp-co-test-di-helper n/a generic-all
+runtime/valhalla/inlinetypes/AnnotationsTests.java n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/EmptyValueTest.java n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_COOP_CCP_COH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_COOP_CCP_NCOH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_NCOOP_CCP_COH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_NCOOP_CCP_NCOH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java#64_NCOOP_NCCP_NCOH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_COOP_CCP_COH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_COOP_CCP_NCOH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_NCOOP_CCP_COH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_NCOOP_CCP_NCOH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java#64_NCOOP_NCCP_NCOH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/StrictFinalTest.java n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_0 n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_1 n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_2 n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_3 n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_4 n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_5 n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_6 n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java#TestLayoutFlags_7 n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_atomic_flat_and_no_nullable_flat n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_atomic_flat_and_nullable_flat n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_no_atomic_flat_and_no_nullable_flat n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueCompositionTest.java#ValueCompositionTest_no_atomic_flat_and_nullable_flat n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_COOP_CCP_NCOH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_COOP_CCP_COH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_NCOOP_CCP_NCOH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_NCOOP_CCP_COH n/a generic-all
+runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java#64_NCOOP_NCCP_NCOH n/a generic-all
+runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#parallel n/a generic-all
+runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#g1 n/a generic-all
+runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#serial n/a generic-all
 runtime/valhalla/inlinetypes/InlineTypeDensity.java#compressed-oops n/a generic-all
 runtime/valhalla/inlinetypes/InlineTypeDensity.java#force-non-tearable n/a generic-all
 runtime/valhalla/inlinetypes/InlineTypeDensity.java#no-compressed-oops n/a generic-all
 runtime/valhalla/inlinetypes/InlineTypeDensity.java#no-explicit-compression n/a generic-all
+runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id0 n/a generic-all
+runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id1 n/a generic-all
+runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id2 n/a generic-all
+runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id3 n/a generic-all


### PR DESCRIPTION
- Exclude new TestJNIIsSameObject variation
- Permanently exclude field_layout tests
- Reorder tests alphabetically

Newly excluded tests are related to failures in the latest weekly build https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Test_JDKnext_valhalla_openjdk_x86-64_linux/8/

fyi @hangshao0 