### PR TITLE
Add /exclude command support for OpenJDK test exclusions

### DIFF
--- a/.github/workflows/autoTestPR.yml
+++ b/.github/workflows/autoTestPR.yml
@@ -63,6 +63,37 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.event.comment.body, '/exclude ')
     steps:
+      - name: Check permission
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          # Check if commenter is the issue author
+          if [ "$COMMENTER" = "$ISSUE_AUTHOR" ]; then
+            echo "✅ Commenter is the issue author"
+            exit 0
+          fi
+          
+          # Check if commenter has write permission (is a project committer)
+          PERMISSION=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/collaborators/$COMMENTER/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          
+          if [ "$PERMISSION" = "admin" ] || [ "$PERMISSION" = "write" ]; then
+            echo "✅ Commenter has $PERMISSION permission"
+            exit 0
+          fi
+          
+          # Permission denied
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body="@${COMMENTER} ⛔ You don't have permission to trigger test exclusions. Only the issue author or project committers can use this command."
+          exit 1
+          
       - name: Parse exclude command
         id: parse
         env:

--- a/.github/workflows/autoTestPR.yml
+++ b/.github/workflows/autoTestPR.yml
@@ -69,24 +69,24 @@ jobs:
           COMMENTER: ${{ github.event.comment.user.login }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
-          # Check if commenter is the issue author
+          # Allow if commenter is the issue author
           if [ "$COMMENTER" = "$ISSUE_AUTHOR" ]; then
             echo "✅ Commenter is the issue author"
             exit 0
           fi
           
-          # Check if commenter has write permission (is a project committer)
+          # Allow if commenter is a project committer (write/admin permission)
           PERMISSION=$(gh api \
             -H "Accept: application/vnd.github+json" \
             "/repos/${{ github.repository }}/collaborators/$COMMENTER/permission" \
             --jq '.permission' 2>/dev/null || echo "none")
           
           if [ "$PERMISSION" = "admin" ] || [ "$PERMISSION" = "write" ]; then
-            echo "✅ Commenter has $PERMISSION permission"
+            echo "✅ Commenter is a project committer with $PERMISSION permission"
             exit 0
           fi
           
-          # Permission denied
+          # Deny if neither condition is met
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/autoTestPR.yml
+++ b/.github/workflows/autoTestPR.yml
@@ -70,7 +70,6 @@ jobs:
           COMMENTER: ${{ github.event.comment.user.login }}
         run: |
           # Extract command components
-          echo "comment_body=$COMMENT_BODY" >> "$GITHUB_OUTPUT"
           echo "commenter=$COMMENTER" >> "$GITHUB_OUTPUT"
           
           # Basic validation - check format

--- a/.github/workflows/autoTestPR.yml
+++ b/.github/workflows/autoTestPR.yml
@@ -3,8 +3,9 @@ on:
   issue_comment:
     types: [created]
 permissions:
-      contents: write
-      issues: write
+  contents: write
+  issues: write
+  pull-requests: write
 jobs:
   autoTestPR:
     runs-on: ubuntu-latest
@@ -57,3 +58,129 @@ jobs:
       - name: add label
         run: |
           curl -u github-actions:${{ secrets.GITHUB_TOKEN }} -d '{"labels":["test excluded"]}' -X POST ${{ github.event.issue.url }}/labels
+
+  exclude-openjdk-test:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, '/exclude ')
+    steps:
+      - name: Parse exclude command
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          # Extract command components
+          echo "comment_body=$COMMENT_BODY" >> "$GITHUB_OUTPUT"
+          echo "commenter=$COMMENTER" >> "$GITHUB_OUTPUT"
+          
+          # Basic validation - check format
+          if ! echo "$COMMENT_BODY" | grep -qE '^/exclude [^ ]+ [^ ]+ [^ ]+ [^ ]+'; then
+            echo "❌ Invalid command format"
+            echo "Expected: /exclude <targets> <testcase> <issue_url> <platform>"
+            echo "Example: /exclude jdk11,jdk21 java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all"
+            exit 1
+          fi
+          
+          # Extract targets (second word)
+          TARGETS=$(echo "$COMMENT_BODY" | awk '{print $2}')
+          echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
+          
+          # Extract testcase (third word)
+          TESTCASE=$(echo "$COMMENT_BODY" | awk '{print $3}')
+          echo "testcase=$TESTCASE" >> "$GITHUB_OUTPUT"
+          
+      - name: Post acknowledgement comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGETS: ${{ steps.parse.outputs.targets }}
+          TESTCASE: ${{ steps.parse.outputs.testcase }}
+          COMMENTER: ${{ steps.parse.outputs.commenter }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f "body=@${COMMENTER} 🔧 Processing exclusion for \`${TESTCASE}\` with targets: \`${TARGETS}\`..."
+            
+      - name: Set up Python 3.8
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.8
+          
+      - name: Checkout current repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: 'tests'
+          
+      - name: Run exclude script
+        id: exclude
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+        run: |
+          cd tests
+          python scripts/disabled_tests/exclude_openjdk.py \
+            -m "$COMMENT_BODY" \
+            -c "$COMMENT_URL" \
+            -d "$GITHUB_WORKSPACE/tests"
+            
+      - name: Script failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENTER: ${{ steps.parse.outputs.commenter }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f "body=@${COMMENTER} ❌ Failed to process exclusion. Please check the [action run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) for details."
+            
+      - name: Create Pull Request
+        if: success()
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          path: 'tests'
+          title: 'Exclude OpenJDK test: ${{ steps.parse.outputs.testcase }}'
+          body: |
+            **OpenJDK Test Exclusion**
+            
+            - **Test**: `${{ steps.parse.outputs.testcase }}`
+            - **Targets**: `${{ steps.parse.outputs.targets }}`
+            - **Triggered by**: @${{ steps.parse.outputs.commenter }}
+            - **Related**: ${{ github.event.comment.html_url }}
+            
+            This PR excludes the specified test from the ProblemList files for the given targets.
+          commit-message: |
+            Exclude OpenJDK test: ${{ steps.parse.outputs.testcase }}
+            
+            Targets: ${{ steps.parse.outputs.targets }}
+            Related: ${{ github.event.comment.html_url }}
+          branch: 'exclude-openjdk-test'
+          branch-suffix: 'random'
+          signoff: 'true'
+          
+      - name: Add label
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels" \
+            -f "labels[]=test excluded"
+            
+      - name: Comment success
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGETS: ${{ steps.parse.outputs.targets }}
+          TESTCASE: ${{ steps.parse.outputs.testcase }}
+          COMMENTER: ${{ steps.parse.outputs.commenter }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f "body=@${COMMENTER} ✅ Successfully created PR to exclude \`${TESTCASE}\` for targets: \`${TARGETS}\`"

--- a/.github/workflows/autoTestPR.yml
+++ b/.github/workflows/autoTestPR.yml
@@ -103,34 +103,37 @@ jobs:
           # Extract command components
           echo "commenter=$COMMENTER" >> "$GITHUB_OUTPUT"
           
-          # Basic validation - check format
-          if ! echo "$COMMENT_BODY" | grep -qE '^/exclude [^ ]+ [^ ]+ [^ ]+ [^ ]+'; then
+          # Basic validation - check format (minimum 3 required parameters + optional parameters)
+          # Format: /exclude <testcases> <issue_url> <platform> [jdk=<versions>] [impl=<impl>] [variant=<variant>]
+          if ! echo "$COMMENT_BODY" | grep -qE '^/exclude [^ ]+ [^ ]+ [^ ]+'; then
             echo "❌ Invalid command format"
-            echo "Expected: /exclude <targets> <testcase> <issue_url> <platform>"
-            echo "Example: /exclude jdk11,jdk21 java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all"
+            echo "Expected: /exclude <testcases> <issue_url> <platform> [jdk=<versions>] [impl=<impl>] [variant=<variant>]"
+            echo ""
+            echo "Examples:"
+            echo "  /exclude java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all"
+            echo "  /exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 linux-x64 jdk=11,17,21"
+            echo "  /exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 linux-x64 jdk=11 impl=openj9"
+            echo "  /exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 linux-x64 variant=alpine"
+            echo ""
+            echo "Note: When jdk= is omitted, defaults to LTS versions (8,11,17,21,25) + latest (26)"
             exit 1
           fi
           
-          # Extract targets (second word)
-          TARGETS=$(echo "$COMMENT_BODY" | awk '{print $2}')
-          echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
-          
-          # Extract testcase (third word)
-          TESTCASE=$(echo "$COMMENT_BODY" | awk '{print $3}')
-          echo "testcase=$TESTCASE" >> "$GITHUB_OUTPUT"
+          # Extract testcases (second word)
+          TESTCASES=$(echo "$COMMENT_BODY" | awk '{print $2}')
+          echo "testcases=$TESTCASES" >> "$GITHUB_OUTPUT"
           
       - name: Post acknowledgement comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGETS: ${{ steps.parse.outputs.targets }}
-          TESTCASE: ${{ steps.parse.outputs.testcase }}
+          TESTCASES: ${{ steps.parse.outputs.testcases }}
           COMMENTER: ${{ steps.parse.outputs.commenter }}
         run: |
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
-            -f "body=@${COMMENTER} 🔧 Processing exclusion for \`${TESTCASE}\` with targets: \`${TARGETS}\`..."
+            -f "body=@${COMMENTER} 🔧 Processing OpenJDK test exclusion for: \`${TESTCASES}\`..."
             
       - name: Set up Python 3.8
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -167,24 +170,25 @@ jobs:
             -f "body=@${COMMENTER} ❌ Failed to process exclusion. Please check the [action run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) for details."
             
       - name: Create Pull Request
+        id: create-pr
         if: success()
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           path: 'tests'
-          title: 'Exclude OpenJDK test: ${{ steps.parse.outputs.testcase }}'
+          title: 'Exclude OpenJDK test: ${{ steps.parse.outputs.testcases }}'
           body: |
             **OpenJDK Test Exclusion**
             
-            - **Test**: `${{ steps.parse.outputs.testcase }}`
-            - **Targets**: `${{ steps.parse.outputs.targets }}`
+            - **Test(s)**: `${{ steps.parse.outputs.testcases }}`
             - **Triggered by**: @${{ steps.parse.outputs.commenter }}
             - **Related**: ${{ github.event.comment.html_url }}
             
-            This PR excludes the specified test from the ProblemList files for the given targets.
-          commit-message: |
-            Exclude OpenJDK test: ${{ steps.parse.outputs.testcase }}
+            This PR excludes the specified test(s) from ProblemList files.
             
-            Targets: ${{ steps.parse.outputs.targets }}
+            See the commit for details on which ProblemList files were modified.
+          commit-message: |
+            Exclude OpenJDK test: ${{ steps.parse.outputs.testcases }}
+            
             Related: ${{ github.event.comment.html_url }}
           branch: 'exclude-openjdk-test'
           branch-suffix: 'random'
@@ -205,15 +209,14 @@ jobs:
         if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGETS: ${{ steps.parse.outputs.targets }}
-          TESTCASE: ${{ steps.parse.outputs.testcase }}
+          TESTCASES: ${{ steps.parse.outputs.testcases }}
           COMMENTER: ${{ steps.parse.outputs.commenter }}
         run: |
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
-            -f "body=@${COMMENTER} ✅ Successfully created PR to exclude \`${TESTCASE}\` for targets: \`${TARGETS}\`"
+            -f "body=@${COMMENTER} ✅ Successfully created PR to exclude OpenJDK test(s): \`${TESTCASES}\`. Check the PR for details on which ProblemList files were modified."
 
       - name: Comment no changes
         if: success() && steps.create-pr.outputs.pull-request-number == ''

--- a/.github/workflows/autoTestPR.yml
+++ b/.github/workflows/autoTestPR.yml
@@ -155,7 +155,7 @@ jobs:
             -d "$GITHUB_WORKSPACE/tests"
             
       - name: Script failed
-        if: failure()
+        if: failure() && steps.exclude.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENTER: ${{ steps.parse.outputs.commenter }}
@@ -214,3 +214,17 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
             -f "body=@${COMMENTER} ✅ Successfully created PR to exclude \`${TESTCASE}\` for targets: \`${TARGETS}\`"
+
+      - name: Comment no changes
+        if: success() && steps.create-pr.outputs.pull-request-number == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGETS: ${{ steps.parse.outputs.targets }}
+          TESTCASE: ${{ steps.parse.outputs.testcase }}
+          COMMENTER: ${{ steps.parse.outputs.commenter }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f "body=@${COMMENTER} ℹ️ No changes were made — \`${TESTCASE}\` may already be excluded for targets: \`${TARGETS}\`"

--- a/scripts/disabled_tests/exclude_openjdk.py
+++ b/scripts/disabled_tests/exclude_openjdk.py
@@ -3,17 +3,27 @@
 Script to add OpenJDK test exclusions to ProblemList files.
 
 Usage:
-    python exclude_openjdk.py -m "/exclude <targets> <testcase> <issue_url> <platform>" -c <comment_url> -d <workspace_dir>
+    python exclude_openjdk.py -m "/exclude <testcases> <issue_url> <platform> [jdk=<versions>] [impl=<impl>] [variant=<variant>]" -c <comment_url> -d <workspace_dir>
 
-Example:
-    python exclude_openjdk.py -m "/exclude jdk11,jdk21-openj9 java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all" -c "https://github.com/..." -d "/path/to/aqa-tests"
+Examples:
+    # Simple exclusion (all JDK versions)
+    python exclude_openjdk.py -m "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all" -c "https://..." -d "."
+    
+    # Specific JDK versions
+    python exclude_openjdk.py -m "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all jdk=11,17,21" -c "https://..." -d "."
+    
+    # With implementation
+    python exclude_openjdk.py -m "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 linux-x64 jdk=11,21 impl=openj9" -c "https://..." -d "."
+    
+    # With variant (alpine or vendor)
+    python exclude_openjdk.py -m "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 linux-x64 jdk=11 variant=alpine" -c "https://..." -d "."
 """
 
 import argparse
 import os
 import re
 import sys
-from typing import List, Dict, Tuple, Any
+from typing import List, Dict, Tuple, Any, Optional
 
 
 class ExcludeCommandError(Exception):
@@ -21,25 +31,46 @@ class ExcludeCommandError(Exception):
     pass
 
 
-def parse_exclude_command(comment_body: str) -> Tuple[List[str], List[str], str, str]:
+def parse_optional_params(params_str: str) -> Dict[str, str]:
     """
-    Parse /exclude command with target specifiers.
+    Parse optional parameters in format key=value.
     
-    Format: /exclude <targets> <testcases> <issue_urls> <platforms>
+    Args:
+        params_str: String containing optional parameters
+        
+    Returns:
+        Dictionary of parameter name to value
+    """
+    params = {}
+    # Match patterns like jdk=11,17 impl=openj9 variant=alpine
+    pattern = r'(\w+)=([^\s]+)'
+    matches = re.findall(pattern, params_str)
+    
+    for key, value in matches:
+        params[key] = value
+    
+    return params
+
+
+def parse_exclude_command(comment_body: str) -> Tuple[List[str], str, str, Dict[str, str]]:
+    """
+    Parse /exclude command with optional parameters.
+    
+    Format: /exclude <testcases> <issue_url> <platform> [jdk=<versions>] [impl=<impl>] [variant=<variant>]
     
     Where:
-    - targets: comma-separated (e.g., jdk11,jdk17,jdk21) - will be parsed
-    - testcases: comma-separated (e.g., test1.java,test2.java) - will be parsed
-    - issue_urls: kept as-is (can contain commas like https://...,https://...)
-    - platforms: kept as-is (can contain commas like linux-all,windows-x64)
-    
-    Each testcase will create one line in ProblemList with the same issue_urls and platforms.
+    - testcases: comma-separated (e.g., test1.java,test2.java)
+    - issue_url: single URL
+    - platform: platform spec (can contain commas)
+    - jdk: optional, comma-separated versions (e.g., 11,17,21) - defaults to all
+    - impl: optional, implementation (e.g., openj9, sap)
+    - variant: optional, variant (e.g., alpine, eclipse, microsoft)
     
     Args:
         comment_body: The full comment body containing the /exclude command
         
     Returns:
-        Tuple of (target_list, testcase_list, issue_urls, platforms)
+        Tuple of (testcase_list, issue_url, platform, optional_params)
         
     Raises:
         ExcludeCommandError: If command format is invalid
@@ -55,22 +86,30 @@ def parse_exclude_command(comment_body: str) -> Tuple[List[str], List[str], str,
     if not exclude_line:
         raise ExcludeCommandError("No /exclude command found in comment")
     
-    # Split the command into parts (space-separated)
-    parts = exclude_line.split(None, 4)
+    # Split the command: /exclude <testcases> <issue_url> <platform> [optional params...]
+    # First split on spaces, but we need at least 4 parts (command, testcases, issue_url, platform)
+    parts = exclude_line.split(None, 3)
     
-    if len(parts) != 5:
+    if len(parts) < 4:
         raise ExcludeCommandError(
-            f"Invalid format. Expected: /exclude <targets> <testcases> <issue_urls> <platforms>\n"
+            f"Invalid format. Expected: /exclude <testcases> <issue_url> <platform> [jdk=<versions>] [impl=<impl>] [variant=<variant>]\n"
             f"Got {len(parts)} parts: {parts}"
         )
     
-    _, targets_str, testcases_str, issue_urls, platforms = parts
+    _, testcases_str, issue_url, remaining = parts
     
-    # Parse comma-separated targets
-    targets = [t.strip() for t in targets_str.split(',') if t.strip()]
-    
-    if not targets:
-        raise ExcludeCommandError("At least one target must be specified")
+    # Parse remaining part for platform and optional parameters
+    # Platform is everything before the first key=value pattern
+    optional_match = re.search(r'\s+(\w+=)', remaining)
+    if optional_match:
+        # Found optional parameters
+        platform = remaining[:optional_match.start()].strip()
+        optional_str = remaining[optional_match.start():].strip()
+        optional_params = parse_optional_params(optional_str)
+    else:
+        # No optional parameters, everything is platform
+        platform = remaining.strip()
+        optional_params = {}
     
     # Parse comma-separated test cases
     testcases = [tc.strip() for tc in testcases_str.split(',') if tc.strip()]
@@ -78,66 +117,97 @@ def parse_exclude_command(comment_body: str) -> Tuple[List[str], List[str], str,
     if not testcases:
         raise ExcludeCommandError("At least one test case must be specified")
     
-    return targets, testcases, issue_urls, platforms
+    if not platform:
+        raise ExcludeCommandError("Platform must be specified")
+    
+    return testcases, issue_url, platform, optional_params
 
 
-def resolve_target_to_file(target: str, base_dir: str) -> str:
+def resolve_targets_from_params(optional_params: Dict[str, str], base_dir: str) -> List[Tuple[str, str]]:
     """
-    Resolves a target specifier to ProblemList file path.
-    
-    Format: jdk{version}[-{variant}]
-    
-    Variants:
-    - None (default): openjdk/excludes/ProblemList_openjdk{version}.txt
-    - openj9/sap: openjdk/excludes/ProblemList_openjdk{version}-{impl}.txt
-    - alpine: openjdk/excludes/alpine/ProblemList_openjdk{version}.txt
-    - vendor names: openjdk/excludes/vendors/{vendor}/ProblemList_openjdk{version}.txt
+    Resolve target files from optional parameters.
     
     Args:
-        target: Target specifier (e.g., jdk11, jdk21-openj9, jdk11-alpine)
+        optional_params: Dictionary of optional parameters (jdk, impl, variant)
         base_dir: Base directory of the workspace
         
     Returns:
-        Full path to the ProblemList file
+        List of tuples (target_description, file_path)
         
     Raises:
-        ExcludeCommandError: If target format is invalid or file doesn't exist
+        ExcludeCommandError: If parameters are invalid or files don't exist
     """
-    # Parse target: jdk{version}[-{variant}]
-    match = re.match(r'^jdk(\d+|valhalla)(?:-(.+))?$', target.lower())
-    if not match:
-        raise ExcludeCommandError(
-            f"Invalid target format: '{target}'. Expected: jdk{{version}}[-{{variant}}]"
-        )
-    
-    version = match.group(1)
-    variant = match.group(2)
-    
     excludes_dir = os.path.join(base_dir, "openjdk", "excludes")
     
-    if variant is None:
-        # Root level: ProblemList_openjdk{version}.txt
-        file_path = os.path.join(excludes_dir, f"ProblemList_openjdk{version}.txt")
-    
-    elif variant in ['openj9', 'sap']:
-        # Implementation-specific: ProblemList_openjdk{version}-{impl}.txt
-        file_path = os.path.join(excludes_dir, f"ProblemList_openjdk{version}-{variant}.txt")
-    
-    elif variant == 'alpine':
-        # Alpine: alpine/ProblemList_openjdk{version}.txt
-        file_path = os.path.join(excludes_dir, "alpine", f"ProblemList_openjdk{version}.txt")
-    
+    # Parse JDK versions (default to all if not specified)
+    jdk_versions = []
+    if 'jdk' in optional_params:
+        jdk_versions = [v.strip() for v in optional_params['jdk'].split(',') if v.strip()]
     else:
-        # Vendor-specific: vendors/{vendor}/ProblemList_openjdk{version}.txt
-        file_path = os.path.join(excludes_dir, "vendors", variant, f"ProblemList_openjdk{version}.txt")
+        # Default: find all available JDK versions
+        jdk_versions = get_all_jdk_versions(excludes_dir)
     
-    # Validate file exists
-    if not os.path.isfile(file_path):
-        raise ExcludeCommandError(
-            f"ProblemList file not found for target '{target}': {file_path}"
-        )
+    impl = optional_params.get('impl', '')  # e.g., 'openj9', 'sap'
+    variant = optional_params.get('variant', '')  # e.g., 'alpine', 'eclipse', 'microsoft'
     
-    return file_path
+    targets = []
+    
+    for version in jdk_versions:
+        # Construct file path based on parameters
+        if variant:
+            # Variant takes precedence
+            if variant == 'alpine':
+                file_path = os.path.join(excludes_dir, "alpine", f"ProblemList_openjdk{version}.txt")
+                target_desc = f"jdk{version}-{variant}"
+            else:
+                # Assume it's a vendor
+                file_path = os.path.join(excludes_dir, "vendors", variant, f"ProblemList_openjdk{version}.txt")
+                target_desc = f"jdk{version}-{variant}"
+        elif impl:
+            # Implementation-specific
+            file_path = os.path.join(excludes_dir, f"ProblemList_openjdk{version}-{impl}.txt")
+            target_desc = f"jdk{version}-{impl}"
+        else:
+            # Root level (default)
+            file_path = os.path.join(excludes_dir, f"ProblemList_openjdk{version}.txt")
+            target_desc = f"jdk{version}"
+        
+        # Validate file exists
+        if not os.path.isfile(file_path):
+            raise ExcludeCommandError(
+                f"ProblemList file not found for {target_desc}: {file_path}"
+            )
+        
+        targets.append((target_desc, file_path))
+    
+    return targets
+
+
+def get_all_jdk_versions(excludes_dir: str) -> List[str]:
+    """
+    Get default JDK versions for exclusions (LTS versions + latest).
+    
+    Returns LTS versions (8, 11, 17, 21, 25) and the latest version (currently 26).
+    This list should be updated quarterly when new versions are released.
+    
+    Args:
+        excludes_dir: Path to the excludes directory
+        
+    Returns:
+        List of JDK version strings (e.g., ['8', '11', '17', '21', '25', '26'])
+    """
+    # LTS versions: 8, 11, 17, 21, 25 (next LTS will be 29 in 2028)
+    # Latest: 26 (update quarterly: 27 in Q1 2026, 28 in Q3 2026, etc.)
+    default_versions = ['8', '11', '17', '21', '25', '26']
+    
+    # Verify each version has a ProblemList file
+    available_versions = []
+    for version in default_versions:
+        file_path = os.path.join(excludes_dir, f"ProblemList_openjdk{version}.txt")
+        if os.path.isfile(file_path):
+            available_versions.append(version)
+    
+    return available_versions
 
 
 def check_exclusion_exists(file_path: str, testcase: str, platform: str) -> bool:
@@ -187,7 +257,7 @@ def add_exclusion_to_file(file_path: str, testcase: str, issue_url: str, platfor
         print(f"  ⚠️  Exclusion already exists in {os.path.basename(file_path)}")
         return False
     
-    # Read the file to find the right place to insert
+    # Read the file
     with open(file_path, 'r') as f:
         lines = f.readlines()
     
@@ -223,13 +293,22 @@ def process_exclude_command(comment_body: str, workspace_dir: str) -> Dict[str, 
         ExcludeCommandError: If command processing fails
     """
     # Parse the command
-    targets, testcases, issue_urls, platforms = parse_exclude_command(comment_body)
+    testcases, issue_url, platform, optional_params = parse_exclude_command(comment_body)
     
     print(f"Processing /exclude command:")
-    print(f"  Targets: {', '.join(targets)}")
     print(f"  Test cases: {', '.join(testcases)}")
-    print(f"  Issue URLs: {issue_urls}")
-    print(f"  Platforms: {platforms}")
+    print(f"  Issue URL: {issue_url}")
+    print(f"  Platform: {platform}")
+    if optional_params:
+        print(f"  Optional parameters: {optional_params}")
+    print()
+    
+    # Resolve targets from parameters
+    targets = resolve_targets_from_params(optional_params, workspace_dir)
+    
+    print(f"Resolved targets:")
+    for target_desc, file_path in targets:
+        print(f"  {target_desc} → {os.path.relpath(file_path, workspace_dir)}")
     print()
     
     # Process each target
@@ -238,44 +317,39 @@ def process_exclude_command(comment_body: str, workspace_dir: str) -> Dict[str, 
     total_exclusions_added = 0
     total_exclusions_skipped = 0
     
-    for target in targets:
-        try:
-            file_path = resolve_target_to_file(target, workspace_dir)
-            print(f"Target '{target}' → {os.path.relpath(file_path, workspace_dir)}")
-            
-            # Add each testcase as a separate line
-            target_added = 0
-            target_skipped = 0
-            
-            for testcase in testcases:
-                was_added = add_exclusion_to_file(file_path, testcase, issue_urls, platforms)
-                
-                if was_added:
-                    target_added += 1
-                    total_exclusions_added += 1
-                else:
-                    target_skipped += 1
-                    total_exclusions_skipped += 1
-            
-            if target_added > 0:
-                modified_files.append({
-                    'target': target,
-                    'file_path': os.path.relpath(file_path, workspace_dir),
-                    'exclusions_added': target_added,
-                    'exclusions_skipped': target_skipped
-                })
-            else:
-                skipped_files.append({
-                    'target': target,
-                    'file_path': os.path.relpath(file_path, workspace_dir),
-                    'exclusions_skipped': target_skipped
-                })
+    for target_desc, file_path in targets:
+        print(f"Processing {target_desc}...")
         
-        except ExcludeCommandError as e:
-            print(f"  ❌ Error: {e}")
-            raise
+        # Add each testcase as a separate line
+        target_added = 0
+        target_skipped = 0
+        
+        for testcase in testcases:
+            was_added = add_exclusion_to_file(file_path, testcase, issue_url, platform)
+            
+            if was_added:
+                target_added += 1
+                total_exclusions_added += 1
+            else:
+                target_skipped += 1
+                total_exclusions_skipped += 1
+        
+        if target_added > 0:
+            modified_files.append({
+                'target': target_desc,
+                'file_path': os.path.relpath(file_path, workspace_dir),
+                'exclusions_added': target_added,
+                'exclusions_skipped': target_skipped
+            })
+        else:
+            skipped_files.append({
+                'target': target_desc,
+                'file_path': os.path.relpath(file_path, workspace_dir),
+                'exclusions_skipped': target_skipped
+            })
+        
+        print()
     
-    print()
     print(f"Summary:")
     print(f"  Modified: {len(modified_files)} file(s)")
     print(f"  Total exclusions added: {total_exclusions_added}")
@@ -285,10 +359,10 @@ def process_exclude_command(comment_body: str, workspace_dir: str) -> Dict[str, 
         raise ExcludeCommandError("No files were processed")
     
     return {
-        'targets': targets,
         'testcases': testcases,
-        'issue_urls': issue_urls,
-        'platforms': platforms,
+        'issue_url': issue_url,
+        'platform': platform,
+        'optional_params': optional_params,
         'modified_files': modified_files,
         'skipped_files': skipped_files,
         'total_exclusions_added': total_exclusions_added,

--- a/scripts/disabled_tests/exclude_openjdk.py
+++ b/scripts/disabled_tests/exclude_openjdk.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""
+Script to add OpenJDK test exclusions to ProblemList files.
+
+Usage:
+    python exclude_openjdk.py -m "/exclude <targets> <testcase> <issue_url> <platform>" -c <comment_url> -d <workspace_dir>
+
+Example:
+    python exclude_openjdk.py -m "/exclude jdk11,jdk21-openj9 java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all" -c "https://github.com/..." -d "/path/to/aqa-tests"
+"""
+
+import argparse
+import os
+import re
+import sys
+from typing import List, Dict, Tuple, Any
+
+
+class ExcludeCommandError(Exception):
+    """Exception raised for errors in the exclude command."""
+    pass
+
+
+def parse_exclude_command(comment_body: str) -> Tuple[List[str], List[str], str, str]:
+    """
+    Parse /exclude command with target specifiers.
+    
+    Format: /exclude <targets> <testcases> <issue_urls> <platforms>
+    
+    Where:
+    - targets: comma-separated (e.g., jdk11,jdk17,jdk21) - will be parsed
+    - testcases: comma-separated (e.g., test1.java,test2.java) - will be parsed
+    - issue_urls: kept as-is (can contain commas like https://...,https://...)
+    - platforms: kept as-is (can contain commas like linux-all,windows-x64)
+    
+    Each testcase will create one line in ProblemList with the same issue_urls and platforms.
+    
+    Args:
+        comment_body: The full comment body containing the /exclude command
+        
+    Returns:
+        Tuple of (target_list, testcase_list, issue_urls, platforms)
+        
+    Raises:
+        ExcludeCommandError: If command format is invalid
+    """
+    # Extract the /exclude command line
+    lines = comment_body.strip().split('\n')
+    exclude_line = None
+    for line in lines:
+        if line.strip().startswith('/exclude '):
+            exclude_line = line.strip()
+            break
+    
+    if not exclude_line:
+        raise ExcludeCommandError("No /exclude command found in comment")
+    
+    # Split the command into parts (space-separated)
+    parts = exclude_line.split(None, 4)
+    
+    if len(parts) != 5:
+        raise ExcludeCommandError(
+            f"Invalid format. Expected: /exclude <targets> <testcases> <issue_urls> <platforms>\n"
+            f"Got {len(parts)} parts: {parts}"
+        )
+    
+    _, targets_str, testcases_str, issue_urls, platforms = parts
+    
+    # Parse comma-separated targets
+    targets = [t.strip() for t in targets_str.split(',') if t.strip()]
+    
+    if not targets:
+        raise ExcludeCommandError("At least one target must be specified")
+    
+    # Parse comma-separated test cases
+    testcases = [tc.strip() for tc in testcases_str.split(',') if tc.strip()]
+    
+    if not testcases:
+        raise ExcludeCommandError("At least one test case must be specified")
+    
+    return targets, testcases, issue_urls, platforms
+
+
+def resolve_target_to_file(target: str, base_dir: str) -> str:
+    """
+    Resolves a target specifier to ProblemList file path.
+    
+    Format: jdk{version}[-{variant}]
+    
+    Variants:
+    - None (default): openjdk/excludes/ProblemList_openjdk{version}.txt
+    - openj9/sap: openjdk/excludes/ProblemList_openjdk{version}-{impl}.txt
+    - alpine: openjdk/excludes/alpine/ProblemList_openjdk{version}.txt
+    - vendor names: openjdk/excludes/vendors/{vendor}/ProblemList_openjdk{version}.txt
+    
+    Args:
+        target: Target specifier (e.g., jdk11, jdk21-openj9, jdk11-alpine)
+        base_dir: Base directory of the workspace
+        
+    Returns:
+        Full path to the ProblemList file
+        
+    Raises:
+        ExcludeCommandError: If target format is invalid or file doesn't exist
+    """
+    # Parse target: jdk{version}[-{variant}]
+    match = re.match(r'^jdk(\d+|valhalla)(?:-(.+))?$', target.lower())
+    if not match:
+        raise ExcludeCommandError(
+            f"Invalid target format: '{target}'. Expected: jdk{{version}}[-{{variant}}]"
+        )
+    
+    version = match.group(1)
+    variant = match.group(2)
+    
+    excludes_dir = os.path.join(base_dir, "openjdk", "excludes")
+    
+    if variant is None:
+        # Root level: ProblemList_openjdk{version}.txt
+        file_path = os.path.join(excludes_dir, f"ProblemList_openjdk{version}.txt")
+    
+    elif variant in ['openj9', 'sap']:
+        # Implementation-specific: ProblemList_openjdk{version}-{impl}.txt
+        file_path = os.path.join(excludes_dir, f"ProblemList_openjdk{version}-{variant}.txt")
+    
+    elif variant == 'alpine':
+        # Alpine: alpine/ProblemList_openjdk{version}.txt
+        file_path = os.path.join(excludes_dir, "alpine", f"ProblemList_openjdk{version}.txt")
+    
+    else:
+        # Vendor-specific: vendors/{vendor}/ProblemList_openjdk{version}.txt
+        file_path = os.path.join(excludes_dir, "vendors", variant, f"ProblemList_openjdk{version}.txt")
+    
+    # Validate file exists
+    if not os.path.isfile(file_path):
+        raise ExcludeCommandError(
+            f"ProblemList file not found for target '{target}': {file_path}"
+        )
+    
+    return file_path
+
+
+def check_exclusion_exists(file_path: str, testcase: str, platform: str) -> bool:
+    """
+    Check if an exclusion already exists in the ProblemList file.
+    
+    Args:
+        file_path: Path to the ProblemList file
+        testcase: Test case name
+        platform: Platform specification
+        
+    Returns:
+        True if exclusion already exists, False otherwise
+    """
+    with open(file_path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            
+            parts = line.split()
+            if len(parts) >= 3:
+                existing_testcase = parts[0]
+                existing_platform = parts[2]
+                
+                if existing_testcase == testcase and existing_platform == platform:
+                    return True
+    
+    return False
+
+
+def add_exclusion_to_file(file_path: str, testcase: str, issue_url: str, platform: str) -> bool:
+    """
+    Add an exclusion entry to a ProblemList file.
+    
+    Args:
+        file_path: Path to the ProblemList file
+        testcase: Test case name
+        issue_url: Issue tracker URL
+        platform: Platform specification
+        
+    Returns:
+        True if exclusion was added, False if it already existed
+    """
+    # Check if exclusion already exists
+    if check_exclusion_exists(file_path, testcase, platform):
+        print(f"  ⚠️  Exclusion already exists in {os.path.basename(file_path)}")
+        return False
+    
+    # Read the file to find the right place to insert
+    with open(file_path, 'r') as f:
+        lines = f.readlines()
+    
+    # Add the exclusion at the end of the file
+    exclusion_line = f"{testcase} {issue_url} {platform}\n"
+    
+    # Ensure file ends with newline before adding
+    if lines and not lines[-1].endswith('\n'):
+        lines[-1] += '\n'
+    
+    lines.append(exclusion_line)
+    
+    # Write back to file
+    with open(file_path, 'w') as f:
+        f.writelines(lines)
+    
+    print(f"  ✅ Added exclusion to {os.path.basename(file_path)}")
+    return True
+
+
+def process_exclude_command(comment_body: str, workspace_dir: str) -> Dict[str, Any]:
+    """
+    Process /exclude command and modify ProblemList files.
+    
+    Args:
+        comment_body: The full comment body containing the /exclude command
+        workspace_dir: Base directory of the workspace
+        
+    Returns:
+        Dictionary with processing results
+        
+    Raises:
+        ExcludeCommandError: If command processing fails
+    """
+    # Parse the command
+    targets, testcases, issue_urls, platforms = parse_exclude_command(comment_body)
+    
+    print(f"Processing /exclude command:")
+    print(f"  Targets: {', '.join(targets)}")
+    print(f"  Test cases: {', '.join(testcases)}")
+    print(f"  Issue URLs: {issue_urls}")
+    print(f"  Platforms: {platforms}")
+    print()
+    
+    # Process each target
+    modified_files = []
+    skipped_files = []
+    total_exclusions_added = 0
+    total_exclusions_skipped = 0
+    
+    for target in targets:
+        try:
+            file_path = resolve_target_to_file(target, workspace_dir)
+            print(f"Target '{target}' → {os.path.relpath(file_path, workspace_dir)}")
+            
+            # Add each testcase as a separate line
+            target_added = 0
+            target_skipped = 0
+            
+            for testcase in testcases:
+                was_added = add_exclusion_to_file(file_path, testcase, issue_urls, platforms)
+                
+                if was_added:
+                    target_added += 1
+                    total_exclusions_added += 1
+                else:
+                    target_skipped += 1
+                    total_exclusions_skipped += 1
+            
+            if target_added > 0:
+                modified_files.append({
+                    'target': target,
+                    'file_path': os.path.relpath(file_path, workspace_dir),
+                    'exclusions_added': target_added,
+                    'exclusions_skipped': target_skipped
+                })
+            else:
+                skipped_files.append({
+                    'target': target,
+                    'file_path': os.path.relpath(file_path, workspace_dir),
+                    'exclusions_skipped': target_skipped
+                })
+        
+        except ExcludeCommandError as e:
+            print(f"  ❌ Error: {e}")
+            raise
+    
+    print()
+    print(f"Summary:")
+    print(f"  Modified: {len(modified_files)} file(s)")
+    print(f"  Total exclusions added: {total_exclusions_added}")
+    print(f"  Total exclusions skipped: {total_exclusions_skipped} (already excluded)")
+    
+    if not modified_files and not skipped_files:
+        raise ExcludeCommandError("No files were processed")
+    
+    return {
+        'targets': targets,
+        'testcases': testcases,
+        'issue_urls': issue_urls,
+        'platforms': platforms,
+        'modified_files': modified_files,
+        'skipped_files': skipped_files,
+        'total_exclusions_added': total_exclusions_added,
+        'total_exclusions_skipped': total_exclusions_skipped
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Add OpenJDK test exclusions to ProblemList files"
+    )
+    parser.add_argument(
+        '-m', '--message',
+        required=True,
+        help='Comment body containing /exclude command'
+    )
+    parser.add_argument(
+        '-c', '--comment-url',
+        required=True,
+        help='URL of the comment that triggered this action'
+    )
+    parser.add_argument(
+        '-d', '--directory',
+        required=True,
+        help='Base directory of the aqa-tests workspace'
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        # Process the exclude command
+        result = process_exclude_command(args.message, args.directory)
+        
+        # Exit successfully
+        sys.exit(0)
+    
+    except ExcludeCommandError as e:
+        print(f"\n❌ Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()
+
+# Made with Bob

--- a/scripts/disabled_tests/tests/test_exclude_openjdk.py
+++ b/scripts/disabled_tests/tests/test_exclude_openjdk.py
@@ -1,0 +1,312 @@
+import os
+import tempfile
+import shutil
+from unittest import TestCase
+from unittest.mock import patch
+
+from exclude_openjdk import (
+    parse_exclude_command,
+    parse_optional_params,
+    resolve_targets_from_params,
+    get_all_jdk_versions,
+    check_exclusion_exists,
+    add_exclusion_to_file,
+    ExcludeCommandError,
+)
+
+
+class TestParseOptionalParams(TestCase):
+    """Test parsing of optional parameters from command."""
+    
+    def test_parse_single_param(self):
+        result = parse_optional_params("jdk=11")
+        self.assertEqual(result, {'jdk': '11'})
+    
+    def test_parse_multiple_params(self):
+        result = parse_optional_params("jdk=11,17,21 impl=openj9")
+        self.assertEqual(result, {'jdk': '11,17,21', 'impl': 'openj9'})
+    
+    def test_parse_all_params(self):
+        result = parse_optional_params("jdk=11 impl=openj9 variant=alpine")
+        self.assertEqual(result, {
+            'jdk': '11',
+            'impl': 'openj9',
+            'variant': 'alpine'
+        })
+    
+    def test_parse_empty_string(self):
+        result = parse_optional_params("")
+        self.assertEqual(result, {})
+    
+    def test_parse_with_extra_spaces(self):
+        result = parse_optional_params("  jdk=11   impl=openj9  ")
+        self.assertEqual(result, {'jdk': '11', 'impl': 'openj9'})
+
+
+class TestParseExcludeCommand(TestCase):
+    """Test parsing of /exclude command."""
+    
+    def test_simple_command(self):
+        comment = "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all"
+        testcases, issue_url, platform, params = parse_exclude_command(comment)
+        
+        self.assertEqual(testcases, ['test.java'])
+        self.assertEqual(issue_url, 'https://bugs.openjdk.java.net/browse/JDK-8173082')
+        self.assertEqual(platform, 'macosx-all')
+        self.assertEqual(params, {})
+    
+    def test_command_with_jdk_param(self):
+        comment = "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all jdk=11,17,21"
+        testcases, issue_url, platform, params = parse_exclude_command(comment)
+        
+        self.assertEqual(testcases, ['test.java'])
+        self.assertEqual(platform, 'macosx-all')
+        self.assertEqual(params, {'jdk': '11,17,21'})
+    
+    def test_command_with_impl_param(self):
+        comment = "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 linux-x64 jdk=11,21 impl=openj9"
+        testcases, issue_url, platform, params = parse_exclude_command(comment)
+        
+        self.assertEqual(platform, 'linux-x64')
+        self.assertEqual(params, {'jdk': '11,21', 'impl': 'openj9'})
+    
+    def test_command_with_variant_param(self):
+        comment = "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 linux-x64 jdk=11 variant=alpine"
+        testcases, issue_url, platform, params = parse_exclude_command(comment)
+        
+        self.assertEqual(params, {'jdk': '11', 'variant': 'alpine'})
+    
+    def test_command_with_multiple_testcases(self):
+        comment = "/exclude test1.java,test2.java,test3.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all"
+        testcases, issue_url, platform, params = parse_exclude_command(comment)
+        
+        self.assertEqual(testcases, ['test1.java', 'test2.java', 'test3.java'])
+    
+    def test_command_with_platform_containing_comma(self):
+        comment = "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 linux-x64,windows-x64"
+        testcases, issue_url, platform, params = parse_exclude_command(comment)
+        
+        self.assertEqual(platform, 'linux-x64,windows-x64')
+    
+    def test_command_in_multiline_comment(self):
+        comment = """
+Some text before
+/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all jdk=11
+Some text after
+"""
+        testcases, issue_url, platform, params = parse_exclude_command(comment)
+        
+        self.assertEqual(testcases, ['test.java'])
+        self.assertEqual(params, {'jdk': '11'})
+    
+    def test_invalid_command_missing_parts(self):
+        comment = "/exclude test.java https://bugs.openjdk.java.net/browse/JDK-8173082"
+        
+        with self.assertRaises(ExcludeCommandError) as cm:
+            parse_exclude_command(comment)
+        
+        self.assertIn("Invalid format", str(cm.exception))
+    
+    def test_invalid_command_no_exclude(self):
+        comment = "some other comment"
+        
+        with self.assertRaises(ExcludeCommandError) as cm:
+            parse_exclude_command(comment)
+        
+        self.assertIn("No /exclude command found", str(cm.exception))
+
+
+class TestGetAllJdkVersions(TestCase):
+    """Test getting default JDK versions."""
+    
+    def setUp(self):
+        # Create temporary directory structure
+        self.temp_dir = tempfile.mkdtemp()
+        self.excludes_dir = os.path.join(self.temp_dir, "openjdk", "excludes")
+        os.makedirs(self.excludes_dir)
+        
+        # Create some ProblemList files
+        for version in ['8', '11', '17', '21', '25', '26']:
+            file_path = os.path.join(self.excludes_dir, f"ProblemList_openjdk{version}.txt")
+            with open(file_path, 'w') as f:
+                f.write("# Test file\n")
+    
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+    
+    def test_get_all_jdk_versions(self):
+        versions = get_all_jdk_versions(self.excludes_dir)
+        
+        # Should return LTS + latest that exist
+        self.assertEqual(versions, ['8', '11', '17', '21', '25', '26'])
+    
+    def test_get_all_jdk_versions_missing_some(self):
+        # Remove version 25
+        os.remove(os.path.join(self.excludes_dir, "ProblemList_openjdk25.txt"))
+        
+        versions = get_all_jdk_versions(self.excludes_dir)
+        
+        # Should only return versions that exist
+        self.assertEqual(versions, ['8', '11', '17', '21', '26'])
+    
+    def test_get_all_jdk_versions_nonexistent_dir(self):
+        versions = get_all_jdk_versions("/nonexistent/path")
+        
+        self.assertEqual(versions, [])
+
+
+class TestResolveTargetsFromParams(TestCase):
+    """Test resolving target files from parameters."""
+    
+    def setUp(self):
+        # Create temporary directory structure
+        self.temp_dir = tempfile.mkdtemp()
+        self.excludes_dir = os.path.join(self.temp_dir, "openjdk", "excludes")
+        os.makedirs(self.excludes_dir)
+        
+        # Create base ProblemList files
+        for version in ['8', '11', '17', '21']:
+            file_path = os.path.join(self.excludes_dir, f"ProblemList_openjdk{version}.txt")
+            with open(file_path, 'w') as f:
+                f.write("# Test file\n")
+        
+        # Create openj9 files
+        for version in ['11', '21']:
+            file_path = os.path.join(self.excludes_dir, f"ProblemList_openjdk{version}-openj9.txt")
+            with open(file_path, 'w') as f:
+                f.write("# Test file\n")
+        
+        # Create alpine directory and files
+        alpine_dir = os.path.join(self.excludes_dir, "alpine")
+        os.makedirs(alpine_dir)
+        file_path = os.path.join(alpine_dir, "ProblemList_openjdk11.txt")
+        with open(file_path, 'w') as f:
+            f.write("# Test file\n")
+        
+        # Create vendor directory and files
+        vendor_dir = os.path.join(self.excludes_dir, "vendors", "eclipse")
+        os.makedirs(vendor_dir)
+        file_path = os.path.join(vendor_dir, "ProblemList_openjdk11.txt")
+        with open(file_path, 'w') as f:
+            f.write("# Test file\n")
+    
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+    
+    def test_resolve_specific_jdk_versions(self):
+        params = {'jdk': '11,17,21'}
+        targets = resolve_targets_from_params(params, self.temp_dir)
+        
+        self.assertEqual(len(targets), 3)
+        self.assertEqual([desc for desc, _ in targets], ['jdk11', 'jdk17', 'jdk21'])
+    
+    def test_resolve_with_impl(self):
+        params = {'jdk': '11,21', 'impl': 'openj9'}
+        targets = resolve_targets_from_params(params, self.temp_dir)
+        
+        self.assertEqual(len(targets), 2)
+        self.assertEqual([desc for desc, _ in targets], ['jdk11-openj9', 'jdk21-openj9'])
+    
+    def test_resolve_with_alpine_variant(self):
+        params = {'jdk': '11', 'variant': 'alpine'}
+        targets = resolve_targets_from_params(params, self.temp_dir)
+        
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0][0], 'jdk11-alpine')
+        self.assertIn('alpine', targets[0][1])
+    
+    def test_resolve_with_vendor_variant(self):
+        params = {'jdk': '11', 'variant': 'eclipse'}
+        targets = resolve_targets_from_params(params, self.temp_dir)
+        
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0][0], 'jdk11-eclipse')
+        self.assertIn('vendors/eclipse', targets[0][1])
+    
+    def test_resolve_nonexistent_file(self):
+        params = {'jdk': '99'}
+        
+        with self.assertRaises(ExcludeCommandError) as cm:
+            resolve_targets_from_params(params, self.temp_dir)
+        
+        self.assertIn("not found", str(cm.exception))
+
+
+class TestCheckExclusionExists(TestCase):
+    """Test checking if exclusion already exists."""
+    
+    def setUp(self):
+        self.temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt')
+        self.temp_file.write("""# Test ProblemList file
+test1.java https://bugs.openjdk.java.net/browse/JDK-1234 macosx-all
+test2.java https://bugs.openjdk.java.net/browse/JDK-5678 linux-x64
+# Comment line
+test3.java https://bugs.openjdk.java.net/browse/JDK-9012 windows-x64
+""")
+        self.temp_file.close()
+    
+    def tearDown(self):
+        os.unlink(self.temp_file.name)
+    
+    def test_exclusion_exists(self):
+        result = check_exclusion_exists(self.temp_file.name, 'test1.java', 'macosx-all')
+        self.assertTrue(result)
+    
+    def test_exclusion_not_exists(self):
+        result = check_exclusion_exists(self.temp_file.name, 'test4.java', 'macosx-all')
+        self.assertFalse(result)
+    
+    def test_exclusion_different_platform(self):
+        result = check_exclusion_exists(self.temp_file.name, 'test1.java', 'linux-x64')
+        self.assertFalse(result)
+
+
+class TestAddExclusionToFile(TestCase):
+    """Test adding exclusion to file."""
+    
+    def setUp(self):
+        self.temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt')
+        self.temp_file.write("""# Test ProblemList file
+test1.java https://bugs.openjdk.java.net/browse/JDK-1234 macosx-all
+""")
+        self.temp_file.close()
+    
+    def tearDown(self):
+        os.unlink(self.temp_file.name)
+    
+    def test_add_new_exclusion(self):
+        result = add_exclusion_to_file(
+            self.temp_file.name,
+            'test2.java',
+            'https://bugs.openjdk.java.net/browse/JDK-5678',
+            'linux-x64'
+        )
+        
+        self.assertTrue(result)
+        
+        # Verify it was added
+        with open(self.temp_file.name, 'r') as f:
+            content = f.read()
+        
+        self.assertIn('test2.java https://bugs.openjdk.java.net/browse/JDK-5678 linux-x64', content)
+    
+    def test_add_duplicate_exclusion(self):
+        # Try to add existing exclusion
+        result = add_exclusion_to_file(
+            self.temp_file.name,
+            'test1.java',
+            'https://bugs.openjdk.java.net/browse/JDK-1234',
+            'macosx-all'
+        )
+        
+        self.assertFalse(result)
+        
+        # Verify file wasn't modified
+        with open(self.temp_file.name, 'r') as f:
+            lines = f.readlines()
+        
+        # Should still have only 2 lines (comment + original exclusion)
+        non_empty_lines = [l for l in lines if l.strip() and not l.strip().startswith('#')]
+        self.assertEqual(len(non_empty_lines), 1)
+
+# Made with Bob

--- a/scripts/disabled_tests/tests/test_exclude_openjdk.py
+++ b/scripts/disabled_tests/tests/test_exclude_openjdk.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 import shutil
 from unittest import TestCase
-from unittest.mock import patch
 
 from exclude_openjdk import (
     parse_exclude_command,


### PR DESCRIPTION
close #7110 

- Add new exclude-openjdk-test job to autoTestPR.yml workflow
- Create exclude_openjdk.py script to handle /exclude commands
- Support comma-separated variant (jdk=11,17)
- Support comma-separated test cases (test1.java,test2.java)
- Support multiple ProblemList file locations:
  * Root: openjdk/excludes/ProblemList_openjdk{version}[-{impl}].txt
  * Alpine: openjdk/excludes/alpine/ProblemList_openjdk{version}.txt
  * Vendors: openjdk/excludes/vendors/{vendor}/ProblemList_openjdk{version}.txt
- Automatically create PR with exclusions
- Add duplicate detection and validation
- Streamlines test triage for nightly/weekly/dry-run/release testing

Assisted-by: IBM Bob