### PR TITLE
User inputs to get.sh are no longer overwritten, even when USE_TESTENV_PROPERTIES=true

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -40,8 +40,10 @@ CURL_OPTS="s"
 CODE_COVERAGE=false
 ADDITIONAL_ARTIFACTS_REQUIRED=""
 SETUP_JCK_RUN="false"
-# Use this dict to restore inputs in case USE_TESTENV_PROPERTIES is set to true
-declare -A TESTENV_CLI_OVERRIDES
+# Use parallel arrays to restore inputs in case USE_TESTENV_PROPERTIES is set to true.
+# macOS still ships Bash 3.2, which does not support associative arrays (dictionaries).
+declare -a TESTENV_CLI_OVERRIDE_KEYS
+declare -a TESTENV_CLI_OVERRIDE_VALUES
 
 usage ()
 {
@@ -72,13 +74,21 @@ usage ()
 
 # Ensures that test environment variables are properly set,
 #   even if USE_TESTENV_PROPERTIES is set to true
+rememberTestenvOverride()
+{
+	TESTENV_CLI_OVERRIDE_KEYS+=("$1")
+	TESTENV_CLI_OVERRIDE_VALUES+=("$2")
+}
+
 replayTestenvOverrides()
 {
+	local i
 	local key
 	# Iterate through all env overwrites that the user provided as input
-	for key in "${!TESTENV_CLI_OVERRIDES[@]}"; do
+	for i in "${!TESTENV_CLI_OVERRIDE_KEYS[@]}"; do
+		key="${TESTENV_CLI_OVERRIDE_KEYS[$i]}"
 		# Set the env overwrite again
-		printf -v "$key" '%s' "${TESTENV_CLI_OVERRIDES[$key]}"
+		printf -v "$key" '%s' "${TESTENV_CLI_OVERRIDE_VALUES[$i]}"
 		# export the env variable so that future processes are consistent
 		export "$key"
 	done
@@ -128,7 +138,7 @@ parseCommandLineArgs()
 
 			"--openj9_repo" )
 				OPENJ9_REPO="$1"
-				TESTENV_CLI_OVERRIDES["OPENJ9_REPO"]="$OPENJ9_REPO"
+				rememberTestenvOverride "OPENJ9_REPO" "$OPENJ9_REPO"
 				shift;;
 
 			"--openj9_sha" )
@@ -136,17 +146,17 @@ parseCommandLineArgs()
 
 			"--openj9_branch" )
 				OPENJ9_BRANCH="$1"
-				TESTENV_CLI_OVERRIDES["OPENJ9_BRANCH"]="$OPENJ9_BRANCH"
+				rememberTestenvOverride "OPENJ9_BRANCH" "$OPENJ9_BRANCH"
 				shift;;
 
 			"--tkg_repo" )
 				TKG_REPO="$1"
-				TESTENV_CLI_OVERRIDES["TKG_REPO"]="$TKG_REPO"
+				rememberTestenvOverride "TKG_REPO" "$TKG_REPO"
 				shift;;
 
 			"--tkg_branch" )
 				TKG_BRANCH="$1"
-				TESTENV_CLI_OVERRIDES["TKG_BRANCH"]="$TKG_BRANCH"
+				rememberTestenvOverride "TKG_BRANCH" "$TKG_BRANCH"
 				shift;;
 
 			"--vendor_repos" )

--- a/get.sh
+++ b/get.sh
@@ -40,6 +40,7 @@ CURL_OPTS="s"
 CODE_COVERAGE=false
 ADDITIONAL_ARTIFACTS_REQUIRED=""
 SETUP_JCK_RUN="false"
+declare -A TESTENV_CLI_OVERRIDES
 
 usage ()
 {
@@ -66,6 +67,20 @@ usage ()
 	echo '                [--vendor_dirs ] : optional. Comma separated directories storing vendor test resources'
 	echo '                [--setup_jck_run ] : optional. true or false. Setup jck_run folder if compliance repo is provided. Default to false'
 	echo '                [--code_coverage ] : optional. indicate if code coverage is required'
+}
+
+# Ensures that test environment variables are properly set,
+#   even if USE_TESTENV_PROPERTIES is set to true
+replayTestenvOverrides()
+{
+	local key
+	# Itereate through all env overwrites that the user provided as input
+	for key in "${!TESTENV_CLI_OVERRIDES[@]}"; do
+		# Set the env overwrite again
+		printf -v "$key" '%s' "${TESTENV_CLI_OVERRIDES[$key]}"
+		# export the env variable so that future processes are consistent
+		export "$key"
+	done
 }
 
 parseCommandLineArgs()
@@ -111,19 +126,27 @@ parseCommandLineArgs()
 				CLONE_OPENJ9="$1"; shift;;
 
 			"--openj9_repo" )
-				OPENJ9_REPO="$1"; shift;;
+				OPENJ9_REPO="$1"
+				TESTENV_CLI_OVERRIDES["OPENJ9_REPO"]="$OPENJ9_REPO"
+				shift;;
 
 			"--openj9_sha" )
 				OPENJ9_SHA="$1"; shift;;
 
 			"--openj9_branch" )
-				OPENJ9_BRANCH="$1"; shift;;
+				OPENJ9_BRANCH="$1"
+				TESTENV_CLI_OVERRIDES["OPENJ9_BRANCH"]="$OPENJ9_BRANCH"
+				shift;;
 
 			"--tkg_repo" )
-				TKG_REPO="$1"; shift;;
+				TKG_REPO="$1"
+				TESTENV_CLI_OVERRIDES["TKG_REPO"]="$TKG_REPO"
+				shift;;
 
 			"--tkg_branch" )
-				TKG_BRANCH="$1"; shift;;
+				TKG_BRANCH="$1"
+				TESTENV_CLI_OVERRIDES["TKG_BRANCH"]="$TKG_BRANCH"
+				shift;;
 
 			"--vendor_repos" )
 				VENDOR_REPOS="$1"; shift;;
@@ -955,6 +978,8 @@ if [ "$USE_TESTENV_PROPERTIES" = true ]; then
 		echo "load ./testenv/testenv.properties"
 		source ./testenv/testenv.properties
 	fi
+	# Reapply all use input test environment overrides
+	replayTestenvOverrides
 	if [[ $JDK_IMPL != "openj9" && $JDK_IMPL != "ibm" ]]; then
 		echo "Running checkTags with $teFile and $JDK_VERSION"
 		./scripts/testenv/checkTags.sh $teFile $JDK_VERSION

--- a/get.sh
+++ b/get.sh
@@ -40,6 +40,7 @@ CURL_OPTS="s"
 CODE_COVERAGE=false
 ADDITIONAL_ARTIFACTS_REQUIRED=""
 SETUP_JCK_RUN="false"
+# Use this dict to restore inputs in case USE_TESTENV_PROPERTIES is set to true
 declare -A TESTENV_CLI_OVERRIDES
 
 usage ()
@@ -74,7 +75,7 @@ usage ()
 replayTestenvOverrides()
 {
 	local key
-	# Itereate through all env overwrites that the user provided as input
+	# Iterate through all env overwrites that the user provided as input
 	for key in "${!TESTENV_CLI_OVERRIDES[@]}"; do
 		# Set the env overwrite again
 		printf -v "$key" '%s' "${TESTENV_CLI_OVERRIDES[$key]}"


### PR DESCRIPTION
Currently, if a user sets USE_TESTENV_PROPERTIES=true, then inputs like "--tkg_repo" and "--tkg_branch" are ignored. This PR ensures that they are no-longer ignored.