### PR TITLE
Disable RH CryptoTests in Java 8 and higher

### DIFF
--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -17,9 +17,14 @@
 		<testCaseName>CryptoTests</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/16712</comment>
-				<version>19+</version>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/16712, https://github.ibm.com/runtimes/backlog/issues/1739, https://github.com/eclipse-openj9/openj9/issues/23342</comment>
+				<version>8+</version>
 				<impl>openj9</impl>
+			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/16712</comment>
+				<version>8+</version>
+				<impl>ibm</impl>
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/16710</comment>
@@ -63,13 +68,13 @@
 		<testCaseName>CryptoTests_jtreg</testCaseName>
 		<disables>
 			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/16712</comment>
-				<version>19+</version>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/16712, https://github.ibm.com/runtimes/backlog/issues/1739, https://github.com/eclipse-openj9/openj9/issues/23342</comment>
+				<version>8+</version>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/16712</comment>
-				<version>21+</version>
+				<version>8+</version>
 				<impl>ibm</impl>
 			</disable>
 			<disable>


### PR DESCRIPTION
This set of tests have basic coverage and are no longer needed.

Closes https://github.com/eclipse-openj9/openj9/issues/23342

Signed-off-by: Jason Katonica <katonica@us.ibm.com>