### PR TITLE
Exclude Double128VectorTests on OpenJ9 AArch64 Linux

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -3125,6 +3125,12 @@
 	</test>
 	<test>
 		<testCaseName>jdk_vector_double128_j9</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/20389</comment>
+				<platform>aarch64_linux</platform>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xjit:{*Double128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,dontApplyLogFileNameSuffix,verbose={vectorAPI}</variation>
 		</variations>


### PR DESCRIPTION
Issue: https://github.com/eclipse-openj9/openj9/issues/20389
Related: #7063