### PR TITLE
Unexclude JDK11 java/security/Security/ConfigFileTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -272,7 +272,6 @@ java/security/KeyPairGenerator/FinalizeHalf.java    https://github.com/eclipse-o
 java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java	https://github.com/adoptium/aqa-tests/issues/2790	generic-all
 java/security/SecureRandom/ApiTest.java https://github.com/eclipse-openj9/openj9/issues/16734 windows-all
 java/security/SecureRandom/EnoughSeedTest.java https://github.com/eclipse-openj9/openj9/issues/16734 windows-all
-java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/openj9/issues/23925 generic-all
 java/security/Signature/ResetAfterException.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 java/security/Signature/SignatureLength.java    https://github.com/eclipse-openj9/openj9/issues/12807   windows-all
 


### PR DESCRIPTION
[Unexclude JDK11 java/security/Security/ConfigFileTest.java](https://github.com/adoptium/aqa-tests/commit/b881a3c3cd3b72e04a5c2cea4dfce3a4c0c31214) 

closes https://github.com/eclipse-openj9/openj9/issues/23925

Signed-off-by: Jason Feng <fengj@ca.ibm.com>