### PR TITLE
Update OpenJ9 Valhalla exclude list from weekly run

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -50,6 +50,7 @@ com/sun/jdi/valhalla/ValueClassTypeTest.java https://github.com/adoptium/aqa-tes
 
 ############################################################################
 runtime/valhalla/inlinetypes/AcmpTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/InheritedFlatFieldTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/InlineWithJni.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/MonitorEnterTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/MonitorEnterTest.java#id0 https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
@@ -70,6 +71,7 @@ runtime/valhalla/inlinetypes/classloading/PreLoadCircularityTest.java https://gi
 # serviceability_valhalla_j9 - serviceability/jvmti/valhalla
 
 ############################################################################
+serviceability/jvmti/valhalla/GetCtorLocal/ValueGetCtorLocal.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
@@ -98,6 +100,7 @@ valhalla/valuetypes/NullRestrictedTest.java https://github.com/eclipse-openj9/op
 ############################################################################
 runtime/valhalla/inlinetypes/AnnotationsTests.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/ClassPrintLayoutDcmd.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+runtime/valhalla/inlinetypes/ContendedFlatFieldOopMap.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/DirectMethodTest.java#default https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/DirectMethodTest.java#no-array-flattening https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/field_layout/EmptyValueTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
- ContendedFlatFieldOopMap and InheritedFlatFieldTest are excluded to be investigated in the future
- ValueGetCtorLocal is permanently excluded

https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Test_JDKnext_valhalla_openjdk_x86-64_linux/80/