### PR TITLE
Update problem list link for JDK 8 JFR TestCompilerPhase

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -415,7 +415,7 @@ jdk/jfr/event/sampling/TestNative.java https://github.com/adoptium/aqa-tests/iss
 jdk/jfr/jcmd/TestJcmdDumpPathToGCRoots.java https://bugs.openjdk.org/browse/JDK-8305931 generic-all
 # jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/2985 generic-all
-jdk/jfr/event/compiler/TestCompilerPhase.java https://bugs.openjdk.org/browse/JDK-8326521 generic-all
+jdk/jfr/event/compiler/TestCompilerPhase.java https://github.com/adoptium/aqa-tests/issues/3045#issuecomment-3960035561 generic-all
 jdk/jfr/event/compiler/TestCompile.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/collection/TestGCCauseWithG1ConcurrentMark.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/collection/TestGCCauseWithG1FullCollection.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm


### PR DESCRIPTION
This PR replaces the link to the [upstream JBS fix/issue](https://bugs.openjdk.org/browse/JDK-8326521) with a link to the original AQA tests issue.

The upstream fix only solves part of the problem. The second half of the problem is that the Adoptium tests (GRINDER) run with the default JVM. On windows 32 bit, this means CLIENT. The test will always fail on CLIENT JVMs. Please see my [comment](https://github.com/adoptium/aqa-tests/issues/3045#issuecomment-3960035561) that explains in more detail why.

So now the reason the test is failing is not related to the upstream JBS issue. It's instead due to the testing infrastructure. The new link points to my comment on the original AQA issue explaining why .