### PR TITLE
[v1.0.13-release] Cherry pick: Exclude compiler test on JDK17 riscv linux (#7034)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -397,6 +397,7 @@ compiler/whitebox/MakeMethodNotCompilableTest.java https://github.com/adoptium/a
 compiler/codecache/MHIntrinsicAllocFailureTest.java https://github.com/adoptium/aqa-tests/issues/4515#issuecomment-1512404678 windows-x86,linux-arm
 compiler/loopopts/TestRemoveEmptyCountedLoop.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
 compiler/splitif/TestCrashAtIGVNSplitIfSubType.java https://bugs.openjdk.org/browse/JDK-8311964 windows-x86
+compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java https://github.com/adoptium/aqa-tests/issues/7021 linux-riscv64
 
 ############################################################################
 


### PR DESCRIPTION
Cherry pick of https://github.com/adoptium/aqa-tests/pull/7034