### PR TITLE
openjdk: add vmTestbase_nsk_sysdict target

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -625,6 +625,23 @@ vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java https://g
 
 ############################################################################
 
+# hotspot_vmTestbase_nsk_sysdict
+
+vmTestbase/nsk/sysdict/vm/stress/btree/btree001/btree001.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree002/btree002.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree003/btree003.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree004/btree004.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree005/btree005.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree006/btree006.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree007/btree007.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree008/btree008.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree009/btree009.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree010/btree010.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree012/btree012.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+
+############################################################################
+
 # Unreliables - Tests that fail infrequently. These must not block releases.
 # Uncomment duplicates above if any of these lines are removed.
 

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -538,6 +538,23 @@ vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java https://g
 
 ############################################################################
 
+# hotspot_vmTestbase_nsk_sysdict
+
+vmTestbase/nsk/sysdict/vm/stress/btree/btree001/btree001.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree002/btree002.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree003/btree003.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree004/btree004.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree005/btree005.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree006/btree006.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree007/btree007.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree008/btree008.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree009/btree009.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree010/btree010.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree012/btree012.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+
+############################################################################
+
 # hotspot_tier1_runtime
 
 runtime/DefineClass/NullClassBytesTest.java https://github.com/adoptium/aqa-tests/issues/6197 aix-ppc64

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -546,6 +546,23 @@ vmTestbase/vm/mlvm/hiddenloader/stress/byteMutation/Test.java https://github.com
 
 ############################################################################
 
+# hotspot_vmTestbase_nsk_sysdict
+
+vmTestbase/nsk/sysdict/vm/stress/btree/btree001/btree001.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree002/btree002.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree003/btree003.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree004/btree004.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree005/btree005.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree006/btree006.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree007/btree007.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree008/btree008.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree009/btree009.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree010/btree010.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree012/btree012.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+
+############################################################################
+
 # Unreliables - Tests that fail infrequently. These must not block releases.
 # Uncomment duplicates above if any of these lines are removed.
 

--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -529,6 +529,23 @@ vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java https://g
 
 ############################################################################
 
+# hotspot_vmTestbase_nsk_sysdict
+
+vmTestbase/nsk/sysdict/vm/stress/btree/btree001/btree001.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree002/btree002.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree003/btree003.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree004/btree004.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree005/btree005.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree006/btree006.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree007/btree007.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree008/btree008.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree009/btree009.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree010/btree010.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree012/btree012.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+
+############################################################################
+
 # hotspot_vmTestbase_vm_gc
 
 vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adoptium/aqa-tests/issues/6849 aix-ppc64

--- a/openjdk/excludes/ProblemList_openjdk26.txt
+++ b/openjdk/excludes/ProblemList_openjdk26.txt
@@ -487,6 +487,23 @@ vmTestbase/vm/mlvm/mixed/stress/java/findDeadlock/TestDescription.java https://g
 
 ############################################################################
 
+# hotspot_vmTestbase_nsk_sysdict
+
+vmTestbase/nsk/sysdict/vm/stress/btree/btree001/btree001.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree002/btree002.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree003/btree003.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree004/btree004.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree005/btree005.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree006/btree006.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree007/btree007.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree008/btree008.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree009/btree009.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree010/btree010.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+vmTestbase/nsk/sysdict/vm/stress/btree/btree012/btree012.java https://github.com/adoptium/aqa-tests/issues/7078 windows-x86
+
+############################################################################
+
 # hotspot_vmTestbase_vm_gc
 
 vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adoptium/aqa-tests/issues/6849 aix-ppc64

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -957,6 +957,32 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>hotspot_vmTestbase_nsk_sysdict</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m $(APPLICATION_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JVM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(JTREG_HOTSPOT_TEST_DIR):vmTestbase_nsk_sysdict$(Q); \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_awt</testCaseName>
 		<disables>
 			<disable>


### PR DESCRIPTION
Adds hotspot [vmTestbase_nsk_sysdict](https://github.com/openjdk/jdk11u-dev/blob/168024359375be044ec76c6c7a0781ddec1db689/test/hotspot/jtreg/TEST.groups#L456) target to openjdk tests.
Its part of [effort](https://github.com/adoptium/aqa-tests/issues/6767) to add VM Testbase tests to aqa.

**Testing:**
**jdk11:** [RESULTS](https://ci.adoptium.net/job/Grinder/17142/)
- x86-64_linux, aarch64_linux, s390x_linux, x86-64_windows, x86-64_mac: **OK**
- x86-32_windows: [FAILURES](https://ci.adoptium.net/job/Grinder/17147/) (OOMs, rerun [same](https://ci.adoptium.net/job/Grinder/17180/))
  `vmTestbase/nsk/sysdict/vm/stress/btree/btree*`

**jdk17:** [RESULTS](https://ci.adoptium.net/job/Grinder/17151/)
- x86-64_linux, x86-64_windows, x86-64_mac: **OK**

**jdk21:** [RESULTS](https://ci.adoptium.net/job/Grinder/17158/)
- x86-64_linux, aarch64_linux, x86-64_windows, x86-64_mac: **OK**

**jdk25:** [RESULTS](https://ci.adoptium.net/job/Grinder/17163/)
- x86-64_linux, aarch64_linux, x86-64_windows, x86-64_mac, s390x_linux: **OK**