### PR TITLE
Consolidate boilerplate build.xml files into shared templates

### DIFF
--- a/external/aot/build.properties
+++ b/external/aot/build.properties
@@ -1,0 +1,2 @@
+do.prepare=true
+do.build_image=false

--- a/external/aot/build.xml
+++ b/external/aot/build.xml
@@ -1,36 +1,4 @@
 <?xml version="1.0"?>
-<project name="aot" default="build" basedir=".">
-	<description>
-		Build aot Test
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="aot" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="prepare_base_image" depends="move_scripts,clean_image" description="prepare the base image">
-		<echo message="Executing external.sh --prepare --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} --base_docker_registry_url 'icr.io' --base_docker_registry_dir 'default' --docker_args ${extra_docker_args} " />
-		<exec executable="bash" failonerror="true">
-			<arg value="${DEST_EXTERNAL}/external.sh"/>
-			<arg value="--prepare"/>
-			<arg value="--dir"/>
-			<arg value="${TEST}"/>
-			<arg value="--tag"/>
-			<arg value="${dockerImageTag}"/>
-			<arg value="--version"/>
-			<arg value="${JDK_VERSION}"/>
-			<arg value="--impl"/>
-			<arg value="${JDK_IMPL}"/>
-			<arg value="--base_docker_registry_url"/>
-			<arg value="icr.io"/>
-			<arg value="--base_docker_registry_dir"/>
-			<arg value="default"/>
-			<arg value="--docker_args"/>
-			<arg value="${extra_docker_args}"/>
-		</exec>
-	</target>
-
-	<target name="build" depends="prepare_base_image, copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/build.xml
+++ b/external/build.xml
@@ -19,19 +19,7 @@
 		Build external tests
 	</description>
 
-	<!-- set properties for this build -->
-	<property name="DEST_EXTERNAL" value="${BUILD_ROOT}/external" />
-	<property environment="env" />
-	<property name="top" location="../" />
-
-	<set-property name="DOCKERIMAGE_TAG_ISSET" if-property-isset="env.DOCKERIMAGE_TAG"/>
-	<set-property name="EXTRA_DOCKER_ARGS_ISSET" if-property-isset="env.EXTRA_DOCKER_ARGS"/>
-	<condition property="dockerImageTag" value="${env.DOCKERIMAGE_TAG}" else="nightly">
-		<isset property="DOCKERIMAGE_TAG_ISSET"/>
-	</condition>
-	<condition property="extra_docker_args" value="${env.EXTRA_DOCKER_ARGS}" else="">
-		<isset property="EXTRA_DOCKER_ARGS_ISSET"/>
-	</condition>
+	<import file="external-targets.xml" />
 
 	<target name="init">
 		<mkdir dir="${DEST_EXTERNAL}" />
@@ -52,61 +40,8 @@
 
 	<target name="docker_prune" description="Remove all unused images from the machine before running new builds">
 		<exec executable="bash">
-            <arg value="${DEST_EXTERNAL}/external.sh"/>
+			<arg value="${DEST_EXTERNAL}/external.sh"/>
 			<arg value="--prune"/>
 		</exec>
-	</target>
-
-	<target name="clean_image"  description="clean test docker image if there is one">
-		<echo message="Executing external.sh --clean --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} " />
-		<exec executable="bash">
-			<arg value="${DEST_EXTERNAL}/external.sh"/>
-			<arg value="--clean"/>
-			<arg value="--dir"/>
-			<arg value="${TEST}"/>
-			<arg value="--tag"/>
-			<arg value="${dockerImageTag}"/>
-			<arg value="--version"/>
-			<arg value="${JDK_VERSION}"/>
-			<arg value="--impl"/>
-			<arg value="${JDK_IMPL}"/>
-		</exec>
-	</target>
-
-	<target name="move_scripts" description="move shell scripts to working directory">
-		<copy todir="${DEST_EXTERNAL}/${TEST}">
-			<fileset dir="${src}/" includes="*.sh, *.properties"/>
-		</copy>
-		<copy todir="${DEST_EXTERNAL}">
-			<fileset dir="${top}" includes="*.sh common.properties"/>
-		</copy>
-	</target>
-
-	<target name="build_image" description="build test dockerfile">
-		<echo message="Executing external.sh --build --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} --platform ${env.SPEC} --docker_args ${extra_docker_args} " />
-		<exec executable="bash" failonerror="true">
-			<arg value="${DEST_EXTERNAL}/external.sh"/>
-			<arg value="--build"/>
-			<arg value="--dir"/>
-			<arg value="${TEST}"/>
-			<arg value="--tag"/>
-			<arg value="${dockerImageTag}"/>
-			<arg value="--version"/>
-			<arg value="${JDK_VERSION}"/>
-			<arg value="--impl"/>
-			<arg value="${JDK_IMPL}"/>
-			<arg value="--platform"/>
-			<arg value="${env.SPEC}"/>
-			<arg value="--docker_args"/>
-			<arg value="${extra_docker_args}"/>
-		</exec>
-	</target>
-	<target name="copy_dest" >
-		<copy todir="${DEST}">
-			<fileset dir="${src}" includes="*.xml, *.mk, *.sh"/>
-		</copy>
-		<copy todir="${src}">
-			<fileset dir="${DEST}" includes="**/Dockerfile.*"/>
-		</copy>
 	</target>
 </project>

--- a/external/camel/build.xml
+++ b/external/camel/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Camel-Test" default="build" basedir=".">
-	<description>
-		Build camel-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="camel" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/criu-functional/build.properties
+++ b/external/criu-functional/build.properties
@@ -1,0 +1,1 @@
+do.prepare=true

--- a/external/criu-functional/build.xml
+++ b/external/criu-functional/build.xml
@@ -1,36 +1,4 @@
 <?xml version="1.0"?>
-<project name="criu-functional" default="build" basedir=".">
-	<description>
-		Build criu-functional Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="criu-functional" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="prepare_base_image" depends="move_scripts,clean_image" description="prepare the base image">
-		<echo message="Executing external.sh --prepare --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} --base_docker_registry_url 'icr.io' --base_docker_registry_dir 'default' --docker_args ${extra_docker_args} " />
-		<exec executable="bash" failonerror="true">
-			<arg value="${DEST_EXTERNAL}/external.sh"/>
-			<arg value="--prepare"/>
-			<arg value="--dir"/>
-			<arg value="${TEST}"/>
-			<arg value="--tag"/>
-			<arg value="${dockerImageTag}"/>
-			<arg value="--version"/>
-			<arg value="${JDK_VERSION}"/>
-			<arg value="--impl"/>
-			<arg value="${JDK_IMPL}"/>
-			<arg value="--base_docker_registry_url"/>
-			<arg value="icr.io"/>
-			<arg value="--base_docker_registry_dir"/>
-			<arg value="default"/>
-			<arg value="--docker_args"/>
-			<arg value="${extra_docker_args}"/>
-		</exec>
-	</target>
-
-	<target name="build" depends="prepare_base_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/criu-portable-checkpoint/build.properties
+++ b/external/criu-portable-checkpoint/build.properties
@@ -1,0 +1,1 @@
+do.prepare=true

--- a/external/criu-portable-checkpoint/build.xml
+++ b/external/criu-portable-checkpoint/build.xml
@@ -1,36 +1,4 @@
 <?xml version="1.0"?>
-<project name="criu-portable-checkpoint" default="build" basedir=".">
-	<description>
-		Build criu-portable-checkpoint Test
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="criu-portable-checkpoint" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="prepare_base_image" depends="move_scripts,clean_image" description="prepare the base image">
-		<echo message="Executing external.sh --prepare --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} --base_docker_registry_url 'icr.io' --base_docker_registry_dir 'default' --docker_args ${extra_docker_args} " />
-		<exec executable="bash" failonerror="true">
-			<arg value="${DEST_EXTERNAL}/external.sh"/>
-			<arg value="--prepare"/>
-			<arg value="--dir"/>
-			<arg value="${TEST}"/>
-			<arg value="--tag"/>
-			<arg value="${dockerImageTag}"/>
-			<arg value="--version"/>
-			<arg value="${JDK_VERSION}"/>
-			<arg value="--impl"/>
-			<arg value="${JDK_IMPL}"/>
-			<arg value="--base_docker_registry_url"/>
-			<arg value="icr.io"/>
-			<arg value="--base_docker_registry_dir"/>
-			<arg value="default"/>
-			<arg value="--docker_args"/>
-			<arg value="${extra_docker_args}"/>
-		</exec>
-	</target>
-
-	<target name="build" depends="prepare_base_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/criu-portable-restore/build.properties
+++ b/external/criu-portable-restore/build.properties
@@ -1,0 +1,1 @@
+do.build_image=false

--- a/external/criu-portable-restore/build.xml
+++ b/external/criu-portable-restore/build.xml
@@ -1,15 +1,4 @@
 <?xml version="1.0"?>
-<project name="criu-portable-restore" default="build" basedir=".">
-	<description>
-		Build criu-portable-restore Test
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="criu-portable-restore" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,copy_dest" />
-
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/criu-ubi-portable-checkpoint/build.xml
+++ b/external/criu-ubi-portable-checkpoint/build.xml
@@ -3,7 +3,7 @@
 	<description>
 		Build criu-ubi-portable-checkpoint Test
 	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
+	<import file="${TEST_ROOT}/external/external-targets.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="TEST" value="criu-ubi-portable-checkpoint" />

--- a/external/criu-ubi-portable-restore/build.properties
+++ b/external/criu-ubi-portable-restore/build.properties
@@ -1,0 +1,1 @@
+do.build_image=false

--- a/external/criu-ubi-portable-restore/build.xml
+++ b/external/criu-ubi-portable-restore/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="criu-ubi-portable-restore" default="build" basedir=".">
-	<description>
-		Build criu-ubi-portable-restore Test
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="criu-ubi-portable-restore" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/criu/build.properties
+++ b/external/criu/build.properties
@@ -1,0 +1,3 @@
+do.move_scripts=false
+do.clean_image=false
+do.build_image=false

--- a/external/criu/build.xml
+++ b/external/criu/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="criu-portable-checkpoint" default="build" basedir=".">
-	<description>
-		CRIU PingPerf
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="criu" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/derby/build.properties
+++ b/external/derby/build.properties
@@ -1,0 +1,1 @@
+skip.impls=ibm,openj9

--- a/external/derby/build.xml
+++ b/external/derby/build.xml
@@ -1,30 +1,4 @@
 <?xml version="1.0"?>
-<project name="Derby-Test" default="build" basedir=".">
-	<description>
-		Build derby-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="derby" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<!-- Temporarily disable for openj9 and ibm due to ibm_git/runtimes/infrastructure/issues/6056 -->
-	<condition property="skip.build">
-		<or>
-			<equals arg1="${JDK_IMPL}" arg2="ibm" />
-			<equals arg1="${JDK_IMPL}" arg2="openj9" />
-		</or>
-	</condition>
-
-	<target name="init">
-		<mkdir dir="${DEST}"/>
-	</target>
-
-	<target name="dist" depends="move_scripts,clean_image,build_image,copy_dest" description="generate the distribution" />
-
-	<target name="build" unless="skip.build">
-		<antcall target="dist" inheritall="true" />
-	</target>
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/elasticsearch/build.xml
+++ b/external/elasticsearch/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Elasticsearch-Test" default="build" basedir=".">
-	<description>
-		Build elasticsearch-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="elasticsearch" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/external-targets.xml
+++ b/external/external-targets.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<!-- Shared target definitions for external tests. Imported by both the
+     parent orchestrator (external/build.xml) and child test build files. -->
+<project name="external-targets" xmlns:if="ant:if" xmlns:unless="ant:unless">
+
+	<property name="DEST_EXTERNAL" value="${BUILD_ROOT}/external" />
+	<property environment="env" />
+	<property name="top" location="../" />
+
+	<set-property name="DOCKERIMAGE_TAG_ISSET" if-property-isset="env.DOCKERIMAGE_TAG"/>
+	<set-property name="EXTRA_DOCKER_ARGS_ISSET" if-property-isset="env.EXTRA_DOCKER_ARGS"/>
+	<condition property="dockerImageTag" value="${env.DOCKERIMAGE_TAG}" else="nightly">
+		<isset property="DOCKERIMAGE_TAG_ISSET"/>
+	</condition>
+	<condition property="extra_docker_args" value="${env.EXTRA_DOCKER_ARGS}" else="">
+		<isset property="EXTRA_DOCKER_ARGS_ISSET"/>
+	</condition>
+
+	<target name="move_scripts" description="move shell scripts to working directory">
+		<copy todir="${DEST_EXTERNAL}/${TEST}">
+			<fileset dir="${src}/" includes="*.sh, *.properties"/>
+		</copy>
+		<copy todir="${DEST_EXTERNAL}">
+			<fileset dir="${top}" includes="*.sh common.properties"/>
+		</copy>
+	</target>
+
+	<target name="clean_image" description="clean test docker image if there is one">
+		<echo message="Executing external.sh --clean --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} " />
+		<exec executable="bash">
+			<arg value="${DEST_EXTERNAL}/external.sh"/>
+			<arg value="--clean"/>
+			<arg value="--dir"/>
+			<arg value="${TEST}"/>
+			<arg value="--tag"/>
+			<arg value="${dockerImageTag}"/>
+			<arg value="--version"/>
+			<arg value="${JDK_VERSION}"/>
+			<arg value="--impl"/>
+			<arg value="${JDK_IMPL}"/>
+		</exec>
+	</target>
+
+	<target name="build_image" description="build test dockerfile">
+		<echo message="Executing external.sh --build --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} --platform ${env.SPEC} --docker_args ${extra_docker_args} " />
+		<exec executable="bash" failonerror="true">
+			<arg value="${DEST_EXTERNAL}/external.sh"/>
+			<arg value="--build"/>
+			<arg value="--dir"/>
+			<arg value="${TEST}"/>
+			<arg value="--tag"/>
+			<arg value="${dockerImageTag}"/>
+			<arg value="--version"/>
+			<arg value="${JDK_VERSION}"/>
+			<arg value="--impl"/>
+			<arg value="${JDK_IMPL}"/>
+			<arg value="--platform"/>
+			<arg value="${env.SPEC}"/>
+			<arg value="--docker_args"/>
+			<arg value="${extra_docker_args}"/>
+		</exec>
+	</target>
+
+	<target name="prepare_base_image" description="prepare the base image">
+		<echo message="Executing external.sh --prepare --dir ${TEST} --tag ${dockerImageTag} --version ${JDK_VERSION} --impl ${JDK_IMPL} --base_docker_registry_url '${prepare.registry_url}' --base_docker_registry_dir '${prepare.registry_dir}' --docker_args ${extra_docker_args} " />
+		<exec executable="bash" failonerror="true">
+			<arg value="${DEST_EXTERNAL}/external.sh"/>
+			<arg value="--prepare"/>
+			<arg value="--dir"/>
+			<arg value="${TEST}"/>
+			<arg value="--tag"/>
+			<arg value="${dockerImageTag}"/>
+			<arg value="--version"/>
+			<arg value="${JDK_VERSION}"/>
+			<arg value="--impl"/>
+			<arg value="${JDK_IMPL}"/>
+			<arg value="--base_docker_registry_url"/>
+			<arg value="${prepare.registry_url}"/>
+			<arg value="--base_docker_registry_dir"/>
+			<arg value="${prepare.registry_dir}"/>
+			<arg value="--docker_args"/>
+			<arg value="${extra_docker_args}"/>
+		</exec>
+	</target>
+
+	<target name="copy_dest">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml, *.mk, *.sh"/>
+		</copy>
+		<copy todir="${src}">
+			<fileset dir="${DEST}" includes="**/Dockerfile.*"/>
+		</copy>
+	</target>
+</project>

--- a/external/external-test.xml
+++ b/external/external-test.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<!--
+  Generic build file for external test children.
+
+  Each child directory imports this file. The TEST name is auto-derived
+  from the child directory name. Behaviour is controlled via optional
+  build.properties in the child directory:
+
+    do.move_scripts  = true|false  (default true)
+    do.clean_image   = true|false  (default true)
+    do.build_image   = true|false  (default true)
+    do.prepare       = true|false  (default false)
+    prepare.registry_url = ...     (default icr.io)
+    prepare.registry_dir = ...     (default default)
+    skip.impls       = comma-separated list of JDK_IMPL values to skip
+
+  See README.md for the full list of options.
+-->
+<project name="external-test" default="build" basedir="." xmlns:if="ant:if" xmlns:unless="ant:unless">
+
+	<!-- Auto-derive TEST from the directory name -->
+	<basename property="TEST" file="${basedir}" />
+	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
+	<property name="src" location="." />
+
+	<!-- Load optional per-test configuration -->
+	<property file="build.properties" />
+
+	<!-- Import shared targets (move_scripts, clean_image, build_image, prepare_base_image, copy_dest) -->
+	<import file="${TEST_ROOT}/external/external-targets.xml" />
+
+	<!-- Pipeline step defaults -->
+	<property name="do.move_scripts" value="true" />
+	<property name="do.clean_image" value="true" />
+	<property name="do.build_image" value="true" />
+	<property name="do.prepare" value="false" />
+
+	<!-- Prepare defaults -->
+	<property name="prepare.registry_url" value="icr.io" />
+	<property name="prepare.registry_dir" value="default" />
+
+	<!-- Skip logic: set skip.build if JDK_IMPL matches any value in skip.impls -->
+	<condition property="skip.build">
+		<or>
+			<contains string=",${skip.impls}," substring=",${JDK_IMPL}," />
+		</or>
+	</condition>
+
+	<target name="pipeline" description="run the configurable build pipeline">
+		<antcall target="move_scripts" if:true="${do.move_scripts}" />
+		<antcall target="clean_image" if:true="${do.clean_image}" />
+		<antcall target="prepare_base_image" if:true="${do.prepare}" />
+		<antcall target="build_image" if:true="${do.build_image}" />
+		<antcall target="copy_dest" />
+	</target>
+
+	<target name="build" unless="skip.build">
+		<antcall target="pipeline" inheritall="true" />
+	</target>
+</project>

--- a/external/external_custom/build.xml
+++ b/external/external_custom/build.xml
@@ -3,7 +3,7 @@
 	<description>
 		Build external_custom Docker image
 	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
+	<import file="${TEST_ROOT}/external/external-targets.xml"/>
 
 	<!-- set properties for this build -->
 	<property name="TEST" value="external_custom" />

--- a/external/functional-test/build.xml
+++ b/external/functional-test/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="functional-test" default="build" basedir=".">
-	<description>
-		Build functional-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="functional-test" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/jacoco/build.xml
+++ b/external/jacoco/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Jacoco-Test" default="build" basedir=".">
-	<description>
-		Build jacoco-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="jacoco" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/jenkins/build.xml
+++ b/external/jenkins/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Jenkins-Test" default="build" basedir=".">
-	<description>
-		Build Jenkins test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="jenkins" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/kafka/build.xml
+++ b/external/kafka/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="kafka-test" default="build" basedir=".">
-	<description>
-		Build kafka test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="kafka" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/lucene-solr/build.properties
+++ b/external/lucene-solr/build.properties
@@ -1,0 +1,1 @@
+skip.impls=ibm,openj9

--- a/external/lucene-solr/build.xml
+++ b/external/lucene-solr/build.xml
@@ -1,26 +1,4 @@
 <?xml version="1.0"?>
-<project name="Lucene-solr-Test" default="build" basedir=".">
-	<description>
-		Build lucene-solr-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="lucene-solr" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<!-- Temporarily disable for openj9 and ibm due to ibm_git/runtimes/infrastructure/issues/6056 -->
-	<condition property="skip.build">
-		<or>
-			<equals arg1="${JDK_IMPL}" arg2="ibm" />
-			<equals arg1="${JDK_IMPL}" arg2="openj9" />
-		</or>
-	</condition>
-
-	<target name="dist" depends="move_scripts,clean_image,build_image,copy_dest" description="generate the distribution" />
-
-	<target name="build" unless="skip.build">
-		<antcall target="dist" inheritall="true" />
-	</target>
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/netty/build.xml
+++ b/external/netty/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Netty-Test" default="build" basedir=".">
-	<description>
-		Build Netty-Test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="netty" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/openliberty-mp-tck/build.properties
+++ b/external/openliberty-mp-tck/build.properties
@@ -1,0 +1,1 @@
+skip.impls=ibm,openj9

--- a/external/openliberty-mp-tck/build.xml
+++ b/external/openliberty-mp-tck/build.xml
@@ -1,30 +1,4 @@
 <?xml version="1.0"?>
-<project name="Openliberty-mp-tck-Test" default="build" basedir=".">
-	<description>
-		Build openliberty-mp-tck-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="openliberty-mp-tck" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<!-- Temporarily disable for openj9 and ibm due to ibm_git/runtimes/infrastructure/issues/6056 -->
-	<condition property="skip.build">
-		<or>
-			<equals arg1="${JDK_IMPL}" arg2="ibm" />
-			<equals arg1="${JDK_IMPL}" arg2="openj9" />
-		</or>
-	</condition>
-
-	<target name="init">
-		<mkdir dir="${DEST}"/>
-	</target>
-
-	<target name="dist" depends="move_scripts,clean_image,build_image,copy_dest" description="generate the distribution" />
-
-	<target name="build" unless="skip.build">
-		<antcall target="dist" inheritall="true" />
-	</target>
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/payara-mp-tck/build.xml
+++ b/external/payara-mp-tck/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Payara-mp-tck-Test" default="build" basedir=".">
-	<description>
-		Build payara-mp-tck-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="payara-mp-tck" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/quarkus/build.xml
+++ b/external/quarkus/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Quarkus-Test" default="build" basedir=".">
-	<description>
-		Build quarkus-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="quarkus" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/quarkus_openshift/build.properties
+++ b/external/quarkus_openshift/build.properties
@@ -1,0 +1,3 @@
+do.move_scripts=false
+do.clean_image=false
+do.build_image=false

--- a/external/quarkus_openshift/build.xml
+++ b/external/quarkus_openshift/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Quarkus-OpenShift-Test" default="build" basedir=".">
-	<description>
-		Build quarkus openshift test
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="quarkus_openshift" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/quarkus_quickstarts/build.xml
+++ b/external/quarkus_quickstarts/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Quarkus-Quickstarts-Test" default="build" basedir=".">
-	<description>
-		Build quarkus quickstarts test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="quarkus_quickstarts" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/scala/build.xml
+++ b/external/scala/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Scala-Test" default="build" basedir=".">
-	<description>
-		Build scala-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="scala" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/scc/build.properties
+++ b/external/scc/build.properties
@@ -1,0 +1,3 @@
+do.move_scripts=false
+do.clean_image=false
+do.build_image=false

--- a/external/scc/build.xml
+++ b/external/scc/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="portableSCC" default="build" basedir=".">
-	<description>
-		Build portableSCC Test
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="scc" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/spring/build.xml
+++ b/external/spring/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Spring-Test" default="build" basedir=".">
-	<description>
-		Build Spring-Test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="spring" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/system-test/build.xml
+++ b/external/system-test/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="System-Test" default="build" basedir=".">
-	<description>
-		Build system-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="system-test" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/tck-ubi-test/build.xml
+++ b/external/tck-ubi-test/build.xml
@@ -3,7 +3,7 @@
 	<description>
 		Build tck-ubi-test Docker image
 	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
+	<import file="${TEST_ROOT}/external/external-targets.xml"/>
 	<import file="${TEST_ROOT}/jck/build.xml"/>
 
 	<!-- set properties for this build -->

--- a/external/tomcat/build.properties
+++ b/external/tomcat/build.properties
@@ -1,0 +1,1 @@
+skip.impls=ibm,openj9

--- a/external/tomcat/build.xml
+++ b/external/tomcat/build.xml
@@ -1,26 +1,4 @@
 <?xml version="1.0"?>
-<project name="Tomcat-Test" default="build" basedir=".">
-	<description>
-		Build tomcat-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="tomcat" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<!-- Temporarily disable for openj9 and ibm due to ibm_git/runtimes/infrastructure/issues/6056 -->
-	<condition property="skip.build">
-		<or>
-			<equals arg1="${JDK_IMPL}" arg2="ibm" />
-			<equals arg1="${JDK_IMPL}" arg2="openj9" />
-		</or>
-	</condition>
-
-	<target name="dist" depends="move_scripts,clean_image,build_image,copy_dest" description="generate the distribution" />
-
-	<target name="build" unless="skip.build">
-		<antcall target="dist" inheritall="true" />
-	</target>
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/tomee/build.xml
+++ b/external/tomee/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Tomee-Test" default="build" basedir=".">
-	<description>
-		Build tomee-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="tomee" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/wildfly/build.xml
+++ b/external/wildfly/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Wildfly-Test" default="build" basedir=".">
-	<description>
-		Build wildfly-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="wildfly" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/wycheproof/build.xml
+++ b/external/wycheproof/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Wycheproof-Test" default="build" basedir=".">
-	<description>
-		Build wycheproof-test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="wycheproof" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/external/zookeeper/build.xml
+++ b/external/zookeeper/build.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0"?>
-<project name="Zookeeper-Test" default="build" basedir=".">
-	<description>
-		Build Zookeeper-Test Docker image
-	</description>
-	<import file="${TEST_ROOT}/external/build.xml"/>
-
-	<!-- set properties for this build -->
-	<property name="TEST" value="zookeeper" />
-	<property name="DEST" value="${BUILD_ROOT}/external/${TEST}" />
-	<property name="src" location="." />
-
-	<target name="build" depends="move_scripts,clean_image,build_image,copy_dest" />
+<project default="build" basedir=".">
+	<import file="${TEST_ROOT}/external/external-test.xml" />
 </project>

--- a/system/daaLoadTest/build.xml
+++ b/system/daaLoadTest/build.xml
@@ -14,20 +14,6 @@
 # limitations under the License.
 -->
 
-<project name="daaLoadTest" default="build" basedir=".">
-	<description>daaLoadTest</description>
-
-	<import file="../common.xml"/>
-
-	<property name="DEST" value="${BUILD_ROOT}/system/daaLoadTest" />
-
-	<target name="init">
-		<mkdir dir="${DEST}" />
-	</target>
-
-	<target name="build" depends="init, common_build">
-		<copy todir="${DEST}">
-			<fileset dir="." includes="*.mk,*.xml"/>
-		</copy>
-	</target>
+<project default="build" basedir=".">
+	<import file="../system-test.xml" />
 </project>

--- a/system/jlm/build.xml
+++ b/system/jlm/build.xml
@@ -14,20 +14,6 @@
 # limitations under the License.
 -->
 
-<project name="jlm" default="build" basedir=".">
-	<description>jlm</description>
-
-	<import file="../common.xml" />
-
-	<property name="DEST" value="${BUILD_ROOT}/system/jlm" />
-
-	<target name="init">
-		<mkdir dir="${DEST}" />
-	</target>
-
-	<target name="build" depends="init,common_build">
-		<copy todir="${DEST}">
-			<fileset dir="." includes="*.mk,*.xml" />
-		</copy>
-	</target>
+<project default="build" basedir=".">
+	<import file="../system-test.xml" />
 </project>

--- a/system/lambdaLoadTest/build.xml
+++ b/system/lambdaLoadTest/build.xml
@@ -14,20 +14,6 @@
 # limitations under the License.
 -->
 
-<project name="lambdaLoadTest" default="build" basedir=".">
-	<description>lambdaLoadTest</description>
-
-	<import file="../common.xml" />
-
-	<property name="DEST" value="${BUILD_ROOT}/system/lambdaLoadTest" />
-
-	<target name="init">
-		<mkdir dir="${DEST}" />
-	</target>
-
-	<target name="build" depends="init, common_build">
-		<copy todir="${DEST}">
-			<fileset dir="." includes="*.mk,*.xml" />
-		</copy>
-	</target>
+<project default="build" basedir=".">
+	<import file="../system-test.xml" />
 </project>

--- a/system/mathLoadTest/build.xml
+++ b/system/mathLoadTest/build.xml
@@ -14,20 +14,6 @@
 # limitations under the License.
 -->
 
-<project name="mathLoadTest" default="build" basedir=".">
-	<description>mathLoadTest</description>
-
-	<import file="../common.xml" />
-
-	<property name="DEST" value="${BUILD_ROOT}/system/mathLoadTest" />
-
-	<target name="init">
-		<mkdir dir="${DEST}" />
-	</target>
-
-	<target name="build" depends="init, common_build">
-		<copy todir="${DEST}">
-			<fileset dir="." includes="*.mk,*.xml" />
-		</copy>
-	</target>
+<project default="build" basedir=".">
+	<import file="../system-test.xml" />
 </project>

--- a/system/mauveLoadTest/build.xml
+++ b/system/mauveLoadTest/build.xml
@@ -14,20 +14,6 @@
 # limitations under the License.
 -->
 
-<project name="mauveLoadTest" default="build" basedir=".">
-	<description>mauveLoadTest</description>
-
-	<import file="../common.xml" />
-
-	<property name="DEST" value="${BUILD_ROOT}/system/mauveLoadTest" />
-
-	<target name="init">
-		<mkdir dir="${DEST}" />
-	</target>
-
-	<target name="build" depends="init, common_build">
-		<copy todir="${DEST}">
-			<fileset dir="." includes="*.mk,*.xml" />
-		</copy>
-	</target>
+<project default="build" basedir=".">
+	<import file="../system-test.xml" />
 </project>

--- a/system/modularity/build.xml
+++ b/system/modularity/build.xml
@@ -14,20 +14,6 @@
 # limitations under the License.
 -->
 
-<project name="modularity" default="build" basedir=".">
-	<description>modularity</description>
-
-	<import file="../common.xml" />
-
-	<property name="DEST" value="${BUILD_ROOT}/system/modularity" />
-
-	<target name="init">
-		<mkdir dir="${DEST}" />
-	</target>
-
-	<target name="build" depends="init, common_build">
-		<copy todir="${DEST}">
-			<fileset dir="." includes="*.mk,*.xml" />
-		</copy>
-	</target>
+<project default="build" basedir=".">
+	<import file="../system-test.xml" />
 </project>

--- a/system/otherLoadTest/build.xml
+++ b/system/otherLoadTest/build.xml
@@ -14,20 +14,6 @@
 # limitations under the License.
 -->
 
-<project name="otherLoadTest" default="build" basedir=".">
-	<description>otherLoadTest</description>
-
-	<import file="../common.xml" />
-
-	<property name="DEST" value="${BUILD_ROOT}/system/otherLoadTest" />
-
-	<target name="init">
-		<mkdir dir="${DEST}" />
-	</target>
-
-	<target name="build" depends="init, common_build">
-		<copy todir="${DEST}">
-			<fileset dir="." includes="*.mk,*.xml" />
-		</copy>
-	</target>
+<project default="build" basedir=".">
+	<import file="../system-test.xml" />
 </project>

--- a/system/security/build.xml
+++ b/system/security/build.xml
@@ -14,20 +14,6 @@
 # limitations under the License.
 -->
 
-<project name="security" default="build" basedir=".">
-	<description>security</description>
-
-	<import file="../common.xml" />
-
-	<property name="DEST" value="${BUILD_ROOT}/system/security" />
-
-	<target name="init">
-		<mkdir dir="${DEST}" />
-	</target>
-
-	<target name="build" depends="init, common_build">
-		<copy todir="${DEST}">
-			<fileset dir="." includes="*.mk,*.xml" />
-		</copy>
-	</target>
+<project default="build" basedir=".">
+	<import file="../system-test.xml" />
 </project>

--- a/system/sharedClasses/build.xml
+++ b/system/sharedClasses/build.xml
@@ -14,20 +14,6 @@
 # limitations under the License.
 -->
 
-<project name="sharedClasses" default="build" basedir=".">
-	<description>sharedClasses</description>
-
-	<import file="../common.xml" />
-
-	<property name="DEST" value="${BUILD_ROOT}/system/sharedClasses" />
-
-	<target name="init">
-		<mkdir dir="${DEST}" />
-	</target>
-
-	<target name="build" depends="init, common_build">
-		<copy todir="${DEST}">
-			<fileset dir="." includes="*.mk,*.xml" />
-		</copy>
-	</target>
+<project default="build" basedir=".">
+	<import file="../system-test.xml" />
 </project>

--- a/system/system-test.xml
+++ b/system/system-test.xml
@@ -20,8 +20,7 @@
   standard init/build targets that 9 of 11 system children share.
 -->
 <project name="system-test" default="build" basedir=".">
-
-	<import file="../common.xml"/>
+	<import file="${TEST_ROOT}/system/common.xml"/>
 
 	<!-- Auto-derive test name and DEST from directory -->
 	<basename property="SYSDIR" file="${basedir}" />

--- a/system/system-test.xml
+++ b/system/system-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+
+<!--
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<!--
+  Generic build file for system test children.
+  Auto-derives the test name from the directory and provides the
+  standard init/build targets that 9 of 11 system children share.
+-->
+<project name="system-test" default="build" basedir=".">
+
+	<import file="../common.xml"/>
+
+	<!-- Auto-derive test name and DEST from directory -->
+	<basename property="SYSDIR" file="${basedir}" />
+	<property name="DEST" value="${BUILD_ROOT}/system/${SYSDIR}" />
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+	</target>
+
+	<target name="build" depends="init, common_build">
+		<copy todir="${DEST}">
+			<fileset dir="." includes="*.mk,*.xml"/>
+		</copy>
+	</target>
+</project>


### PR DESCRIPTION
## Summary

Extracts duplicated Ant targets and build logic into shared template files, replacing 38 boilerplate `build.xml` files (29 external + 9 system) with minimal stubs that import a generic template.

This is a follow-up to #7116 (ant-contrib elimination) — now that we're using native Ant features, the remaining boilerplate becomes even more apparent.

## Changes

### external/
- **`external-targets.xml`** (new): Shared target definitions (`move_scripts`, `clean_image`, `build_image`, `prepare_base_image`, `copy_dest`) extracted from `build.xml`
- **`external-test.xml`** (new): Generic child template with auto-derived `TEST` name and configurable pipeline via `build.properties`
- **29 children** converted to 3-line stubs importing `external-test.xml`
- **12 `build.properties` files** for non-default pipeline behaviour (`skip.impls`, `do.prepare`, `do.build_image`, etc.)
- **3 custom tests** (criu-ubi-portable-checkpoint, external_custom, tck-ubi-test) updated to import `external-targets.xml` directly
- **`build.xml`** reduced to orchestrator-only (init, subant, dist, prune)

### system/
- **`system-test.xml`** (new): Generic child template with auto-derived DEST, `init` + `common_build` + copy pattern
- **9 identical children** converted to stubs importing `system-test.xml`
- `churn` and `jcstress` left unchanged (unique logic)

## How it works

Instead of each child duplicating the same XML targets, they now import a shared template. Non-default behaviour is declared in a simple `build.properties` file:

```properties
# Skip for certain JDK implementations
skip.impls=ibm,openj9

# Copy-only test (no Docker build)
do.move_scripts=false
do.clean_image=false
do.build_image=false

# Test that needs prepare step
do.prepare=true
```

## Impact
- **57 files changed**, net **-362 lines** of duplicated XML
- No functional changes — all targets produce identical behaviour
- Adding new external tests now requires only a stub `build.xml` (+ optional `build.properties`)