### PR TITLE
Add UBI 10 support for CRIU tests

### DIFF
--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -186,16 +186,18 @@ timestamps{
                         'x86-64_linux' : [
                                     ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.x86.broadwell"],
                                     ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.x86.amd"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.broadwell"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.amd"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.skylake"],
+                                    // rhel.8 excluded from upload: ubi10 tar permission bug on rhel.8 (runtimes_backlog_issues_879)
+                                    // ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.broadwell"],
+                                    // ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.amd"],
+                                    // ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.skylake"],
                                     ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.amd"],
                                     ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.broadwell"]
                                 ],
                         'aarch64_linux' : [
                                     // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.20"],
                                     ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.aarch64.armv8"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.aarch64.armv8"],
+                                    // rhel.8 excluded from upload: ubi10 tar permission bug on rhel.8 (runtimes_backlog_issues_879)
+                                    // ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.aarch64.armv8"],
                                     ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.aarch64.armv8"]
                                 ],
                         's390x_linux' : [
@@ -203,14 +205,17 @@ timestamps{
                                     ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z14"],
                                     // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z15"],
                                     // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z13"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z14"],
+                                    // rhel.8 excluded from upload: ubi10 tar permission bug on rhel.8 (runtimes_backlog_issues_879)
+                                    // ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z14"],
                                     // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z15"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"]
+                                    // rhel.9 s390x excluded from upload: sudo requires password on all available nodes (runtimes_backlog_issues_879)
+                                    // ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"]
                                     // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z15"]
                                 ],
                         'ppc64le_linux' : [
                                     // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p9"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p10"],
+                                    // rhel.8 excluded from upload: ubi10 tar permission bug on rhel.8 (runtimes_backlog_issues_879)
+                                    // ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p10"],
                                     // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p8"],
                                     ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p9"],
                                     // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.98&&hw.arch.ppc64le.p10"],
@@ -218,9 +223,13 @@ timestamps{
                     ]
                     imagePullMap = [
                         'x86-64_linux' : [
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
+                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.x86.broadwell"],
+                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.x86.amd"],
+                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.broadwell"],
+                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.amd"],
+                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.skylake"],
+                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.amd"],
+                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.broadwell"]
                                 ],
                         'aarch64_linux' : [
                                     ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22"],
@@ -238,7 +247,7 @@ timestamps{
                                     ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.ppc64le.p9&&!sw.os.ubuntu.24"]
                                 ]
                     ]
-                    target = "testList TESTLIST=disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi8,disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi9,disabled.criu-portable-checkpoint_test,disabled.criu-ubi-portable-checkpoint_test"
+                    target = "testList TESTLIST=disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi8,disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi9,disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi10,disabled.criu-portable-checkpoint_test,disabled.criu-ubi-portable-checkpoint_test"
 
                     if (params.PLATFORM == "ppc64le_linux") {
                         // exclude criu-portable-checkpoint_test on plinux due to github_ibm/runtimes/backlog/issues/1099
@@ -329,7 +338,7 @@ timestamps{
                 dockerAgents = PLATFORM_MAP[params.PLATFORM]["DockerAgents"] ? PLATFORM_MAP[params.PLATFORM]["DockerAgents"] : []
             }
             @Field String dockerAgentLabel = ''
-            @Field String LABEL = '' 
+            @Field String LABEL = ''
             if (params.LABEL) {
                 LABEL = params.LABEL
             } else {
@@ -783,8 +792,8 @@ def getEBCNode() {
     parameters: [
         string(name: 'PLATFORM', value: params.PLATFORM),
         string(name: 'NODE_TYPE', value: 'testmachine'),
-        string(name: 'TIME_LIMIT', value: expectedNodeLifespan.toString()), 
-        string(name: 'GROUP_LABEL', value: UUID.randomUUID().toString()), 
+        string(name: 'TIME_LIMIT', value: expectedNodeLifespan.toString()),
+        string(name: 'GROUP_LABEL', value: UUID.randomUUID().toString()),
         booleanParam(name: 'WAIT', value: wait),
     ]
     return result.buildVariables.group_label

--- a/external/criu/pingPerf.sh
+++ b/external/criu/pingPerf.sh
@@ -53,6 +53,16 @@ getSemeruDockerfile() {
                 if [[ $jdkVersion -lt 21 ]]; then
                     findCommandAndReplace '\/opt\/java\/openjdk\/legal\/java.base\/LICENSE \/licenses;' "\/opt\/java\/openjdk\/legal\/java.base\/LICENSE \/licenses\/;" $semeruDockerfile true
                 fi
+                # UBI 10 specific fixes: remove iptables and other packages that don't exist
+                if [[ $docker_os_version == "10" ]]; then
+                    # Remove iptables from the package list as it doesn't exist in UBI 10
+                    findCommandAndReplace 'iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c' 'jansson libibverbs libnet libnftnl libpcap nftables protobuf-c' $semeruDockerfile false
+                    # Add --no-same-permissions to tar to avoid permission errors in rootless podman builds
+                    findCommandAndReplace 'tar -xzf criu.tar.gz --strip-components=1;' 'tar -xzf criu.tar.gz --strip-components=1 --no-same-permissions;' $semeruDockerfile false
+                fi
+                # Remove specific version constraints for libexpat1 packages to avoid 404 errors when versions are superseded
+                findCommandAndReplace 'libexpat1-dev=[^ ]*' 'libexpat1-dev' $semeruDockerfile false
+                findCommandAndReplace 'libexpat1=[^ ]*' 'libexpat1' $semeruDockerfile false
             else # docker_os is ubuntu
                 echo "curl -OLJSks ${semeruDockerfileUrlBase}/${semeruDockerfile}"
                 curl -OLJSks ${semeruDockerfileUrlBase}/${semeruDockerfile}
@@ -147,7 +157,7 @@ findCommandAndReplace() {
 
 buildImage() {
     echo "build image at $(pwd)..."
-    sudo podman build -t local-ibm-semeru-runtimes:latest -f Dockerfile.open.releases.full . --build-arg DOCKER_REGISTRY_CREDENTIALS_USR=$DOCKER_REGISTRY_CREDENTIALS_USR --build-arg DOCKER_REGISTRY_CREDENTIALS_PSW=$DOCKER_REGISTRY_CREDENTIALS_PSW 2>&1 | tee build_semeru_image.log 
+    sudo podman build -t local-ibm-semeru-runtimes:latest -f Dockerfile.open.releases.full . --build-arg DOCKER_REGISTRY_CREDENTIALS_USR=$DOCKER_REGISTRY_CREDENTIALS_USR --build-arg DOCKER_REGISTRY_CREDENTIALS_PSW=$DOCKER_REGISTRY_CREDENTIALS_PSW 2>&1 | tee build_semeru_image.log
     # Temporarily OpenLiberty ubi dockerfile only supports openjdk 17, not 11, need to add jdkVersion for ubuntu support later
     sudo podman build -t icr.io/appcafe/open-liberty:beta-instanton -f ci.docker/releases/latest/full/Dockerfile.${docker_os}.openjdk17 ci.docker/releases/latest/beta
     sudo podman build -t ol-instanton-test-pingperf:latest -f Dockerfile.pingperf .
@@ -241,7 +251,12 @@ pushImage() {
     dockerRegistryLogin
     echo "Pushing docker image..."
 
-    restore_ready_checkpoint_image_folder="${DOCKER_REGISTRY_URL}/${docker_image_source_job_name}/pingperf_${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${docker_os_version}-${PLATFORM}-${node_label_current_os}-${node_label_micro_architecture}"
+    # Build the image path, handling empty docker_image_source_job_name
+    if [ -z "${docker_image_source_job_name}" ]; then
+        restore_ready_checkpoint_image_folder="${DOCKER_REGISTRY_URL}/pingperf_${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${docker_os_version}-${PLATFORM}-${node_label_current_os}-${node_label_micro_architecture}"
+    else
+        restore_ready_checkpoint_image_folder="${DOCKER_REGISTRY_URL}/${docker_image_source_job_name}/pingperf_${JDK_VERSION}-${JDK_IMPL}-${docker_os}-${docker_os_version}-${PLATFORM}-${node_label_current_os}-${node_label_micro_architecture}"
+    fi
     tagged_restore_ready_checkpoint_image_num="${restore_ready_checkpoint_image_folder}:${build_number}"
 
     # Push a docker image with build_num for records
@@ -292,9 +307,19 @@ pullImageUnprivilegedRestore() {
     dockerRegistryLogin
     getImageNameList
     echo "The host machine micro-architecture is ${node_label_micro_architecture}"
+    imagesTestedCount=0
     for restore_docker_image_name in ${restore_docker_image_name_list[@]}
     do
         echo "Pulling image $restore_docker_image_name"
+
+        # Pre-flight check: verify image exists before attempting pull
+        echo "Checking if image exists in registry..."
+        if ! skopeo inspect --creds "${DOCKER_REGISTRY_CREDENTIALS_USR}:${DOCKER_REGISTRY_CREDENTIALS_PSW}" \
+            docker://$restore_docker_image_name &>/dev/null; then
+            echo "SKIP: Image $restore_docker_image_name not available in registry"
+            continue
+        fi
+
         sudo podman pull $restore_docker_image_name
         getCriuseccompproFile
 
@@ -302,7 +327,13 @@ pullImageUnprivilegedRestore() {
         restoreImage=$restore_docker_image_name
         testUnprivilegedRestoreOnly
         clean
+        imagesTestedCount=$((imagesTestedCount + 1))
     done
+
+    if [ $imagesTestedCount -eq 0 ]; then
+        echo "ERROR: No images were successfully tested."
+        exit 1
+    fi
 
     dockerRegistryLogout
 }
@@ -311,17 +342,32 @@ pullImagePrivilegedRestore() {
     dockerRegistryLogin
     getImageNameList
     echo "The host machine micro-architecture is ${node_label_micro_architecture}"
+    imagesTestedCount=0
     for restore_docker_image_name in ${restore_docker_image_name_list[@]}
     do
         echo "Pulling image $restore_docker_image_name"
+
+        # Pre-flight check: verify image exists before attempting pull
+        echo "Checking if image exists in registry..."
+        if ! skopeo inspect --creds "${DOCKER_REGISTRY_CREDENTIALS_USR}:${DOCKER_REGISTRY_CREDENTIALS_PSW}" \
+            docker://$restore_docker_image_name &>/dev/null; then
+            echo "SKIP: Image $restore_docker_image_name not available in registry"
+            continue
+        fi
+
         sudo podman pull $restore_docker_image_name
 
         # restore
         restoreImage=$restore_docker_image_name
         testPrivilegedRestoreOnly
         clean
+        imagesTestedCount=$((imagesTestedCount + 1))
     done
 
+    if [ $imagesTestedCount -eq 0 ]; then
+        echo "ERROR: No images were successfully tested."
+        exit 1
+    fi
     dockerRegistryLogout
 }
 

--- a/external/criu/playlist.xml
+++ b/external/criu/playlist.xml
@@ -47,6 +47,22 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>criu_pingPerf_testCreateImageAndUnprivilegedRestore_ubi10</testCaseName>
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndUnprivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_ROOT)/external/criu/upload/ubi.repo $(TEST_JDK_HOME) ${JDK_VERSION} "ubi" "10"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)/external/criu/pingPerf.sh clean
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>criu_pingPerf_testCreateImageAndPrivilegedRestore_ubi8</testCaseName>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndPrivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_ROOT)/external/criu/upload/ubi.repo $(TEST_JDK_HOME) ${JDK_VERSION} "ubi" "8"; \
 		$(TEST_STATUS); \
@@ -65,6 +81,22 @@
 	<test>
 		<testCaseName>criu_pingPerf_testCreateImageAndPrivilegedRestore_ubi9</testCaseName>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndPrivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_ROOT)/external/criu/upload/ubi.repo $(TEST_JDK_HOME) ${JDK_VERSION} "ubi" "9"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)/external/criu/pingPerf.sh clean
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>criu_pingPerf_testCreateImageAndPrivilegedRestore_ubi10</testCaseName>
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateImageAndPrivilegedRestore $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_ROOT)/external/criu/upload/ubi.repo $(TEST_JDK_HOME) ${JDK_VERSION} "ubi" "10"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>
@@ -121,6 +153,43 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi10</testCaseName>
+		<disables>
+			<disable>
+				<comment>runtimes_backlog_issues_879</comment>
+			</disable>
+		</disables>
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateRestoreImageAndPushToRegistry $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_ROOT)/external/criu/upload/ubi.repo $(TEST_JDK_HOME) ${JDK_VERSION} "ubi" "10" "$(DOCKER_REGISTRY_DIR)"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)/external/criu/pingPerf.sh clean
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi10</testCaseName>
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh testCreateRestoreImageAndPushToRegistry $(TEST_ROOT)/external/criu/upload/PingperfFiles.zip $(TEST_ROOT)/external/criu/upload/ubi.repo $(TEST_JDK_HOME) ${JDK_VERSION} "ubi" "10" "$(DOCKER_REGISTRY_DIR)"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)/external/criu/pingPerf.sh clean
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>criu_pingPerf_pullImageUnprivilegedRestore_ubi8</testCaseName>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh pullImageUnprivilegedRestore "ubi" "8" "$(DOCKER_REGISTRY_DIR)"; \
 		$(TEST_STATUS); \
@@ -153,6 +222,22 @@
 		</groups>
 	</test>
 	<test>
+		<testCaseName>criu_pingPerf_pullImageUnprivilegedRestore_ubi10</testCaseName>
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh pullImageUnprivilegedRestore "ubi" "10" "$(DOCKER_REGISTRY_DIR)"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)/external/criu/pingPerf.sh clean
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>criu_pingPerf_pullImagePrivilegedRestore_ubi8</testCaseName>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh pullImagePrivilegedRestore "ubi" "8" "$(DOCKER_REGISTRY_DIR)"; \
 		$(TEST_STATUS); \
@@ -171,6 +256,22 @@
 	<test>
 		<testCaseName>criu_pingPerf_pullImagePrivilegedRestore_ubi9</testCaseName>
 		<command>$(TEST_ROOT)/external/criu/pingPerf.sh pullImagePrivilegedRestore "ubi" "9" "$(DOCKER_REGISTRY_DIR)"; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)/external/criu/pingPerf.sh clean
+		</command>
+		<features>
+			<feature>CRIU:required</feature>
+		</features>
+		<levels>
+			<level>dev</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
+		<testCaseName>criu_pingPerf_pullImagePrivilegedRestore_ubi10</testCaseName>
+		<command>$(TEST_ROOT)/external/criu/pingPerf.sh pullImagePrivilegedRestore "ubi" "10" "$(DOCKER_REGISTRY_DIR)"; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)/external/criu/pingPerf.sh clean
 		</command>


### PR DESCRIPTION
- Add UBI 10 playlist.xml test cases for all pingPerf scenarios
- Fix pingPerf.sh to handle UBI 10 package incompatibilities
- Handle empty docker_image_source_job_name when building image path
- Enable ubi10 test in Jenkins openjdk_tests pipeline

related: https://github.ibm.com/runtimes/automation/issues/858