### PR TITLE
Update DateFormatTest for taiwaese

### DIFF
--- a/functional/MBCS_Tests/i18n/src/DateFormatTest.java
+++ b/functional/MBCS_Tests/i18n/src/DateFormatTest.java
@@ -35,7 +35,9 @@ public class DateFormatTest {
 		}
 	}
     long feature = JavaVersion.getFeature();
-    if (feature >= 22L) {
+    if (feature >= 26L) {
+       resource = tryGetBundle("ResourceBundleTest_26", locale);
+    } else if (feature >= 22L) {
        resource = tryGetBundle("ResourceBundleTest_22", locale);
     } else if (feature >= 19L) {
         resource = tryGetBundle("ResourceBundleTest_19", locale);

--- a/functional/MBCS_Tests/i18n/src/ResourceBundleTest_26_zh_TW.java
+++ b/functional/MBCS_Tests/i18n/src/ResourceBundleTest_26_zh_TW.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+import java.util.ListResourceBundle;
+
+public class ResourceBundleTest_26_zh_TW extends ListResourceBundle {
+   public Object[][] getContents(){
+      return contents;
+   }
+
+   static final Object[][] contents = {
+      {"locale","\u5730\u533A"},
+      {"timezone","\u65F6\u533A"},
+      {"date","\u65E5\u671F"},
+      {"number","\u6570\u5B57"},
+      {"currency","\u8D27\u5E01"},
+      {"percent","\u767E\u5206\u6BD4"},
+      {"FullFormat","y\u5E74M\u6708d\u65E5 EEEEah:mm:ss '['zzzz']'"},
+      {"LongFormat","y\u5E74M\u6708d\u65E5ah:mm:ss '['z']'"},
+      {"MediumFormat","y\u5E74M\u6708d\u65E5ah:mm:ss"},
+      {"ShortFormat","y/M/dah:mm"},
+      /* for E,EE,EEE */
+      {"Day1","\u661F\u671F\u65E5"},
+      {"Day2","\u661F\u671F\u4E00"},
+      {"Day3","\u661F\u671F\u4E8C"},
+      {"Day4","\u661F\u671F\u4E09"},
+      {"Day5","\u661F\u671F\u56DB"},
+      {"Day6","\u661F\u671F\u4E94"},
+      {"Day7","\u661F\u671F\u516D"},
+      /* for EEEE */
+      {"Day1F","\u661F\u671F\u65E5"},
+      {"Day2F","\u661F\u671F\u4E00"},
+      {"Day3F","\u661F\u671F\u4E8C"},
+      {"Day4F","\u661F\u671F\u4E09"},
+      {"Day5F","\u661F\u671F\u56DB"},
+      {"Day6F","\u661F\u671F\u4E94"},
+      {"Day7F","\u661F\u671F\u516D"},
+      /* for MMM */
+      {"Month1","\u0031\u6708"},
+      {"Month2","\u0032\u6708"},
+      {"Month3","\u0033\u6708"},
+      {"Month4","\u0034\u6708"},
+      {"Month5","\u0035\u6708"},
+      {"Month6","\u0036\u6708"},
+      {"Month7","\u0037\u6708"},
+      {"Month8","\u0038\u6708"},
+      {"Month9","\u0039\u6708"},
+      {"Month10","\u0031\u0030\u6708"},
+      {"Month11","\u0031\u0031\u6708"},
+      {"Month12","\u0031\u0032\u6708"},
+      /* for MMMM */
+      {"Month1F","\u0031\u6708"},
+      {"Month2F","\u0032\u6708"},
+      {"Month3F","\u0033\u6708"},
+      {"Month4F","\u0034\u6708"},
+      {"Month5F","\u0035\u6708"},
+      {"Month6F","\u0036\u6708"},
+      {"Month7F","\u0037\u6708"},
+      {"Month8F","\u0038\u6708"},
+      {"Month9F","\u0039\u6708"},
+      {"Month10F","\u0031\u0030\u6708"},
+      {"Month11F","\u0031\u0031\u6708"},
+      {"Month12F","\u0031\u0032\u6708"},
+      /* for a */
+      {"AM","\u4E0A\u5348"},
+      {"PM","\u4E0B\u5348"},
+   };
+}
+
+// Made with Bob


### PR DESCRIPTION
This PR fixes the `DateFormatTest` failure for zh_TW locale caused by CLDR 48.0 format changes in JDK 26.

**Root Cause:** 
CLDR 48.0 changed the date-time format patterns for Chinese (Taiwan) locale, specifically:
1. Removed the space between date and time components
2. Changed bracket notation to use single quotes for literal characters

**Changes Made:**
Updated `ResourceBundleTest_zh_TW.java` with corrected date format patterns:

| Format | Old Pattern | New Pattern (CLDR 48.0) |
|--------|-------------|-------------------------|
| FULL | `y年M月d日 EEEE ah:mm:ss [zzzz]` | `y年M月d日 EEEEah:mm:ss '['zzzz']'` |
| LONG | `y年M月d日 ah:mm:ss [z]` | `y年M月d日ah:mm:ss '['z']'` |
| MEDIUM | `y年M月d日 ah:mm:ss` | `y年M月d日ah:mm:ss` |
| SHORT | `y/M/d ah:mm` | `y/M/dah:mm` |

**Testing:**
✅ Verified with JDK 26 - DateFormatTest now passes with "OK" status for zh_TW locale

**References:**
- JDK-8354550 - Update CLDR to Version 48.0
- CLDR 48.0 Release: https://cldr.unicode.org/index/downloads/cldr-48
- CLDR Date/Time Patterns: https://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns

Signed-off-by: Rishabh Thakur <rishabh@ibm.com>
