### PR TITLE
WIP: jpackage exclusion refactoring for windows jdk25 and up

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -178,12 +178,14 @@ java/nio/channels/vthread/BlockingChannelOps.java#default https://github.com/ado
 java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github.com/adoptium/aqa-tests/issues/4440 aix-all
 java/net/httpclient/ConnectTimeoutWithProxySync.java https://bugs.openjdk.org/browse/JDK-8375352 generic-all
 java/net/httpclient/ConnectTimeoutWithProxyAsync.java https://bugs.openjdk.org/browse/JDK-8375352 generic-all
+
 ############################################################################
 
 # jdk_io
 
 #java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
 java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+
 ############################################################################
 
 # jdk_jdi
@@ -251,6 +253,7 @@ sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-test
 sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 sun/security/ssl/X509TrustManagerImpl/distrust/Entrust.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 sun/security/ssl/X509TrustManagerImpl/distrust/Camerfirma.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
+
 ###########################################################################
 
 # jdk_security4
@@ -298,9 +301,6 @@ tools/jlink/JLinkTest.java https://github.com/adoptium/aqa-tests/issues/2857 win
 tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
 tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-ppc64
 tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/launcher/JliLaunchTest.java https://github.com/adoptium/aqa-tests/issues/5010 aix-all
 
 ############################################################################
@@ -309,6 +309,7 @@ tools/launcher/JliLaunchTest.java https://github.com/adoptium/aqa-tests/issues/5
 
 com/sun/jdi/OnJcmdTest.java https://github.com/adoptium/aqa-tests/issues/2837 windows-x86
 com/sun/jdi/ThreadMemoryLeakTest.java https://github.com/adoptium/aqa-tests/issues/5010 aix-all
+
 ############################################################################
 
 # jdk_util

--- a/openjdk/excludes/ProblemList_openjdk26.txt
+++ b/openjdk/excludes/ProblemList_openjdk26.txt
@@ -186,6 +186,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 #java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 aix-all
 java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,aix-all
+
 ############################################################################
 
 # jdk_jdi
@@ -252,6 +253,7 @@ sun/security/lib/cacerts/VerifyCACerts.java https://github.com/adoptium/aqa-test
 sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 sun/security/ssl/X509TrustManagerImpl/distrust/Entrust.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
 sun/security/ssl/X509TrustManagerImpl/distrust/Camerfirma.java https://github.com/adoptium/aqa-tests/issues/3976 generic-all
+
 ###########################################################################
 
 # jdk_security4
@@ -298,15 +300,14 @@ sun/tools/jstatd/TestJstatdServer.java https://github.com/adoptium/aqa-tests/iss
 tools/jlink/JLinkReproducible3Test.java https://bugs.openjdk.java.net/browse/JDK-8253688 aix-all
 tools/jlink/CheckExecutable.java https://github.com/adoptium/aqa-tests/issues/2857 aixx-ppc64
 tools/jlink/plugins/VendorInfoPluginsTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
-tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/launcher/JliLaunchTest.java https://github.com/adoptium/aqa-tests/issues/5010 aix-all
+
 ############################################################################
 
 # jdk_jdi
 
 com/sun/jdi/ThreadMemoryLeakTest.java https://github.com/adoptium/aqa-tests/issues/5010 aix-all
+
 ############################################################################
 
 # jdk_util

--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk25.txt
@@ -113,24 +113,6 @@ java/io/File/GetCanonicalPath.java https://bugs.openjdk.org/browse/JDK-8380178 w
 
 # jdk_tools
 
-tools/jpackage/share/AddLShortcutTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/BasicTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/EmptyFolderTest.java#id0 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/InOutPathTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/InstallDirTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/JLinkOptionsTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/LicenseTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/PerUserCfgTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/PostImageScriptTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/ServiceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/VendorTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/Win8282351Test.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinInstallerResourceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinLongPathTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinLongVersionTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinOSConditionTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinResourceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk26.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk26.txt
@@ -112,40 +112,6 @@ runtime/os/AvailableProcessors.java https://github.com/adoptium/infrastructure/i
 
 # jdk_tools
 
-tools/jpackage/share/AddLShortcutTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/AsyncTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/BasicTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/EmptyFolderTest.java#id0 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/InOutPathTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/InstallDirTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/JLinkOptionsTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/LicenseTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/PerUserCfgTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/PostImageScriptTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/RuntimePackageTest.java#id0 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/ServiceTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/ServiceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/SimplePackageTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/share/VendorTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/Win8282351Test.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinDirChooserTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinInstallerResourceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinLongPathTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinLongVersionTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinLongVersionTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinMenuGroupTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinMenuTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinOSConditionTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinResourceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinShortcutTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-tools/jpackage/windows/WinUrlTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
-
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2168,6 +2168,12 @@
 				<version>17</version>
 				<impl>hotspot</impl>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/6692</comment>
+				<platform>.*windows.*</platform>
+				<version>25+</version>
+				<impl>hotspot</impl>
+			</disable>
 		</disables>
 		<variations>
 			<variation>Mode150</variation>
@@ -2186,6 +2192,44 @@
 	${VENDOR_PROBLEM_LIST_FILE} \
 	$(Q)$(JTREG_JDK_TEST_DIR):jdk_tools$(Q); \
 	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<features>
+			<feature>FIPS140_2:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
+            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>OpenJCEPlus:nonapplicable</feature>
+		</features>
+	</test>
+	<test>
+		<testCaseName>jdk_tools_win</testCaseName>
+		<comment>https://github.com/adoptium/aqa-tests/issues/6692</comment>
+		<platform>.*windows.*</platform>
+		<version>25+</version>
+		<impl>hotspot</impl>
+		<variations>
+			<variation>Mode150</variation>
+			<variation>Mode650</variation>
+			<variation>Mode1000</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) -Xmx512m $(APPLICATION_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+			$(JTREG_BASIC_OPTIONS) $(JDK_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+			$(TIMEOUT_HANDLER) \
+			-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+			-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+			-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+			-exclude:$(Q)$(JTREG_JDK_TEST_DIR)$(D)ProblemList.txt$(Q) \
+			-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+			${FEATURE_PROBLEM_LIST_FILE} \
+			${VENDOR_PROBLEM_LIST_FILE} \
+			$(Q)$(JTREG_JDK_TEST_DIR):core_tools$(Q) \
+			$(Q)$(JTREG_JDK_TEST_DIR):svc_tools$(Q); \
+			$(TEST_STATUS)</command>
 		<levels>
 			<level>extended</level>
 		</levels>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -2173,6 +2173,7 @@
 				<platform>.*windows.*</platform>
 				<version>25+</version>
 				<impl>hotspot</impl>
+				<vendor>eclipse</vendor>
 			</disable>
 		</disables>
 		<variations>
@@ -2212,6 +2213,7 @@
 		<platform>.*windows.*</platform>
 		<version>25+</version>
 		<impl>hotspot</impl>
+		<vendor>eclipse</vendor>
 		<variations>
 			<variation>Mode150</variation>
 			<variation>Mode650</variation>

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -198,7 +198,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -349,7 +349,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<platformRequirementsList>
@@ -386,7 +386,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<platformRequirements>os.linux</platformRequirements>
@@ -668,7 +668,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -708,7 +708,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -748,7 +748,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -795,7 +795,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -998,7 +998,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1047,7 +1047,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1080,7 +1080,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1113,7 +1113,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1145,7 +1145,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -1184,7 +1184,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1219,7 +1219,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<platformRequirements>os.win,bits.64</platformRequirements>
@@ -1257,7 +1257,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -1294,7 +1294,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -1330,7 +1330,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -1367,7 +1367,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1406,7 +1406,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1499,7 +1499,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1720,7 +1720,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -1761,7 +1761,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1799,7 +1799,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -1832,7 +1832,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2008,7 +2008,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2051,7 +2051,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2089,7 +2089,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2107,7 +2107,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<levels>
@@ -2203,14 +2203,14 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
 	<test>
 		<testCaseName>jdk_tools_win</testCaseName>
 		<comment>https://github.com/adoptium/aqa-tests/issues/6692</comment>
-		<platform>.*windows.*</platform>
+		<platformRequirements>os.windows</platformRequirements>
 		<version>25+</version>
 		<impl>hotspot</impl>
 		<vendor>eclipse</vendor>
@@ -2242,7 +2242,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2274,7 +2274,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -2323,7 +2323,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2403,7 +2403,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2450,7 +2450,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2506,7 +2506,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2551,7 +2551,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2591,7 +2591,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2631,7 +2631,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2677,7 +2677,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2720,7 +2720,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2769,7 +2769,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2839,7 +2839,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2876,7 +2876,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2925,7 +2925,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -2973,7 +2973,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -3009,7 +3009,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -3045,7 +3045,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -3081,7 +3081,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -3129,7 +3129,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>
@@ -3161,7 +3161,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -3197,7 +3197,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -3233,7 +3233,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -3269,7 +3269,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -3305,7 +3305,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -3341,7 +3341,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -3377,7 +3377,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 		<impls>
@@ -3704,7 +3704,7 @@
 			<feature>FIPS140_2:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS:nonapplicable</feature>
 			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3:nonapplicable</feature>
-            <feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
+			<feature>FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced:nonapplicable</feature>
 			<feature>OpenJCEPlus:nonapplicable</feature>
 		</features>
 	</test>


### PR DESCRIPTION
Various jpackage tests fail due to a single issue

However, some are intermittent, and it is unreliable to exclude a fixed list of individual testcases.

So this change prevents all jpackage tests from running on windows for jdk25 and up, while allowing the other jdk_tools tests to run.

Change also excludes formatting improvements and a test unexclusion for jpackage tests logged against a pair of resolved issues.

Note: Change untested. Putting this on the backburner until April release is done.