### PR TITLE
Skip download "tap.zip"

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -337,7 +337,7 @@ getBinaryOpenjdk()
 						if [ "$TEST_IMAGES_REQUIRED" == "true" ]; then
 							download_url+=" ${download_url_base}${n}"
 						fi
-					elif [[ $n != *"install"* && $n != *"unsigned"* ]]; then
+					elif [[ $n != *"install"* && $n != *"unsigned"* && $n != *"tap"* ]]; then
 						download_url+=" ${download_url_base}${n}"
 					fi
 				done


### PR DESCRIPTION
Exclude the tap.zip name from download because in test pipeline unrecognized zip is treated as SDK.


Related: https://github.ibm.com/runtimes/automation/issues/1069