### PR TITLE
Excluding additional jpackage tests due to Wix V6 being unsupported (yet)

### DIFF
--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk25.txt
@@ -31,6 +31,12 @@ runtime/os/AvailableProcessors.java https://github.com/adoptium/infrastructure/i
 
 ############################################################################
 
+# hotspot_vmTestbase_vm_compiler
+
+vmTestbase/jit/misctests/fpustack/GraphApplet.java https://github.com/adoptium/infrastructure/issues/3855 windows-all
+
+############################################################################
+
 # jdk_awt
 
 ############################################################################
@@ -68,6 +74,8 @@ runtime/os/AvailableProcessors.java https://github.com/adoptium/infrastructure/i
 ############################################################################
 
 # jdk_io
+
+java/io/File/GetCanonicalPath.java https://bugs.openjdk.org/browse/JDK-8380178 windows-x64
 
 ############################################################################
 
@@ -110,6 +118,7 @@ tools/jpackage/share/BasicTest.java https://github.com/adoptium/aqa-tests/issues
 tools/jpackage/share/EmptyFolderTest.java#id0 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/InOutPathTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/InstallDirTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/share/JLinkOptionsTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/LicenseTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/PerUserCfgTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/PostImageScriptTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all

--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk26.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk26.txt
@@ -113,23 +113,38 @@ runtime/os/AvailableProcessors.java https://github.com/adoptium/infrastructure/i
 # jdk_tools
 
 tools/jpackage/share/AddLShortcutTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/AsyncTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/BasicTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/EmptyFolderTest.java#id0 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/InOutPathTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/InstallDirTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/JLinkOptionsTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/LicenseTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/PerUserCfgTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/PostImageScriptTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/share/RuntimePackageTest.java#id0 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/share/ServiceTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/ServiceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/share/SimplePackageTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/share/VendorTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/windows/Win8282351Test.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/windows/WinDirChooserTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/windows/WinInstallerResourceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/windows/WinLongPathTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/windows/WinLongVersionTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/windows/WinLongVersionTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/windows/WinMenuGroupTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/windows/WinMenuTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/windows/WinOSConditionTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/windows/WinResourceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/windows/WinShortcutTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
+tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 
 ############################################################################
 


### PR DESCRIPTION
Updating the list of excluded jpackage tests on windows for jdk26

Most failures were likely caused by our machines using Wix v6 (when jdk26 only has updates for v5 and under).

P.S. Change includes a handful of single-test exclusions as well. See the associated issues for details.