### PR TITLE
Disable renaissance-naive-bayes test for JDK 26+

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -244,6 +244,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/6701</comment>
 				<platform>.*windows.*</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6896</comment>
+				<version>26+</version>
+			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)naive-bayes.json$(Q) naive-bayes; \
 		$(TEST_STATUS)</command>


### PR DESCRIPTION
- The test fails on JDK 26 because Apache Spark uses jdk.internal.ref.Cleaner, which was removed in JDK 26. The test will remain disabled until Apache Spark and the Renaissance benchmark suite are updated to support JDK 26.

fixes:https://github.com/adoptium/aqa-tests/issues/6896 Related: eclipse-openj9/openj9#23347