### PR TITLE
Permanently disable LayoutIterationTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -21,7 +21,6 @@
 ############################################################################
 valhalla/valuetypes/FlatVarHandleTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
 valhalla/valuetypes/IsIdentityClassTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
-valhalla/valuetypes/LayoutIterationTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
 valhalla/valuetypes/MethodHandleTest.java https://github.com/eclipse-openj9/openj9/issues/22648 generic-all
 valhalla/valuetypes/NullRestrictedArraysTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
 valhalla/valuetypes/NullRestrictedTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
@@ -363,3 +362,4 @@ runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id0 n/a generic-all
 runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id1 n/a generic-all
 runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id2 n/a generic-all
 runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id3 n/a generic-all
+valhalla/valuetypes/LayoutIterationTest.java n/a generic-all


### PR DESCRIPTION
Permanently disable LayoutIterationTest as OpenJ9's
flattening policy differs from what is being tested.

Signed-off-by: Aditi Srinivas M Aditi.Srini@ibm.com