### PR TITLE
Enable ValueGetCtorLocal.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -62,7 +62,6 @@ runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.c
 # serviceability_valhalla_j9 - serviceability/jvmti/valhalla
 
 ############################################################################
-serviceability/jvmti/valhalla/GetCtorLocal/ValueGetCtorLocal.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all


### PR DESCRIPTION
Enable ValueGetCtorLocal.java
Fixed by: eclipse-openj9/openj9#24011

Passing test:https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/60363/