### PR TITLE
Correct version range for jdk_bytevector64_j9

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -3583,7 +3583,7 @@
 	grep "#VECTOR API" $(REPORTDIR)/work/jdk/incubator/vector/ByteVector64Tests.jtr; \
 	$(TEST_STATUS)</command>
 		<versions>
-			<version>19+</version>
+			<version>27+</version>
 		</versions>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
`ByteVector64Tests` is for jdk27+.

Fixes: https://github.com/eclipse-openj9/openj9/issues/24016.