### PR TITLE
Finding all test exclusion files inside nested folders

### DIFF
--- a/.github/workflows/parse-issues.yml
+++ b/.github/workflows/parse-issues.yml
@@ -26,7 +26,7 @@ jobs:
       - name: discover disabled tests
         run : |
           echo "::group::openjdk exclude files"
-          find ./openjdk/excludes -name '*ProblemList*.txt' | tee exclude_files.txt
+          find openjdk/excludes -name '*ProblemList*.txt' | tee exclude_files.txt
           echo "::endgroup::"
           echo "::group::playlist files"
           find . -name "playlist.xml" -not -path "scripts" | tee playlist_files.txt


### PR DESCRIPTION
Currently, we try to parse a pair of folders as if they were files, which fails the parse-issues github workflow.

This change fixes that, and also allows us to parse the exclude files within the folders, allowing the workflow to proceed.

Many errors are reported, but the exclude files are parsed and the workflow eventually passes.

Tested here: https://github.com/adamfarley/aqa-tests/actions/runs/22314174344/job/64554212310

Resolves https://github.com/adoptium/aqa-tests/issues/6867