### PR TITLE
openjdk: add vmTestbase_nsk_jvmti target

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -535,6 +535,12 @@ vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adop
 
 ############################################################################
 
+# hotspot_vmTestbase_nsk_jvmti
+
+vmTestbase/nsk/jvmti/IterateThroughHeap/callbacks/Callbacks.java https://github.com/adoptium/aqa-tests/issues/7096 linux-s390x
+
+############################################################################
+
 # Unreliables - Tests that fail infrequently. These must not block releases.
 # Uncomment duplicates above if any of these lines are removed.
 

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -957,6 +957,32 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>hotspot_vmTestbase_nsk_jvmti</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m $(APPLICATION_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JVM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(JTREG_HOTSPOT_TEST_DIR):vmTestbase_nsk_jvmti$(Q); \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_awt</testCaseName>
 		<disables>
 			<disable>


### PR DESCRIPTION
Adds hotspot [vmTestbase_nsk_jvmti](https://github.com/openjdk/jdk11u-dev/blob/168024359375be044ec76c6c7a0781ddec1db689/test/hotspot/jtreg/TEST.groups#L463) target to openjdk tests.
Its part of [effort](https://github.com/adoptium/aqa-tests/issues/6767) to add VM Testbase tests to aqa.

**Testing:**
**jdk11:** [RESULTS](https://ci.adoptium.net/job/Grinder/17231/)
- x86-64_linux, aarch64_linux, s390x_linux, x86-64_windows, x86-64_mac: **OK**

**jdk17:** [RESULTS](https://ci.adoptium.net/job/Grinder/17237/)
- x86-64_linux, x86-64_windows, x86-64_mac: **OK**

**jdk21:** [RESULTS](https://ci.adoptium.net/job/Grinder/17241/)
- x86-64_linux, aarch64_linux, x86-64_windows, x86-64_mac: **OK**

**jdk25:** [RESULTS](https://ci.adoptium.net/job/Grinder/17249/)
- x86-64_linux, aarch64_linux, x86-64_mac: **OK**
- x86-64_windows: [1 FAILURE](https://ci.adoptium.net/job/Grinder/17249/) (rerun [OK](https://ci.adoptium.net/job/Grinder/17253/))
  `vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java`
- s390x_linux: [1 FAILURE](https://ci.adoptium.net/job/Grinder/17251/) (rerun [same](https://ci.adoptium.net/job/Grinder/17252/))
  `vmTestbase/nsk/jvmti/IterateThroughHeap/callbacks/Callbacks.java`