### PR TITLE
Fix Badge plugin method calls

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -851,7 +851,7 @@ def runTest( ) {
 						}
 					}
 				}
-			} else if (env.SPEC.startsWith('zos')) { 
+			} else if (env.SPEC.startsWith('zos')) {
 				makeTest("${RUNTEST_CMD}")
 			} else {
 				sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"], ignoreMissing: true) {
@@ -887,8 +887,8 @@ def runTest( ) {
 		} else {
 			env.jobStatus = 'FAILURE'
 			echo 'Could not find test result, set build result to FAILURE.'
-			def summary = manager.createSummary("error.svg")
-			summary.appendText("TEST BUILD FAILURE!", false)
+			def summary = manager.addSummary("error.svg")
+			summary.setText(summary.getText() + "TEST BUILD FAILURE!")
 		}
 	}
 }
@@ -903,24 +903,24 @@ def checkTestResults(results) {
 	if (results["TOTAL"] == 0) {
 		env.jobStatus = 'FAILURE'
 		echo 'No test ran, current build status is FAILURE.'
-		summary = manager.createSummary("folder-delete.svg")
-		summary.appendText("NO TEST FOUND!", false)
+		summary = manager.addSummary("folder-delete.svg")
+		summary.setText(summary.getText() + "NO TEST FOUND!")
 		return
 	}
 
 	if (results["FAILED"] != 0) {
 		env.jobStatus = 'UNSTABLE'
 		echo 'There were test failures, current build status is UNSTABLE.'
-		summary = manager.createSummary("warning.svg")
+		summary = manager.addSummary("warning.svg")
 	} else {
-		summary = manager.createSummary("accept.svg")
+		summary = manager.addSummary("accept.svg")
 	}
 
-	summary.appendText("TEST TARGETS SUMMARY:<ul>", false)
+	summary.setText(summary.getText() + "TEST TARGETS SUMMARY:<ul>")
 	results.each {
-		summary.appendText("<li><b>$it.key</b> : $it.value</li>", false)
+		summary.setText(summary.getText() + "<li><b>$it.key</b> : $it.value</li>")
 	}
-	summary.appendText("</ul>", false)
+	summary.setText(summary.getText() + "</ul>")
 }
 
 def post(output_name) {
@@ -1035,7 +1035,7 @@ def post(output_name) {
 				uploadToArtifactory(pattern)
 			}
 		}
-		
+
 		int rerunIterations = params.RERUN_ITERATIONS ? params.RERUN_ITERATIONS.toInteger() : 0
 		if (JOB_NAME.contains("_rerun") || JOB_NAME.contains("_testList_") || JOB_NAME.contains("_iteration_")) {
 			addFailedTestsGrinderLink()
@@ -1045,7 +1045,7 @@ def post(output_name) {
 			} else {
 				addFailedTestsGrinderLink()
 			}
-		} 
+		}
 
 		try {
 			junit skipMarkingBuildUnstable: true, allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/result/**/*.jtr.xml, **/junitreports/**/*.xml, **/external_test_reports/**/*.xml'
@@ -1621,7 +1621,7 @@ def triggerRerunJob (String originalStatus, Map rerunTestJobParams = null) {
 					def rerunResults = archiveChildJobTap(childJobs, originalStatus)
 					if (env.JDK_IMPL == "openj9" || env.JDK_IMPL == "ibm") {
 						currentBuild.result = originalStatus
-					} else if ( originalStatus == 'ABORTED') { 
+					} else if ( originalStatus == 'ABORTED') {
 						// Set job status to the worst result among its parallel branches including rerun branch.
 						currentBuild.result = originalStatus
 					} else {
@@ -1677,7 +1677,7 @@ def archiveChildJobTap(childJobs, originalStatus = 'SUCCESS') {
 					def childResult = cjob.getCurrentResult()
 					echo "${name} #${buildId} completed with status ${childResult}"
 					// track FAILURE job childTestJobParams if it's rerun stage
-					if ( originalStatus == "SUCCESS" && childResult == "FAILURE" ) { 
+					if ( originalStatus == "SUCCESS" && childResult == "FAILURE" ) {
 						childTestJobParams << parallelTestParams.findAll {it.key == name}
 					}
 					if (isWorseThan( childResult, currentStatus)) {
@@ -1760,8 +1760,8 @@ def runParallelTests() {
 		stage ("Parallel Tests") {
 			def childJobs = parallel parallel_tests
 			// There are cases env.PARALLEL != "None", but job is non parallel if number list is 1
-			if ( !childJobs.isEmpty() ) { 
-				parallelResults = archiveChildJobTap(childJobs) 
+			if ( !childJobs.isEmpty() ) {
+				parallelResults = archiveChildJobTap(childJobs)
 			}
 		}
 	}
@@ -1817,10 +1817,10 @@ def forceCleanWS() {
 
 def checkDacapoH2Metric() {
         def regex = ".*=====\\sDaCapo.*?h2\\sPASSED\\sin\\s(\\d*\\.?\\d*)\\smsec\\s=====\\s*\$"
-        def matcher = manager.getLogMatcher(regex)  
+        def matcher = manager.getLogMatcher(regex)
 
         if (matcher?.matches()) {
-                def runtime = matcher.group(1) 
+                def runtime = matcher.group(1)
                 archiveDacapoH2Metric(runtime)
                 println("DaCapo-h2 metric found and archived")
         } else {
@@ -1831,11 +1831,11 @@ def checkDacapoH2Metric() {
 def archiveDacapoH2Metric(runtime) {
         def fileName = "${env.JOB_NAME}_${env.BUILD_NUMBER}.json"
         def jsonData = [
-                "benchmark": "dacapo-h2", 
+                "benchmark": "dacapo-h2",
                         "metrics": [
                                 "dacapo-h2": [
                                         ["value": runtime],
-                                        ["higherbetter": true], 
+                                        ["higherbetter": true],
                                         ["units": "msec"]
                                 ]
                         ]


### PR DESCRIPTION
Fixes #7107 

Following the final deprecation of 4 methods in the jenkins badge plugin see  version 3.583.vdc8d4a_a_1d586 ( https://plugins.jenkins.io/badge/releases/ )

The following 4 methods have been removed and replaced ( they were deprecated in v2.0 around 18 months ago )

Deprecated Step	Replacement
addHtmlBadge	addBadge
addShortText	addBadge
createSummary	addSummary
summary#appendText	summary#setText - e.g. use summary.setText(summary.getText() + ' text to append')

This PR updates the deprecated methods with their replacements