### PR TITLE
openjdk: add vmTestbase_nsk_jdwp target

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -957,6 +957,32 @@
 		</impls>
 	</test>
 	<test>
+		<testCaseName>hotspot_vmTestbase_nsk_jdwp</testCaseName>
+		<command>$(JAVA_COMMAND) -Xmx512m $(APPLICATION_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)jtreg$(D)lib$(D)jtreg.jar$(Q) \
+	$(JTREG_BASIC_OPTIONS) $(JVM_NATIVE_OPTIONS) -vmoptions:$(Q)-Xmx512m $(JVM_OPTIONS) $(VMOPTION_HEADLESS)$(Q) \
+	-w $(Q)$(REPORTDIR)$(D)work$(Q) \
+	-r $(Q)$(REPORTDIR)$(D)report$(Q) \
+	-jdk:$(Q)$(TEST_JDK_HOME)$(Q) \
+	-exclude:$(Q)$(JTREG_HOTSPOT_TEST_DIR)$(D)ProblemList.txt$(Q) \
+	-exclude:$(Q)$(TEST_RESROOT)$(D)$(PROBLEM_LIST_FILE)$(Q) \
+	${FEATURE_PROBLEM_LIST_FILE} \
+	${VENDOR_PROBLEM_LIST_FILE} \
+	$(Q)$(JTREG_HOTSPOT_TEST_DIR):vmTestbase_nsk_jdwp$(Q); \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>openjdk</group>
+		</groups>
+		<impls>
+			<impl>hotspot</impl>
+		</impls>
+	</test>
+	<test>
 		<testCaseName>jdk_awt</testCaseName>
 		<disables>
 			<disable>


### PR DESCRIPTION
Adds hotspot [vmTestbase_nsk_jdwp](https://github.com/openjdk/jdk11u-dev/blob/168024359375be044ec76c6c7a0781ddec1db689/test/hotspot/jtreg/TEST.groups#L467) target to openjdk tests.
Its part of [effort](https://github.com/adoptium/aqa-tests/issues/6767) to add VM Testbase tests to aqa.

**Testing:**
**jdk11:** [RESULTS](https://ci.adoptium.net/job/Grinder/17264/)
- x86-64_linux, aarch64_linux, s390x_linux, x86-64_windows, x86-64_mac, x86-64_alpine-linux: **OK**

**jdk17:** [RESULTS](https://ci.adoptium.net/job/Grinder/17271/)
- x86-64_linux, x86-64_windows, x86-64_mac: **OK**

**jdk21:** [RESULTS](https://ci.adoptium.net/job/Grinder/17280/)
- x86-64_linux, aarch64_linux, x86-64_windows, x86-64_mac: **OK**
 ([x86-64_mac job](https://ci.adoptium.net/job/Grinder/17284/) shows as failure, but actually all tests passed. Infra issue?)

**jdk25:** [RESULTS](https://ci.adoptium.net/job/Grinder/17285/)
- x86-64_linux, aarch64_linux, x86-64_mac, x86-64_windows, s390x_linux, riscv64_linux: **OK**