### PR TITLE
Changing default openjdk hotspot_custom test

### DIFF
--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -170,7 +170,7 @@ else
 endif
 
 JDK_CUSTOM_TARGET ?= java/math/BigInteger/BigIntegerTest.java
-HOTSPOT_CUSTOM_TARGET ?= gc/stress/gclocker/TestExcessGCLockerCollections.java
+HOTSPOT_CUSTOM_TARGET ?= gc/TestSystemGC.java
 HOTSPOT_CUSTOM_J9_TARGET ?= serviceability/jvmti/GetSystemProperty/JvmtiGetSystemPropertyTest.java
 LANGTOOLS_CUSTOM_TARGET ?= tools/javac/4241573/T4241573.java
 FULLPATH_JDK_CUSTOM_TARGET = $(foreach target,$(JDK_CUSTOM_TARGET),$(JTREG_JDK_TEST_DIR)$(D)$(target))


### PR DESCRIPTION
...because TestExcessGCLockerCollections has been removed as of jdk25. [Link](https://bugs.openjdk.org/browse/JDK-8192647).

TestSystemGC takes only a second to run, and exists in every jdk version from 8 to head.

- Test on jdk8, xLinux: https://ci.adoptium.net/job/Grinder/17365/ - Passed
- Test on jdk25, xWin: https://ci.adoptium.net/job/Grinder/17366/ - Passed