### PR TITLE
Update ProblemList_openjdkvalhalla-openj9.txt

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -82,10 +82,8 @@ runtime/valhalla/inlinetypes/TestJNIIsSameObject.java#id1 https://github.com/ecl
 runtime/valhalla/inlinetypes/ValuePreloadTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/ValueTearing.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/VolatileTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/classfileparser/NullRestrictionWithoutPreview.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/classfileparser/TestIllegalLoadableDescriptors.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/classloading/BigClassTreeClassLoader.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/classloading/PreLoadCircularityTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
@@ -365,3 +363,5 @@ runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id1 https://github.com/adop
 runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id2 https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/LarvalMarkWordTest.java#id3 https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 valhalla/valuetypes/LayoutIterationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java  https://github.com/eclipse-openj9/openj9/issues/13182 generic-all


### PR DESCRIPTION
Added ValueClassValidation.java from the problem list to permanently excluded tests list 

Failing test error message:
> command: compile /Users/konarkshah/openj9-openjdk- jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java
      reason: .class file out of date or does not exist
      started: Tue Mar 03 13:28:32.205 EST 2026
      Mode: agentvm
      Agent id: 1
      Process id: 22147
      finished: Tue Mar 03 13:28:33.048 EST 2026
      elapsed time (seconds): 0.843
      configuration:
      Boot Layer (javac runtime environment)
        class path: /Users/konarkshah/tools/jtreg/lib/javatest.jar 
                    /Users/konarkshah/tools/jtreg/lib/jtreg.jar 
        patch:      java.base /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/patches/java.base
      
      javac compilation environment
        source path: /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser
        class path:  /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser
                     /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d
      
      rerun:
      cd /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/scratch/0 && \
      DOCS_JDK_IMAGE_DIR=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/docs \
      HOME=/Users/konarkshah \
      LANG=en_CA.UTF-8 \
      LC_ALL=C.UTF-8 \
      PATH=/bin:/usr/bin:/usr/sbin \
      TEST_IMAGE_DIR=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test \
          /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk/bin/javac \
              -J-XX:MaxRAMPercentage=4.16667 \
              -J-Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current \
              -J-Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/tmp \
              -J-Dtest.vm.opts='-XX:MaxRAMPercentage=4.16667 -Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current -Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/tmp' \
              -J-Dtest.tool.vm.opts='-J-XX:MaxRAMPercentage=4.16667 -J-Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current -J-Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/tmp' \
              -J-Dtest.compiler.opts= \
              -J-Dtest.java.opts= \
              -J-Dtest.jdk=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk \
              -J-Dcompile.jdk=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk \
              -J-Dtest.timeout.factor=4.0 \
              -J-Dtest.nativepath=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test/hotspot/jtreg/native \
              -J-Dtest.root=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg \
              -J-Dtest.name=runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java \
              -J-Dtest.verbose=Verbose[p=SUMMARY,f=FULL,e=FULL,t=false,m=false] \
              -J-Dtest.file=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java \
              -J-Dtest.main.class=runtime.valhalla.inlinetypes.classfileparser.ValueClassValidation \
              -J-Dtest.src=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
              -J-Dtest.src.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
              -J-Dtest.classes=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d \
              -J-Dtest.class.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d \
              -J-Dtest.class.path.prefix=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d:/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
              -J-Dtest.enable.preview=true \
              -d /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d \
              -sourcepath /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
              -classpath /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser:/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d \
              --enable-preview \
              -source 27 /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java
      
      ACTION: main -- Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE226 A non-interface class must have at least one of ACC_FINAL, ACC_IDENTITY, or ACC_ABSTRACT flags set; class=InvalidClassFlags, offset=143
      REASON: User specified action: run main/othervm -Xverify:remote runtime.valhalla.inlinetypes.classfileparser.ValueClassValidation 
      TIME:   0.336 seconds
      messages:
      command: main -Xverify:remote runtime.valhalla.inlinetypes.classfileparser.ValueClassValidation
      reason: User specified action: run main/othervm -Xverify:remote runtime.valhalla.inlinetypes.classfileparser.ValueClassValidation 
      started: Tue Mar 03 13:28:33.048 EST 2026
      Mode: othervm [/othervm specified]
      Process id: 22153
      finished: Tue Mar 03 13:28:33.384 EST 2026
      elapsed time (seconds): 0.336
      configuration:
      STDOUT:
      Testing: InvalidClassFlags
      STDERR:
      java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE226 A non-interface class must have at least one of ACC_FINAL, ACC_IDENTITY, or ACC_ABSTRACT flags set; class=InvalidClassFlags, offset=143
	      at runtime.valhalla.inlinetypes.classfileparser.ValueClassValidation.runTest(ValueClassValidation.java:46)
	      at runtime.valhalla.inlinetypes.classfileparser.ValueClassValidation.main(ValueClassValidation.java:73)
	      at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	      at java.base/java.lang.reflect.Method.invoke(Method.java:571)
	      at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	      at java.base/java.lang.Thread.run(Thread.java:1527)
      
      JavaTest Message: Test threw exception: java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE226 A non-interface class must have at least one of ACC_FINAL, ACC_IDENTITY, or ACC_ABSTRACT flags set; class=InvalidClassFlags, offset=143
      JavaTest Message: shutting down test
      
      STATUS:Failed.`main' threw exception: java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE226 A non-interface class must have at least one of ACC_FINAL, ACC_IDENTITY, or ACC_ABSTRACT flags set; class=InvalidClassFlags, offset=143
      rerun:
      cd /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/scratch/0 && \
      DOCS_JDK_IMAGE_DIR=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/docs \
      HOME=/Users/konarkshah \
      LANG=en_CA.UTF-8 \
      LC_ALL=C.UTF-8 \
      PATH=/bin:/usr/bin:/usr/sbin \
      TEST_IMAGE_DIR=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test \
      CLASSPATH=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d:/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser:/Users/konarkshah/tools/jtreg/lib/javatest.jar:/Users/konarkshah/tools/jtreg/lib/jtreg.jar \
          /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk/bin/java \
              -Dtest.vm.opts='-XX:MaxRAMPercentage=4.16667 -Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current -Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/tmp' \
              -Dtest.tool.vm.opts='-J-XX:MaxRAMPercentage=4.16667 -J-Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current -J-Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/tmp' \
              -Dtest.compiler.opts= \
              -Dtest.java.opts= \
              -Dtest.jdk=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk \
              -Dcompile.jdk=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk \
              -Dtest.timeout.factor=4.0 \
              -Dtest.nativepath=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test/hotspot/jtreg/native \
              -Dtest.root=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg \
              -Dtest.name=runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java \
              -Dtest.verbose=Verbose[p=SUMMARY,f=FULL,e=FULL,t=false,m=false] \
              -Dtest.file=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java \
              -Dtest.main.class=runtime.valhalla.inlinetypes.classfileparser.ValueClassValidation \
              -Dtest.src=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
              -Dtest.src.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
              -Dtest.classes=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d \
              -Dtest.class.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d \
              -Dtest.class.path.prefix=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d:/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
              -Dtest.enable.preview=true \
              -XX:MaxRAMPercentage=4.16667 \
              -Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current \
              -Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/tmp \
              -Djava.library.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test/hotspot/jtreg/native \
              -Xverify:remote \
              --enable-preview \
              com.sun.javatest.regtest.agent.MainWrapper /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.d/main.0.jta
      
      TEST RESULT: Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE226 A non-interface class must have at least one of ACC_FINAL, ACC_IDENTITY, or ACC_ABSTRACT flags set; class=InvalidClassFlags, offset=143
      --------------------------------------------------
      Test results: failed: 1
      Report written to /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-results/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java/html/report.html
      Results written to /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java
      Error: Some tests failed or other problems occurred.
      Finished running test 'jtreg:test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java'
      Test report is stored in build/macosx-aarch64-server-release/test-results/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_ValueClassValidation_java
      
      ==============================
      Test summary
      ==============================
         TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
         jtreg:test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ValueClassValidation.java
      >>                                                       1     0     1     0     0 <<
      ==============================
      TEST FAILURE
      
      Test error message:

> public static void main(String[] args) throws Exception {

    // Test none of ACC_ABSTRACT, ACC_FINAL or ACC_IDENTITY is illegal.
    runTest("InvalidClassFlags", "Illegal class modifiers in class InvalidClassFlags", null);

    // Test ACC_ABSTRACT without ACC_IDENTITY is legal
    runTest("AbstractValue", null, null);

    // Test ACC_FINAL without ACC_IDENTITY is legal
    runTest("FinalValue", null, null);

    // Test a concrete value class extending an abstract identity class
    runTest("ValueClass", null, "Value type ValueClass has an identity type as supertype");

    // Test a concrete identity class without ACC_IDENTITY but with an older class file version, extending an abstract identity class
    // (Test that the VM fixes missing ACC_IDENTITY in old class files)
    runTest("IdentityClass", null, null);

    // Test a concrete value class extending a concrete (i.e. final) value class
    runTest("ValueClass2", null, "class ValueClass2 cannot inherit from final class FinalValue");

    // Test an abstract value class extending an abstract identity class
    runTest("AbstractValueClass2", null, "Value type AbstractValueClass2 has an identity type as supertype");

    // Test an abstract identity class without ACC_IDENTITY but with an older class file version, extending an abstract identity class
    // (Test that the VM fixes missing ACC_IDENTITY in old class files)
    runTest("AbstractIdentityClass2", null, null);`

The above test was failing due to error message mismatch with the hotspot error message in the test, so am adding the test to the excluded test lists

Added IllegalFieldModifiers.java from the problem list to permanently excluded tests list

Failing test error message:
> ACTION: compile -- Passed. Compilation successful
    REASON: .class file out of date or does not exist
    TIME:   0.806 seconds
    messages:
    command: compile /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java
    reason: .class file out of date or does not exist
    started: Tue Mar 03 13:38:45.956 EST 2026
    Mode: agentvm
    Agent id: 1
    Process id: 32490
    finished: Tue Mar 03 13:38:46.762 EST 2026
    elapsed time (seconds): 0.806
    configuration:
    Boot Layer (javac runtime environment)
      class path: /Users/konarkshah/tools/jtreg/lib/javatest.jar 
                  /Users/konarkshah/tools/jtreg/lib/jtreg.jar 
      patch:      java.base /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/patches/java.base
    
    javac compilation environment
      source path: /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser
      class path:  /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser
                   /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d
    
    rerun:
    cd /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/scratch/0 && \
    DOCS_JDK_IMAGE_DIR=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/docs \
    HOME=/Users/konarkshah \
    LANG=en_CA.UTF-8 \
    LC_ALL=C.UTF-8 \
    PATH=/bin:/usr/bin:/usr/sbin \
    TEST_IMAGE_DIR=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test \
        /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk/bin/javac \
            -J-XX:MaxRAMPercentage=4.16667 \
            -J-Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current \
            -J-Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/tmp \
            -J-Dtest.vm.opts='-XX:MaxRAMPercentage=4.16667 -Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current -Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/tmp' \
            -J-Dtest.tool.vm.opts='-J-XX:MaxRAMPercentage=4.16667 -J-Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current -J-Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/tmp' \
            -J-Dtest.compiler.opts= \
            -J-Dtest.java.opts= \
            -J-Dtest.jdk=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk \
            -J-Dcompile.jdk=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk \
            -J-Dtest.timeout.factor=4.0 \
            -J-Dtest.nativepath=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test/hotspot/jtreg/native \
            -J-Dtest.root=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg \
            -J-Dtest.name=runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java \
            -J-Dtest.verbose=Verbose[p=SUMMARY,f=FULL,e=FULL,t=false,m=false] \
            -J-Dtest.file=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java \
            -J-Dtest.main.class=runtime.valhalla.inlinetypes.classfileparser.IllegalFieldModifiers \
            -J-Dtest.src=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
            -J-Dtest.src.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
            -J-Dtest.classes=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d \
            -J-Dtest.class.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d \
            -J-Dtest.class.path.prefix=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d:/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
            -J-Dtest.enable.preview=true \
            -d /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d \
            -sourcepath /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
            -classpath /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser:/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d \
            --enable-preview \
            -source 27 /Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java
    
    ACTION: main -- Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE117 field cannot be both final and volatile; class=FinalAndVolatile, offset=228
    REASON: User specified action: run main/othervm -Xverify:remote runtime.valhalla.inlinetypes.classfileparser.IllegalFieldModifiers 
    TIME:   0.333 seconds
    messages:
    command: main -Xverify:remote runtime.valhalla.inlinetypes.classfileparser.IllegalFieldModifiers
    reason: User specified action: run main/othervm -Xverify:remote runtime.valhalla.inlinetypes.classfileparser.IllegalFieldModifiers 
    started: Tue Mar 03 13:38:46.762 EST 2026
    Mode: othervm [/othervm specified]
    Process id: 32492
    finished: Tue Mar 03 13:38:47.095 EST 2026
    elapsed time (seconds): 0.333
    configuration:
    STDOUT:
    Testing: FinalAndVolatile
    STDERR:
    java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE117 field cannot be both final and volatile; class=FinalAndVolatile, offset=228
	    at runtime.valhalla.inlinetypes.classfileparser.IllegalFieldModifiers.runTest(IllegalFieldModifiers.java:45)
	    at runtime.valhalla.inlinetypes.classfileparser.IllegalFieldModifiers.main(IllegalFieldModifiers.java:56)
	    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	    at java.base/java.lang.reflect.Method.invoke(Method.java:571)
	    at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	    at java.base/java.lang.Thread.run(Thread.java:1527)
    
    JavaTest Message: Test threw exception: java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE117 field cannot be both final and volatile; class=FinalAndVolatile, offset=228
    JavaTest Message: shutting down test
    
    STATUS:Failed.`main' threw exception: java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE117 field cannot be both final and volatile; class=FinalAndVolatile, offset=228
    rerun:
    cd /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/scratch/0 && \
    DOCS_JDK_IMAGE_DIR=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/docs \
    HOME=/Users/konarkshah \
    LANG=en_CA.UTF-8 \
    LC_ALL=C.UTF-8 \
    PATH=/bin:/usr/bin:/usr/sbin \
    TEST_IMAGE_DIR=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test \
    CLASSPATH=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d:/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser:/Users/konarkshah/tools/jtreg/lib/javatest.jar:/Users/konarkshah/tools/jtreg/lib/jtreg.jar \
        /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk/bin/java \
            -Dtest.vm.opts='-XX:MaxRAMPercentage=4.16667 -Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current -Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/tmp' \
            -Dtest.tool.vm.opts='-J-XX:MaxRAMPercentage=4.16667 -J-Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current -J-Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/tmp' \
            -Dtest.compiler.opts= \
            -Dtest.java.opts= \
            -Dtest.jdk=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk \
            -Dcompile.jdk=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/jdk \
            -Dtest.timeout.factor=4.0 \
            -Dtest.nativepath=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test/hotspot/jtreg/native \
            -Dtest.root=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg \
            -Dtest.name=runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java \
            -Dtest.verbose=Verbose[p=SUMMARY,f=FULL,e=FULL,t=false,m=false] \
            -Dtest.file=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java \
            -Dtest.main.class=runtime.valhalla.inlinetypes.classfileparser.IllegalFieldModifiers \
            -Dtest.src=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
            -Dtest.src.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
            -Dtest.classes=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d \
            -Dtest.class.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d \
            -Dtest.class.path.prefix=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/classes/0/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d:/Users/konarkshah/openj9-openjdk-jdk.valuetypes/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser \
            -Dtest.enable.preview=true \
            -XX:MaxRAMPercentage=4.16667 \
            -Dtest.boot.jdk=/Users/konarkshah/.sdkman/candidates/java/current \
            -Djava.io.tmpdir=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/tmp \
            -Djava.library.path=/Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/images/test/hotspot/jtreg/native \
            -Xverify:remote \
            --enable-preview \
            com.sun.javatest.regtest.agent.MainWrapper /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.d/main.0.jta
    
    TEST RESULT: Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Wrong ClassFormatError: JVMCFRE117 field cannot be both final and volatile; class=FinalAndVolatile, offset=228
    --------------------------------------------------
    Test results: failed: 1
    Report written to /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-results/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java/html/report.html
    Results written to /Users/konarkshah/openj9-openjdk-jdk.valuetypes/build/macosx-aarch64-server-release/test-support/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java
    Error: Some tests failed or other problems occurred.
    Finished running test 'jtreg:test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java'
    Test report is stored in build/macosx-aarch64-server-release/test-results/jtreg_test_hotspot_jtreg_runtime_valhalla_inlinetypes_classfileparser_IllegalFieldModifiers_java
    
    ==============================
    Test summary
    ==============================
       TEST                                              TOTAL  PASS  FAIL ERROR  SKIP   
       jtreg:test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java
    >>                                                       1     0     1     0     0 <<
    ==============================
    TEST FAILURE


Test error message:
>   public static void main(String[] args) throws Exception {

    // Test that ACC_FINAL with ACC_VOLATILE is illegal.
    runTest("FinalAndVolatile", "Illegal field modifiers (fields cannot be final and volatile) in class FinalAndVolatile: 0x850");

    // Test that ACC_STATIC with ACC_STRICT is illegal.
    // runTest("StrictAndStatic", "Illegal field modifiers (field cannot be strict and static) in class StrictAndStatic: 0x808");

    // Test that ACC_STRICT without ACC_FINAL is illegal.
    // runTest("StrictNotFinal", "Illegal field modifiers (strict field must be final) in class StrictNotFinal: 0x800");

    // Test that a concrete value class cannot have field without ACC_STATIC or ACC_STRICT
    runTest("NotStaticNotStrict", "Illegal field modifiers (value class fields must be either non-static final and strict, or static) in class NotStaticNotStrict: 0x10");

    // Test that an abstract value class cannot have field without ACC_STATIC or ACC_STRICT
    runTest("NotStaticNotStrictInAbstract", "Illegal field modifiers (value class fields must be either non-static final and strict, or static) in class NotStaticNotStrictInAbstract: 0x10");

  }

}

The above test was failing due to error message mismatch with the hotspot error message in the test, so am adding the test to the excluded test lists