### PR TITLE
Removing already existing vendor repo

### DIFF
--- a/buildenv/jenkins/perfPipeline_root.groovy
+++ b/buildenv/jenkins/perfPipeline_root.groovy
@@ -22,6 +22,7 @@ if (params.PERFCONFIG_JSON) {
                                 def statusCode = -1
                                 sshagent (credentials: ["$params.USER_CREDENTIALS_ID"], ignoreMissing: true) {
                                         statusCode =  sh returnStatus: true, script: """
+                                        rm -rf ${vendorRepoDir}
                                         git clone -q --depth 1 -b ${params.VENDOR_TEST_BRANCHES} ${params.VENDOR_TEST_REPOS} ${vendorRepoDir}
                                         """
                                 }


### PR DESCRIPTION
While running Perf_Pipeline , the runs were failing because of this error:
```
+ git clone -q --depth 1 -b main git@github.ibm.com:runtimes/rt-performance.git vendorRepo
fatal: destination path 'vendorRepo' already exists and is not an empty directory.
[Pipeline] }

```

https://hyc-runtimes-jenkins.swg-devops.com/job/Perf_Pipeline_JDK21/416/console

Added a step to remove the vendor repo before cloning.