### PR TITLE
[v1.0.13-release] Cherry pick: Exclude 3 aix tests on various JDKs (#7028)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -526,12 +526,20 @@ vmTestbase/gc/gctests/LargeObjects/large002/TestDescription.java https://github.
 vmTestbase/gc/gctests/LargeObjects/large003/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
 vmTestbase/gc/gctests/LargeObjects/large004/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
 vmTestbase/gc/gctests/LargeObjects/large005/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
+vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adoptium/aqa-tests/issues/6849 aix-ppc64
 
 ############################################################################
 
 # hotspot_vmTestbase_vm_mlvm
 
 vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6715 aix-all
+
+############################################################################
+
+# hotspot_tier1_runtime
+
+runtime/DefineClass/NullClassBytesTest.java https://github.com/adoptium/aqa-tests/issues/6197 aix-ppc64
+runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/6197 aix-ppc64
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -535,6 +535,7 @@ vmTestbase/gc/gctests/LargeObjects/large002/TestDescription.java https://github.
 vmTestbase/gc/gctests/LargeObjects/large003/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
 vmTestbase/gc/gctests/LargeObjects/large004/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
 vmTestbase/gc/gctests/LargeObjects/large005/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
+vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adoptium/aqa-tests/issues/6849 aix-ppc64
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -528,6 +528,12 @@ vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java https://g
 
 ############################################################################
 
+# hotspot_vmTestbase_vm_gc
+
+vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adoptium/aqa-tests/issues/6849 aix-ppc64
+
+############################################################################
+
 # Unreliables - Tests that fail infrequently. These must not block releases.
 # Uncomment duplicates above if any of these lines are removed.
 

--- a/openjdk/excludes/ProblemList_openjdk26.txt
+++ b/openjdk/excludes/ProblemList_openjdk26.txt
@@ -485,6 +485,12 @@ vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java https://g
 
 ############################################################################
 
+# hotspot_vmTestbase_vm_gc
+
+vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adoptium/aqa-tests/issues/6849 aix-ppc64
+
+############################################################################
+
 # Unreliables - Tests that fail infrequently. These must not block releases.
 # Uncomment duplicates above if any of these lines are removed.
 


### PR DESCRIPTION
Cherry pick of https://github.com/adoptium/aqa-tests/pull/7028