### PR TITLE
functional/MBCS_Tests/i18n/src/DateFormatTest: ResourceBundleTest_16 only matches for exact version as previously

### DIFF
--- a/functional/MBCS_Tests/i18n/src/DateFormatTest.java
+++ b/functional/MBCS_Tests/i18n/src/DateFormatTest.java
@@ -53,6 +53,10 @@ public class DateFormatTest {
         // Try loading version specific bundles first..
         for(long i : resourceBundleFixVersionsToTry) {
             if (i <= version) {
+                if (i == 16L && version != i) {
+                    // in case of 16, only match exact jdk version
+                    continue;
+                }
                 try {
                     return ResourceBundle.getBundle(baseName+"_"+i, locale);
                 } catch (MissingResourceException e) {


### PR DESCRIPTION
Restores original behavior, where `ResourceBundleTest_16` is only used for jdk 16, changed by: https://github.com/adoptium/aqa-tests/pull/6941
Fixes: https://github.com/adoptium/aqa-tests/issues/7042