### PR TITLE
[v1.0.13-release] Cherry pick: Exclude java/net/Socket/B8312065.java JDK11 JDK17 (#7046)

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -111,6 +111,7 @@ sun/net/www/http/KeepAliveCache/KeepAliveProperty.java https://bugs.openjdk.org/
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/net/httpclient/ConnectTimeoutWithProxySync.java https://bugs.openjdk.org/browse/JDK-8375352 generic-all
 java/net/httpclient/ConnectTimeoutWithProxyAsync.java https://bugs.openjdk.org/browse/JDK-8375352 generic-all
+java/net/Socket/B8312065.java https://github.com/adoptium/aqa-tests/issues/7043 linux-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -136,6 +136,7 @@ java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-
 sun/net/www/http/KeepAliveCache/KeepAliveProperty.java https://bugs.openjdk.org/browse/JDK-8285836 linux-ppc64le
 java/net/httpclient/ConnectTimeoutWithProxySync.java https://bugs.openjdk.org/browse/JDK-8375352 generic-all
 java/net/httpclient/ConnectTimeoutWithProxyAsync.java https://bugs.openjdk.org/browse/JDK-8375352 generic-all
+java/net/Socket/B8312065.java https://github.com/adoptium/aqa-tests/issues/7043 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
Cherry pick of https://github.com/adoptium/aqa-tests/pull/7046