### PR TITLE
Cherry-pick: JDK-21 April 2026 dry-run triage: exclude UNSTABLE tests (#7020)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -349,6 +349,7 @@ javax/management/mxbean/ThreadStartTest.java https://github.com/adoptium/aqa-tes
 
 # hotspot_compiler
 
+compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java https://github.com/adoptium/aqa-tests/issues/7021 linux-riscv64
 compiler/arguments/CheckCICompilerCount.java https://github.com/adoptium/aqa-tests/issues/5378 windows-x86
 compiler/c2/irTests/TestPostParseCallDevirtualization.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -447,6 +448,7 @@ containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JD
 
 # hotspot_gc
 
+gc/stress/TestStressIHOPMultiThread.java#id0 https://github.com/adoptium/aqa-tests/issues/7023 linux-riscv64
 gc/shenandoah/compiler/TestBarrierAboveProj.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 
@@ -463,6 +465,7 @@ runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tes
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
+runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/aqa-tests/issues/7008 windows-aarch64
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5920 windows-aarch64
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
@@ -538,6 +541,7 @@ vmTestbase/gc/gctests/LargeObjects/large005/TestDescription.java https://github.
 # hotspot_vmTestbase_vm_mlvm
 
 vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6715 aix-all
+vmTestbase/vm/mlvm/hiddenloader/stress/byteMutation/Test.java https://github.com/adoptium/aqa-tests/issues/7024 windows-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
Cherry-pick: [JDK-21 April 2026 dry-run triage: exclude UNSTABLE tests (](https://github.com/adoptium/aqa-tests/commit/d8fad559869fd3068de46c8ff72569bab033a68b)https://github.com/adoptium/aqa-tests/pull/7020[)](https://github.com/adoptium/aqa-tests/commit/d8fad559869fd3068de46c8ff72569bab033a68b)
