### PR TITLE
openjdk: add vmTestbase_nsk_monitoring target

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -920,6 +920,32 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>hotspot_vmTestbase_nsk_monitoring</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m $(APPLICATION_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JVM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(JTREG_HOTSPOT_TEST_DIR):vmTestbase_nsk_monitoring$(Q); \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_awt</testCaseName>
 		<disables>
 			<disable>


### PR DESCRIPTION
Adds hotspot [vmTestbase_nsk_monitoring](https://github.com/zzambers/jdk11u-dev/blob/168024359375be044ec76c6c7a0781ddec1db689/test/hotspot/jtreg/TEST.groups#L443) target to openjdk tests. 
Its part of [broader effort](https://github.com/adoptium/aqa-tests/issues/6767) to add VM Testbase tests to aqa.

**TESTING:**
**jdk11**: [RESULTS](https://ci.adoptium.net/view/Test_grinder/job/Grinder/16881/)
- x86-64_linux, aarch64_linux, x86-64_mac, x86-64_windows, x86-32_windows: [FAILURES](https://ci.adoptium.net/view/Test_grinder/job/Grinder/16883/)
`vmTestbase/nsk/monitoring/stress/lowmem/lowmem*/TestDescription.java`
- ppc64_aix: [ERROR](https://ci.adoptium.net/view/Test_grinder/job/Grinder/16887/)

**jdk17**: [RESULTS](https://ci.adoptium.net/view/Test_grinder/job/Grinder/16888/console)
- x86-64_linux, aarch64_linux, x86-64_mac, x86-64_windows, x86-32_windows: **OK**
- ppc64_aix: [ERROR](https://ci.adoptium.net/job/Grinder/16894/console)

**jdk21**: [RESULTS](https://ci.adoptium.net/view/Test_grinder/job/Grinder/16900/)
- x86-64_linux,aarch64_linux,x86-64_mac,x86-64_windows: **OK**

**jdk25**: [RESULTS](https://ci.adoptium.net/view/Test_grinder/job/Grinder/16905/)
- x86-64_mac, x86-64_linux, riscv64_linux: [FAILURES](https://ci.adoptium.net/job/Grinder/16909/) (OOMs)
`vmTestbase/nsk/monitoring/GarbageCollectorMXBean/CollectionCounters/CollectionCounters001/CollectionCounters001.java`
`vmTestbase/nsk/monitoring/GarbageCollectorMXBean/CollectionCounters/CollectionCounters*/TestDescription.java`
- aarch64_linux, x86-64_windows: **OK**