### PR TITLE
JDK26+ exclude vthread/SingleStepKlassInit/SingleStepKlassInit.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk26-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk26-openj9.txt
@@ -608,6 +608,7 @@ serviceability/jvmti/events/VMDeath/AllocatingInVMDeath/TestAllocatingInVMDeath.
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+serviceability/jvmti/vthread/SingleStepKlassInit/SingleStepKlassInit.java https://github.com/eclipse-openj9/openj9/issues/22936 generic-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16689 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all

--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -608,6 +608,7 @@ serviceability/jvmti/events/VMDeath/AllocatingInVMDeath/TestAllocatingInVMDeath.
 serviceability/jvmti/thread/GetStackTrace/getstacktr06/getstacktr06.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/thread/GetStackTrace/getstacktr08/getstacktr08.java https://github.com/eclipse-openj9/openj9/issues/16238 generic-all
 serviceability/jvmti/vthread/MethodExitTest/MethodExitTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+serviceability/jvmti/vthread/SingleStepKlassInit/SingleStepKlassInit.java https://github.com/eclipse-openj9/openj9/issues/22936 generic-all
 serviceability/jvmti/vthread/VThreadTest/VThreadTest.java https://github.com/eclipse-openj9/openj9/issues/15920 generic-all
 serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java https://github.com/eclipse-openj9/openj9/issues/16689 generic-all
 serviceability/jvmti/vthread/ContinuationTest/ContinuationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
JDK26+ exclude vthread/SingleStepKlassInit/SingleStepKlassInit.java

Related to
* https://github.com/eclipse-openj9/openj9/issues/22936

Signed-off-by: Jason Feng <fengj@ca.ibm.com>