### PR TITLE
Set minimum NUM_MACHINES=6 for special.functional on AIX to prevent OOM

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -269,9 +269,10 @@ def setupParallelEnv() {
 							PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=${minParallelNum} TEST_TIME="
 							NUM_LIST = genParallelList(PARALLEL_OPTIONS)
 						}
-					} else if (TARGET == "sanity.functional" && PLATFORM.contains('windows')) {
+					} else if ((TARGET == "sanity.functional" && PLATFORM.contains('windows')) || (TARGET == "special.functional" && PLATFORM.contains('aix'))) {
 						if (NUM_LIST < 6) {
-							echo "Regenerate parallel list with NUM_MACHINES=6 for TARGET ${TARGET} due to long running tests (runtimes/automation/issues/654)."
+							def reason = TARGET == "sanity.functional" ? "due to long running tests (runtimes/automation/issues/654)" : "on AIX due to memory constraints (runtimes/automation/issues/921)"
+							echo "Regenerate parallel list with NUM_MACHINES=6 for TARGET ${TARGET} ${reason}."
 							PARALLEL_OPTIONS = PARALLEL_OPTIONS_TEMP + " NUM_MACHINES=6 TEST_TIME="
 							NUM_LIST = genParallelList(PARALLEL_OPTIONS)
 						}


### PR DESCRIPTION
AIX machines (e.g., paix820) with limited RAM (8GB) run into OOM errors in resultsSummary when special.functional runs as a single unsplit job. Adding a minimum of 6 parallel lists ensures the job is always split, preventing Perl OOM failures during test result processing.

related: https://github.ibm.com/runtimes/automation/issues/921