### PR TITLE
CLDR 48.0 format changes in JDK 26

### DIFF
--- a/functional/MBCS_Tests/language_tag/src/CNTagTest.java
+++ b/functional/MBCS_Tests/language_tag/src/CNTagTest.java
@@ -185,7 +185,11 @@ public class CNTagTest{
         String tag = "zh-CN-u-fw-mon";
         Locale l = Locale.forLanguageTag(tag);
         assertEquals("中文 (中国，fw：mon)", l.getDisplayName(l));
-        assertEquals("Chinese (China, First Day of Week Is Monday)", l.getDisplayName(Locale.ENGLISH));
+        // CLDR 48.0 (JDK 26+) changed format from "First Day of Week Is Monday" to "First day of week: Monday"
+        String expectedDisplay = (JavaVersion.getFeature() >= 26)
+            ? "Chinese (China, First day of week: Monday)"
+            : "Chinese (China, First Day of Week Is Monday)";
+        assertEquals(expectedDisplay, l.getDisplayName(Locale.ENGLISH));
         assertEquals(tag, l.toLanguageTag());
         assertEquals("fw-mon", l.getExtension('u'));
         assertEquals("mon", l.getUnicodeLocaleType("fw"));

--- a/functional/MBCS_Tests/language_tag/src/JPTagTest.java
+++ b/functional/MBCS_Tests/language_tag/src/JPTagTest.java
@@ -185,7 +185,11 @@ public class JPTagTest{
         String tag = "ja-JP-u-fw-mon";
         Locale l = Locale.forLanguageTag(tag);
         assertEquals("日本語 (日本、fw: mon)", l.getDisplayName(l));
-        assertEquals("Japanese (Japan, First Day of Week Is Monday)", l.getDisplayName(Locale.ENGLISH));
+        // CLDR 48.0 (JDK 26+) changed format from "First Day of Week Is Monday" to "First day of week: Monday"
+        String expectedDisplay = (JavaVersion.getFeature() >= 26)
+            ? "Japanese (Japan, First day of week: Monday)"
+            : "Japanese (Japan, First Day of Week Is Monday)";
+        assertEquals(expectedDisplay, l.getDisplayName(Locale.ENGLISH));
         assertEquals(tag, l.toLanguageTag());
         assertEquals("fw-mon", l.getExtension('u'));
         assertEquals("mon", l.getUnicodeLocaleType("fw"));

--- a/functional/MBCS_Tests/language_tag/src/KRTagTest.java
+++ b/functional/MBCS_Tests/language_tag/src/KRTagTest.java
@@ -182,7 +182,11 @@ public class KRTagTest{
         Locale l = Locale.forLanguageTag(tag);
         assertEquals("한국어 (대한민국, fw: mon)",
                      l.getDisplayName(l));
-        assertEquals("Korean (South Korea, First Day of Week Is Monday)",
+        // CLDR 48.0 (JDK 26+) changed format from "First Day of Week Is Monday" to "First day of week: Monday"
+        String expectedDisplay = (JavaVersion.getFeature() >= 26)
+            ? "Korean (South Korea, First day of week: Monday)"
+            : "Korean (South Korea, First Day of Week Is Monday)";
+        assertEquals(expectedDisplay,
                      l.getDisplayName(Locale.ENGLISH));
         assertEquals(tag, l.toLanguageTag());
         assertEquals("fw-mon", l.getExtension('u'));

--- a/functional/MBCS_Tests/language_tag/src/TWTagTest.java
+++ b/functional/MBCS_Tests/language_tag/src/TWTagTest.java
@@ -198,7 +198,11 @@ public class TWTagTest{
         String tag = "zh-TW-u-fw-mon";
         Locale l = Locale.forLanguageTag(tag);
         assertEquals("中文 (台灣，fw：mon)", l.getDisplayName(l));
-        assertEquals("Chinese (Taiwan, First Day of Week Is Monday)", l.getDisplayName(Locale.ENGLISH));
+        // CLDR 48.0 (JDK 26+) changed format from "First Day of Week Is Monday" to "First day of week: Monday"
+        String expectedDisplay = (JavaVersion.getFeature() >= 26)
+            ? "Chinese (Taiwan, First day of week: Monday)"
+            : "Chinese (Taiwan, First Day of Week Is Monday)";
+        assertEquals(expectedDisplay, l.getDisplayName(Locale.ENGLISH));
         assertEquals(tag, l.toLanguageTag());
         assertEquals("fw-mon", l.getExtension('u'));
         assertEquals("mon", l.getUnicodeLocaleType("fw"));

--- a/functional/MBCS_Tests/language_tag/src/USTagTest.java
+++ b/functional/MBCS_Tests/language_tag/src/USTagTest.java
@@ -178,7 +178,11 @@ public class USTagTest{
     public void firstDayOfWeekTest(){
         String tag = "en-US-u-fw-mon";
         Locale l = Locale.forLanguageTag(tag);
-        assertEquals("English (United States, First Day of Week Is Monday)", l.getDisplayName(Locale.ENGLISH));
+        // CLDR 48.0 (JDK 26+) changed format from "First Day of Week Is Monday" to "First day of week: Monday"
+        String expectedDisplay = (JavaVersion.getFeature() >= 26)
+            ? "English (United States, First day of week: Monday)"
+            : "English (United States, First Day of Week Is Monday)";
+        assertEquals(expectedDisplay, l.getDisplayName(Locale.ENGLISH));
         assertEquals(tag, l.toLanguageTag());
         assertEquals("fw-mon", l.getExtension('u'));
         assertEquals("mon", l.getUnicodeLocaleType("fw"));


### PR DESCRIPTION
This PR fixes firstDayOfWeekTest failures across all language tag tests caused by CLDR 48.0 format changes in JDK 26.

Root Cause: CLDR 48.0 changed the SeparateKeyValue display format from capitalized phrases to lowercase with colon separators.

Changes:

Updated expected display format in 5 test files
JDK25 and below: "First Day of Week Is Monday"
JDK26 and above: "First day of week: Monday"
References:

JDK-8354550 - Update CLDR to Version 48.0
CLDR 48.0 Release: https://cldr.unicode.org/index/downloads/cldr-48
Signed-off-by: Rishabh Thakur [rishabh@ibm.com](mailto:rishabh@ibm.com)