### PR TITLE
Re-enable tests related to hash code for value objects

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -19,11 +19,7 @@
 # jdk_valhalla_j9 - valhalla
 
 ############################################################################
-valhalla/valuetypes/MethodHandleTest.java https://github.com/eclipse-openj9/openj9/issues/22648 generic-all
-valhalla/valuetypes/ValueObjectMethodsTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
-valhalla/valuetypes/RecursiveValueClass.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 valhalla/valuetypes/Reflection.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
-valhalla/valuetypes/StreamTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 valhalla/valuetypes/SubstitutabilityTest.java  https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 valhalla/valuetypes/ValueClassPreviewTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 
@@ -52,9 +48,6 @@ com/sun/jdi/valhalla/ValueClassTypeTest.java https://github.com/adoptium/aqa-tes
 runtime/valhalla/inlinetypes/AcmpTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 runtime/valhalla/inlinetypes/HashOverflowTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 runtime/valhalla/inlinetypes/InlineWithJni.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/ObjectMethods.java#compressed-class-pointers https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
-runtime/valhalla/inlinetypes/ObjectMethods.java#no-compressed-class-pointers https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
-runtime/valhalla/inlinetypes/TestCloneableValue.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/23952 generic-all
 
 ############################################################################


### PR DESCRIPTION
Fixed by: https://github.com/eclipse-openj9/openj9/pull/23502

Passing Test:
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/60415/testReport/
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/60414/testReport/