### PR TITLE
Enable TestJNIIsValueObject

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -80,7 +80,6 @@ runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java#id1 https://github
 runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java#id2 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/TestJNIIsSameObject.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/TestJNIIsValueObject.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/VolatileTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/classfileparser/TestIllegalLoadableDescriptors.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/classloading/BigClassTreeClassLoader.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all


### PR DESCRIPTION
Enable runtime/valhalla/inlinetypes/TestJNIIsValueObject.java 
Fixed by: https://github.com/eclipse-openj9/openj9/pull/23625

Passing Test: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/59539/testReport/runtime_valhalla_inlinetypes_TestJNIIsValueObject/