### PR TITLE
Add special handling for VENDOR_TEST_REPOS with compliance content

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -465,62 +465,6 @@ def createJob( TEST_JOB_NAME, ARCH_OS ) {
 	return create
 }
 
-def cloneComplianceScriptsRepo() {
-	try {
-		jenkins_home = "${env.WORKSPACE}/../../"
-        echo "cd ${jenkins_home}"
-
-        echo "*************************************************************************"
-        echo "* Extracting jck_run to ${jenkins_home} on node: ${NODE_NAME}"
-        echo "*************************************************************************"
-
-        //checkout([$class: 'GitSCM', branches: [[name: "${COMPLIANCE_SCRIPTS_BRANCH}"]],
-        //    userRemoteConfigs: [[url: "${COMPLIANCE_SCRIPTS_REPO}",
-        //    credentialsId: "${params.USER_CREDENTIALS_ID}"]]
-        //])
-
-		// Compliance repo was cloned as part of VENDOR_TEST_REPO preparation
-		// Move it to the jck_run folder
-
-        echo "Cleaning ${jenkins_home}/jck_run/arctic folder prior to extract"
-		sh "rm -rf ${jenkins_home}/jck_run/arctic"
-
-        def statusCode=sh(script:"cp -r jck_run ${jenkins_home} 2>&1", returnStatus:true)
-        echo "returnCode = ${statusCode}"
-        if (statusCode != 0) {
-            result = "FAILURE"
-        } else {
-            sh "chgrp jck ${jenkins_home}/jck_run"
-            sh "chmod g+s ${jenkins_home}/jck_run"
-        }
-
-        echo "*************************************************************************"
-
-    } catch (Exception e) {
-        context.println "Failed to extract on node ${label} : ${e.message}"
-    }
-
-    // Reorganize scripts dir
-    echo "Move ./scripts folder to jck_run"
-    def statusCode=sh(script:"cp -r ./scripts ${jenkins_home}/jck_run 2>&1", returnStatus:true)
-    echo "cp returnCode = ${statusCode}"
-    if (statusCode != 0) {
-        result = "FAILURE"
-    }
-
-    // Set permissions
-    statusCode=sh(script:"chgrp -R jck ${jenkins_home}/jck_run 2>&1", returnStatus:true)
-    echo "chgrp returnCode = ${statusCode}"
-    if (statusCode != 0) {
-        result = "FAILURE"
-    }
-    statusCode=sh(script:"chmod -R 775 ${jenkins_home}/jck_run 2>&1", returnStatus:true)
-    echo "chmod returnCode = ${statusCode}"
-    if (statusCode != 0) {
-        result = "FAILURE"
-    }
-}
-
 def setup() {
 	stage('Setup') {
 		setupEnv()
@@ -638,7 +582,8 @@ def setup() {
 		ADDITIONAL_ARTIFACTS_REQUIRED_OPTION = (params.ADDITIONAL_ARTIFACTS_REQUIRED) ? "--additional_artifacts_required ${params.ADDITIONAL_ARTIFACTS_REQUIRED}" : ""
 
 		CURL_OPTS = (params.CURL_OPTS) ? "--curl_opts \"${params.CURL_OPTS}\"" : ""
-		GET_SH_CMD = "./get.sh -s `pwd`/.. -p $PLATFORM -r ${SDK_RESOURCE} ${JDK_VERSION_OPTION} ${JDK_IMPL_OPTION} ${CUSTOMIZED_SDK_URL_OPTION} ${CLONE_OPENJ9_OPTION} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${TKG_REPO_OPTION} ${TKG_BRANCH_OPTION} ${VENDOR_TEST_REPOS} ${VENDOR_TEST_BRANCHES} ${VENDOR_TEST_DIRS} ${VENDOR_TEST_SHAS} ${TEST_IMAGES_REQUIRED} ${DEBUG_IMAGES_REQUIRED} ${CODE_COVERAGE_OPTION} ${CURL_OPTS} ${ADDITIONAL_ARTIFACTS_REQUIRED_OPTION}"
+		SETUP_JCK_RUN_OPTION = (params.SETUP_JCK_RUN) ? "--setup_jck_run true" : ""
+		GET_SH_CMD = "./get.sh -s `pwd`/.. -p $PLATFORM -r ${SDK_RESOURCE} ${JDK_VERSION_OPTION} ${JDK_IMPL_OPTION} ${CUSTOMIZED_SDK_URL_OPTION} ${CLONE_OPENJ9_OPTION} ${OPENJ9_REPO_OPTION} ${OPENJ9_BRANCH_OPTION} ${OPENJ9_SHA_OPTION} ${TKG_REPO_OPTION} ${TKG_BRANCH_OPTION} ${VENDOR_TEST_REPOS} ${VENDOR_TEST_BRANCHES} ${VENDOR_TEST_DIRS} ${VENDOR_TEST_SHAS} ${TEST_IMAGES_REQUIRED} ${DEBUG_IMAGES_REQUIRED} ${CODE_COVERAGE_OPTION} ${CURL_OPTS} ${ADDITIONAL_ARTIFACTS_REQUIRED_OPTION} ${SETUP_JCK_RUN_OPTION}"
 		RESOLVED_MAKE = "if [ `uname` = AIX ] || [ `uname` = SunOS ] || [ `uname` = *BSD ]; then MAKE=gmake; else MAKE=make; fi"
 		dir( WORKSPACE) {
 			// use sshagent with Jenkins credentials ID for all platforms except zOS
@@ -733,10 +678,6 @@ def get_sources() {
 	}
 	if (params.SETUP_JCK_RUN && env.BUILD_LIST.contains('jck')) {
 		setup_jck_interactives()
-		if (env.IS_COMPLIANCE_SCRIPTS_REPO) {
-			println("Setup jck_run with compliance repo contents")
-			// cloneComplianceScriptsRepo()
-		}
 	}
 }
 def makeCompileTest(){

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -562,15 +562,6 @@ def setup() {
 		VENDOR_TEST_DIRS = (params.VENDOR_TEST_DIRS) ? "--vendor_dirs \"${params.VENDOR_TEST_DIRS}\"" : ""
 		VENDOR_TEST_SHAS = (params.VENDOR_TEST_SHAS) ? "--vendor_shas \"${params.VENDOR_TEST_SHAS}\"" : ""
 
-		println(VENDOR_TEST_REPOS)
-		env.IS_COMPLIANCE_SCRIPTS_REPO = (params.VENDOR_TEST_REPOS && params.VENDOR_TEST_REPOS.contains('compliance')) ? true : false
-		echo "IS_COMPLIANCE_SCRIPTS_REPO is set to ${env.IS_COMPLIANCE_SCRIPTS_REPO}"
-
-		// compliance scripts repository must be first, if multiple vendor test repos supplied
-		// env.COMPLIANCE_SCRIPTS_REPO = (params.VENDOR_TEST_REPOS) ? ${params.VENDOR_TEST_REPOS}.split(',')[0] : ""
-		// env.COMPLIANCE_SCRIPTS_BRANCH = (params.VENDOR_TEST_BRANCHES) ? ${params.VENDOR_TEST_BRANCHES}.split(',')[0] : ""
-		// env.COMPLIANCE_SCRIPTS_DIR = (params.VENDOR_TEST_DIRS) ? ${params.VENDOR_TEST_DIRS}.split(',')[0] : ""
-
 		env.IS_SVT_TESTREPO = (params.VENDOR_TEST_REPOS && params.VENDOR_TEST_REPOS.contains('SVTTestRepo')) ? true : false
 		echo "IS_SVT_TESTREPO is set to ${env.IS_SVT_TESTREPO}"
 

--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -465,6 +465,62 @@ def createJob( TEST_JOB_NAME, ARCH_OS ) {
 	return create
 }
 
+def cloneComplianceScriptsRepo() {
+	try {
+		jenkins_home = "${env.WORKSPACE}/../../"
+        echo "cd ${jenkins_home}"
+
+        echo "*************************************************************************"
+        echo "* Extracting jck_run to ${jenkins_home} on node: ${NODE_NAME}"
+        echo "*************************************************************************"
+
+        //checkout([$class: 'GitSCM', branches: [[name: "${COMPLIANCE_SCRIPTS_BRANCH}"]],
+        //    userRemoteConfigs: [[url: "${COMPLIANCE_SCRIPTS_REPO}",
+        //    credentialsId: "${params.USER_CREDENTIALS_ID}"]]
+        //])
+
+		// Compliance repo was cloned as part of VENDOR_TEST_REPO preparation
+		// Move it to the jck_run folder
+
+        echo "Cleaning ${jenkins_home}/jck_run/arctic folder prior to extract"
+		sh "rm -rf ${jenkins_home}/jck_run/arctic"
+
+        def statusCode=sh(script:"cp -r jck_run ${jenkins_home} 2>&1", returnStatus:true)
+        echo "returnCode = ${statusCode}"
+        if (statusCode != 0) {
+            result = "FAILURE"
+        } else {
+            sh "chgrp jck ${jenkins_home}/jck_run"
+            sh "chmod g+s ${jenkins_home}/jck_run"
+        }
+
+        echo "*************************************************************************"
+
+    } catch (Exception e) {
+        context.println "Failed to extract on node ${label} : ${e.message}"
+    }
+
+    // Reorganize scripts dir
+    echo "Move ./scripts folder to jck_run"
+    def statusCode=sh(script:"cp -r ./scripts ${jenkins_home}/jck_run 2>&1", returnStatus:true)
+    echo "cp returnCode = ${statusCode}"
+    if (statusCode != 0) {
+        result = "FAILURE"
+    }
+
+    // Set permissions
+    statusCode=sh(script:"chgrp -R jck ${jenkins_home}/jck_run 2>&1", returnStatus:true)
+    echo "chgrp returnCode = ${statusCode}"
+    if (statusCode != 0) {
+        result = "FAILURE"
+    }
+    statusCode=sh(script:"chmod -R 775 ${jenkins_home}/jck_run 2>&1", returnStatus:true)
+    echo "chmod returnCode = ${statusCode}"
+    if (statusCode != 0) {
+        result = "FAILURE"
+    }
+}
+
 def setup() {
 	stage('Setup') {
 		setupEnv()
@@ -561,6 +617,16 @@ def setup() {
 		VENDOR_TEST_BRANCHES = (params.VENDOR_TEST_BRANCHES) ? "--vendor_branches \"${params.VENDOR_TEST_BRANCHES}\"" : ""
 		VENDOR_TEST_DIRS = (params.VENDOR_TEST_DIRS) ? "--vendor_dirs \"${params.VENDOR_TEST_DIRS}\"" : ""
 		VENDOR_TEST_SHAS = (params.VENDOR_TEST_SHAS) ? "--vendor_shas \"${params.VENDOR_TEST_SHAS}\"" : ""
+
+		println(VENDOR_TEST_REPOS)
+		env.IS_COMPLIANCE_SCRIPTS_REPO = (params.VENDOR_TEST_REPOS && params.VENDOR_TEST_REPOS.contains('compliance')) ? true : false
+		echo "IS_COMPLIANCE_SCRIPTS_REPO is set to ${env.IS_COMPLIANCE_SCRIPTS_REPO}"
+
+		// compliance scripts repository must be first, if multiple vendor test repos supplied
+		// env.COMPLIANCE_SCRIPTS_REPO = (params.VENDOR_TEST_REPOS) ? ${params.VENDOR_TEST_REPOS}.split(',')[0] : ""
+		// env.COMPLIANCE_SCRIPTS_BRANCH = (params.VENDOR_TEST_BRANCHES) ? ${params.VENDOR_TEST_BRANCHES}.split(',')[0] : ""
+		// env.COMPLIANCE_SCRIPTS_DIR = (params.VENDOR_TEST_DIRS) ? ${params.VENDOR_TEST_DIRS}.split(',')[0] : ""
+
 		env.IS_SVT_TESTREPO = (params.VENDOR_TEST_REPOS && params.VENDOR_TEST_REPOS.contains('SVTTestRepo')) ? true : false
 		echo "IS_SVT_TESTREPO is set to ${env.IS_SVT_TESTREPO}"
 
@@ -665,8 +731,12 @@ def get_sources() {
 			sh "$GET_SH_CMD"
 		}
 	}
-	if (params.SETUP_JCK_RUN && env.BUILD_LIST.contains('jck') && SDK_RESOURCE.contains('customized')) {
+	if (params.SETUP_JCK_RUN && env.BUILD_LIST.contains('jck')) {
 		setup_jck_interactives()
+		if (env.IS_COMPLIANCE_SCRIPTS_REPO) {
+			println("Setup jck_run with compliance repo contents")
+			// cloneComplianceScriptsRepo()
+		}
 	}
 }
 def makeCompileTest(){

--- a/docs/pages/JenkinFeatures.md
+++ b/docs/pages/JenkinFeatures.md
@@ -39,10 +39,12 @@ Additional test repositories that can be overlaid onto existing AQA test materia
 This is used for laying down any test material, particularly useful for running private tests that cannot be open-sourced.  Examples of how these parameters are used can be seen by looking at the smoke tests in the temurin-build repository and some MSI tests in the installer repository.  TKG can discover any test material, as long as you tell it where to look (through setting these parameters), and that these repositories contain build instructions (via build.xml ant scripts) and execution instructions (via playlist.xml files).
 
 - `VENDOR_TEST_REPOS`: optional, comma-separated list of repositories containing additional test material.
+  - **Special handling for compliance repositories**: If a repository URL contains the word "compliance" and `SETUP_JCK_RUN` is set to true, the `jck_run` folder from that repository will be moved to the Jenkins home directory for JCK test execution. Other repositories in the comma-separated list will have their contents copied to the test directory only.
 - `VENDOR_TEST_BRANCHES`: optional, comma-separated list of branches for additional test material.
 - `VENDOR_TEST_SHAS`: optional, pin to particular SHAS of VENDOR_TEST_REPOS.
 - `VENDOR_TEST_DIRS`: optional, directories within VENDOR_TEST_REPOS where to find test material.
 - `USER_CREDENTIALS_ID`: optional, credentials to use if VENDOR_TEST_REPOS require them.
+- `SETUP_JCK_RUN`: optional, boolean (default: false). When set to true and `VENDOR_TEST_REPOS` contains a repository with "compliance" in its URL, the `jck_run` folder from the compliance repository will be moved to the Jenkins home directory. This is used for setting up JCK test environments. The move operation only occurs when `BUILD_LIST` contains "jck".
 
 ### Platform and Machine Selection Parameters
 Choose which platform to run tests on and optionally specify the machine label to send the test job to a certain machine if desired.

--- a/get.sh
+++ b/get.sh
@@ -711,7 +711,7 @@ getFunctionalTestMaterial()
 
 moveComplianceRepoToJckRun() {
 	echo "*************************************************************************"
-	echo "* Moving jck_run dir to jenkins home"
+	echo "* Replacing jenkins_home/jck_run contents with compliance_repo/jck_run   "
 	echo "*************************************************************************"
 	
 	# Determine jenkins home directory (two levels up from TESTDIR)

--- a/get.sh
+++ b/get.sh
@@ -39,6 +39,7 @@ DEBUG_IMAGES_REQUIRED=true
 CURL_OPTS="s"
 CODE_COVERAGE=false
 ADDITIONAL_ARTIFACTS_REQUIRED=""
+SETUP_JCK_RUN="false"
 
 usage ()
 {
@@ -63,6 +64,7 @@ usage ()
 	echo '                [--vendor_shas ] : optional. Comma separated SHAs of the vendor repositories'
 	echo '                [--vendor_branches ] : optional. Comma separated vendor branches'
 	echo '                [--vendor_dirs ] : optional. Comma separated directories storing vendor test resources'
+	echo '                [--setup_jck_run ] : optional. true or false. Setup jck_run folder if compliance repo is provided. Default to false'
 	echo '                [--code_coverage ] : optional. indicate if code coverage is required'
 }
 
@@ -149,6 +151,9 @@ parseCommandLineArgs()
 
 			"--additional_artifacts_required" )
 				ADDITIONAL_ARTIFACTS_REQUIRED="$1"; shift;;
+
+			"--setup_jck_run" )
+				SETUP_JCK_RUN="$1"; shift;;
 
 			"--help" | "-h" )
 				usage; exit 0;;
@@ -704,6 +709,59 @@ getFunctionalTestMaterial()
 	cd $TESTDIR
 }
 
+moveComplianceRepoToJckRun() {
+	echo "*************************************************************************"
+	echo "* Moving jck_run dir to jenkins home"
+	echo "*************************************************************************"
+	
+	# Determine jenkins home directory (two levels up from TESTDIR)
+	jenkins_home="$(cd "$TESTDIR/../.." && pwd)"
+	echo "Jenkins home: ${jenkins_home}"
+	
+	if [ -d "$TESTDIR/jck_run" ]; then
+		echo "Cleaning ${jenkins_home}/jck_run/arctic folder prior to extract"
+		rm -rf "${jenkins_home}/jck_run/arctic"
+		
+		echo "Copying jck_run directory to ${jenkins_home}"
+		cp -r "$TESTDIR/jck_run" "${jenkins_home}/" 2>&1
+		
+		if [ $? -eq 0 ]; then
+			echo "Successfully copied jck_run to ${jenkins_home}"
+			
+			# Set permissions if not on Windows
+			if [[ ! "$PLATFORM" == *"windows"* ]]; then
+				chgrp jck "${jenkins_home}/jck_run" 2>/dev/null || echo "Warning: Could not change group to jck"
+				chmod g+s "${jenkins_home}/jck_run" 2>/dev/null || echo "Warning: Could not set setgid bit"
+			fi
+			
+			# Copy scripts folder to jck_run
+			if [ -d "$TESTDIR/scripts" ]; then
+				echo "Copying scripts folder to jck_run"
+				cp -r "$TESTDIR/scripts" "${jenkins_home}/jck_run/" 2>&1
+				
+				if [ $? -eq 0 ]; then
+					echo "Successfully copied scripts to ${jenkins_home}/jck_run"
+				else
+					echo "Warning: Failed to copy scripts folder"
+				fi
+			fi
+			
+			# Set final permissions if not on Windows
+			if [[ ! "$PLATFORM" == *"windows"* ]]; then
+				chgrp -R jck "${jenkins_home}/jck_run" 2>/dev/null || echo "Warning: Could not recursively change group to jck"
+				chmod -R 775 "${jenkins_home}/jck_run" 2>/dev/null || echo "Warning: Could not set permissions to 775"
+			fi
+		else
+			echo "Error: Failed to copy jck_run directory"
+			return 1
+		fi
+	else
+		echo "Warning: jck_run directory not found in $TESTDIR"
+	fi
+	
+	echo "*************************************************************************"
+}
+
 getVendorTestMaterial() {
 	echo "get vendor test material..."
 	cd $TESTDIR
@@ -712,6 +770,7 @@ getVendorTestMaterial() {
 	declare -a vendor_branches_array
 	declare -a vendor_shas_array
 	declare -a vendor_dirs_array
+	local is_compliance_repo=false
 
 	# convert VENDOR_REPOS to array
 	vendor_repos_array=(`echo $VENDOR_REPOS | sed 's/,/\n/g'`)
@@ -742,6 +801,12 @@ getVendorTestMaterial() {
 		branchOption=""
 		if [ "$branch" != "" ]; then
 			branchOption="-b $branch"
+		fi
+
+		# Check if this is a compliance repo
+		if [[ "$repoURL" == *"compliance"* ]]; then
+			is_compliance_repo=true
+			echo "Compliance repository detected: $repoURL"
 		fi
 
 		if [[ "$dir" =~ "jck" ]]; then
@@ -792,6 +857,17 @@ getVendorTestMaterial() {
 		cd $TESTDIR
 
 	done
+	
+	# After processing all vendor repos, check if we need to move compliance repo to jck_run
+	if [ "$is_compliance_repo" = true ] && [ "$SETUP_JCK_RUN" = "true" ]; then
+		echo "SETUP_JCK_RUN is true and compliance repo detected"
+		if [[ "$BUILD_LIST" =~ "jck" ]]; then
+			echo "BUILD_LIST contains 'jck', proceeding with jck_run setup"
+			moveComplianceRepoToJckRun
+		else
+			echo "BUILD_LIST does not contain 'jck', skipping jck_run setup"
+		fi
+	fi
 }
 
 testJavaVersion()


### PR DESCRIPTION
Fixes #6763 

When SETUP_JCK_RUN is set to true, and VENDOR_TEST_REPOS contains compliance repository URL, then replace the contents of jenkins_home/jck_run with those from the vendor supplied compliance repo.  This allows vendors with compliance content such as arctic test recordings to pass the link to their compliance repo which based on this change, must contain the string 'compliance' within the repo name for the special handling to be invoked.