### PR TITLE
Exclude AIX 7.1 machines from extended.openjdk tests on ppc64_aix

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -344,6 +344,9 @@ timestamps{
                     if (!params.JDK_VERSION.isInteger() || params.JDK_VERSION.toInteger() >= 25) {
                         LABEL += "&&sw.tool.c++runtime.17_1"
                     }
+                    if (params.TARGET && (params.TARGET.contains("extended.openjdk") || (params.TARGET.contains("testList") && params.UPSTREAM_TEST_JOB_NAME?.contains("extended.openjdk")))) {
+                        LABEL += "&&!sw.os.aix.7_1"
+                    }
                 }
             }
 
@@ -370,7 +373,6 @@ timestamps{
                     LABEL += "&&!sw.os.mac.10"
                 }
             }
-
             if (params.DOCKER_REQUIRED) {
                 LABEL += "&&sw.tool.docker"
             }


### PR DESCRIPTION
- Add LABEL exclusion for sw.os.aix.7_1 when running extended.openjdk tests
- Apply exclusion to both parent jobs and parallel child testList jobs

related: https://github.com/eclipse-openj9/openj9/issues/23340