### PR TITLE
Update section to revisit after JEP 401 is finalised

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -58,9 +58,6 @@ runtime/valhalla/inlinetypes/ObjectMethods.java#no-compressed-class-pointers htt
 runtime/valhalla/inlinetypes/QuickeningTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/TestCloneableValue.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/classloading/BigClassTreeClassLoader.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/classloading/PreLoadCircularityTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 
 ############################################################################
 
@@ -90,6 +87,15 @@ runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java https://github.com/ecl
 runtime/valhalla/inlinetypes/classfileparser/NullRestrictionWithoutPreview.java https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
 valhalla/valuetypes/NullRestrictedArraysTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 valhalla/valuetypes/NullRestrictedTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
+
+############################################################################
+
+# Tests to revisit after JEP 401 is finalized.
+
+############################################################################
+runtime/valhalla/inlinetypes/classloading/BigClassTreeClassLoader.java https://github.com/eclipse-openj9/openj9/issues/24005 generic-all
+runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java https://github.com/eclipse-openj9/openj9/issues/24005 generic-all
+runtime/valhalla/inlinetypes/classloading/PreLoadCircularityTest.java https://github.com/eclipse-openj9/openj9/issues/24005 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Added BigClassTreeClassLoader.java,  ConcurrentClassLoadingTest.java, and PreLoadCircularityTest.java from the
problem list to revisit after the JEP 401 is finalized.