### PR TITLE
Update ProblemList_openjdkvalhalla-openj9 from April 5 run

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -16,7 +16,7 @@
 
 ############################################################################
 
-# jdk_valhalla - valhalla
+# jdk_valhalla_j9 - valhalla
 
 ############################################################################
 valhalla/valuetypes/FlatVarHandleTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
@@ -33,24 +33,23 @@ valhalla/valuetypes/ValueClassPreviewTest.java https://github.com/eclipse-openj9
 
 ############################################################################
 
-# jdk_valhalla - java/lang/invoke
+# jdk_valhalla_j9 - com/sun/jdi/valhalla
 
 ############################################################################
-java/lang/invoke/callerSensitive/CallerSensitiveAccess.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
-java/lang/invoke/VarHandles/VarHandleTestAccessValue.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
-java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
-java/lang/invoke/defineHiddenClass/BasicTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
-java/lang/invoke/defineHiddenClass/PreviewHiddenClass.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
-
-############################################################################
-
-# jdk_valhalla - java/lang/instrument/valhalla
+com/sun/jdi/valhalla/CtorDebuggingTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+com/sun/jdi/valhalla/FieldWatchpointsTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+com/sun/jdi/valhalla/ValueArrayReferenceTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
+com/sun/jdi/valhalla/ValueClassTypeTest.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
 
 ############################################################################
 
+# jdk_valhalla_j9 - java/lang/instrument/valhalla
+
 ############################################################################
 
-# hotspot_valhalla - runtime/valhalla
+############################################################################
+
+# hotspot_valhalla_runtime_j9 - runtime/valhalla
 
 ############################################################################
 runtime/valhalla/inlinetypes/AcmpTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
@@ -91,7 +90,7 @@ runtime/valhalla/inlinetypes/classloading/PreLoadFailuresDoNotImpactApplicationT
 
 ############################################################################
 
-# hotspot_valhalla - serviceability/jvmti/valhalla
+# serviceability_valhalla_j9 - serviceability/jvmti/valhalla
 
 ############################################################################
 serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all


### PR DESCRIPTION
- remove java/lang/invoke excludes since it is no longer run in jdk_valhalla target
- add com/sun/jdi/valhalla excludes which are newly run in jdk_valhalla target
- update comments to match new target names

https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Test_JDKnext_valhalla_openjdk_x86-64_linux/64/