### PR TITLE
Excluding Test7005594.java on JDK8 Mac

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -20,6 +20,7 @@ serviceability/dcmd/DynLibDcmdTest.java https://github.com/adoptium/aqa-tests/is
 
 # hotspot_all
 
+compiler/5091921/Test7005594.java https://bugs.openjdk.org/browse/JDK-8376338  macosx-all
 # compiler/7184394/TestAESMain.java https://github.com/adoptium/infrastructure/issues/2893
 compiler/7184394/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,solaris-sparcv9
 compiler/intrinsics/sha/TestSHA.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x


### PR DESCRIPTION
Relates to (but does not resolve) https://github.com/adoptium/aqa-tests/issues/6854

Upstream issue: https://bugs.openjdk.org/browse/JDK-8376338