### PR TITLE
Clear Arctic session prior to testcase playback in runtests.sh

### DIFF
--- a/jck/interactives/arctic_tests/runTests.sh
+++ b/jck/interactives/arctic_tests/runTests.sh
@@ -354,6 +354,9 @@ for ARCTIC_GROUP in $ARCTIC_GROUPS; do
               # Testcase started, start Arctic playback...
               sleep $SLEEP_TIME
 
+              echo "Clearing Arctic session info prior to testcase playback..."
+              $ARCTIC_JDK -jar ${LIB_DIR}/arctic.jar -c session clear
+
               echo "Starting Arctic: testcase $ARCTIC_GROUP $ARCTIC_TESTCASE"
               $ARCTIC_JDK -jar ${LIB_DIR}/arctic.jar -c test start "$ARCTIC_GROUP" "$ARCTIC_TESTCASE"
               rc=$?


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/6911

Added Arctic session clear, before executing each testcase.
Testing confirms the saved TESTCASE.session files now only contain the actual TESTCASE session info.
