### PR TITLE
Fix JDK 26 compatibility in CharsetsTest for ArrayEncoder API change

### DIFF
--- a/functional/MBCS_Tests/charsets/src/JavaVersion.java
+++ b/functional/MBCS_Tests/charsets/src/JavaVersion.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+import java.lang.reflect.Method;
+
+public class JavaVersion {
+  final static long version;
+  final static int feature;
+  final static int interim;
+  final static int update;
+
+  static {
+    int tempFeature = 0;
+    int tempInterim = 0;
+    int tempUpdate  = 0;
+    try {
+      Class<?> runtimeClass = Class.forName("java.lang.Runtime");
+      Method versionMid = runtimeClass.getDeclaredMethod("version", (Class<?>[])null);
+      Object ver = versionMid.invoke(null, (Object[])null);
+      Method featureMid = ver.getClass().getDeclaredMethod("feature", (Class<?>[])null);
+      Method interimMid = ver.getClass().getDeclaredMethod("interim", (Class<?>[])null);
+      Method updateMid  = ver.getClass().getDeclaredMethod("update",  (Class<?>[])null);
+      tempFeature = (int)featureMid.invoke(ver, (Object[])null);
+      tempInterim = (int)interimMid.invoke(ver, (Object[])null);
+      tempUpdate  = (int)updateMid.invoke(ver, (Object[])null);
+    } catch (Exception e) {
+    }
+    feature = tempFeature;
+    interim = tempInterim;
+    update  = tempUpdate;
+    version = feature * 1000000L +
+              interim * 1000L +
+              update;
+  }
+
+  public static long getVersion() {
+    return version;
+  }
+
+  public static long getFeature() {
+    return feature;
+  }
+
+  public static long getInterim() {
+    return interim;
+  }
+
+  public static long getUpdate() {
+    return update;
+  }
+
+  public static void main(String[] args) {
+    System.out.println(getVersion());
+  }
+}


### PR DESCRIPTION
This PR updates CharsetsTest to support both JDK 26+ (with new `encodeFromUTF16` API) and earlier JDK versions (with old `encode` API) using version-aware method selection.

## Problem
JDK 26 removed the unused `sun.nio.cs.ArrayEncoder::encode` method as part of cleanup, causing CharsetsTest to fail.

### API Change in JDK 26

**JDK-8363925: Remove unused sun.nio.cs.ArrayEncoder::encode**  
🔗 https://bugs.openjdk.org/browse/JDK-8363925

| Aspect | JDK < 26 (Old API) | JDK 26+ (New API) |
|--------|-------------------|-------------------|
| **Method** | `encode()` | `encodeFromUTF16()` |
| **Input Type** | `char[]` array | UTF-16 LE `byte[]` array |
| **Signature** | `encode(char[] src, int srcOff, int srcLen, byte[] dst)` | `encodeFromUTF16(byte[] src, int srcOff, int srcLen, byte[] dst, int dstOff)` |
| **Parameters** | 4 parameters | 5 parameters (added dstOff) |

### Why the Change?
The old `encode(char[])` method was unused in the JDK codebase and was removed as part of code cleanup. The new `encodeFromUTF16(byte[])` method provides better performance and more control over encoding by working directly with UTF-16 encoded bytes.

## Solution

### 1. Created [`JavaVersion.java`](functional/MBCS_Tests/charsets/src/JavaVersion.java)
Version detection utility to determine JDK feature version at runtime.

```java
public static long getFeature() {
    return feature;  // Returns 21, 26, etc.
}
