### PR TITLE
Exclude jdk8 serviceability/jvmti/DynamicCodeGenerated/DynamicCodeGeneratedTest.sh

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -15,6 +15,7 @@
 # hotspot_jdk
 
 serviceability/dcmd/DynLibDcmdTest.java https://github.com/adoptium/aqa-tests/issues/5854 aix-all
+serviceability/jvmti/DynamicCodeGenerated/DynamicCodeGeneratedTest.sh https://bugs.openjdk.org/browse/JDK-8376503 linux-ppc64le,linux-arm
 
 ############################################################################
 

--- a/openjdk/excludes/alpine/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/alpine/ProblemList_openjdk8.txt
@@ -16,4 +16,4 @@ sun/tools/native2ascii/Native2AsciiTests.sh https://github.com/adoptium/aqa-test
 java/lang/ProcessBuilder/Basic.java https://bugs.openjdk.org/browse/JDK-8282219 linux-all
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/aqa-tests/issues/3238 linux-all
 tools/launcher/ExecutionEnvironment.java https://github.com/adoptium/aqa-tests/issues/5894 linux-x64
-
+serviceability/jvmti/DynamicCodeGenerated/DynamicCodeGeneratedTest.sh https://bugs.openjdk.org/browse/JDK-8376503 linux-all


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/6855

Exclude for upstream raised bug https://bugs.openjdk.org/browse/JDK-8376503
for jdk8 ppc64leLinux, armLinux and AlpineLinux. 
