### PR TITLE
OpenJ9 OpenJDK Valhalla test triage

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -19,9 +19,8 @@
 # jdk_valhalla_j9 - valhalla
 
 ############################################################################
-valhalla/valuetypes/Reflection.java https://github.com/eclipse-openj9/openj9/issues/20404 generic-all
-valhalla/valuetypes/SubstitutabilityTest.java  https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
-valhalla/valuetypes/ValueClassPreviewTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
+valhalla/valuetypes/ValueClassPreviewTest.java https://github.com/eclipse-openj9/openj9/issues/24086 generic-all
+valhalla/valuetypes/ValueObjectMethodsTest.java https://github.com/eclipse-openj9/openj9/issues/24087 generic-all
 
 ############################################################################
 
@@ -46,8 +45,8 @@ com/sun/jdi/valhalla/ValueClassTypeTest.java https://github.com/adoptium/aqa-tes
 
 ############################################################################
 runtime/valhalla/inlinetypes/AcmpTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/HashOverflowTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
-runtime/valhalla/inlinetypes/InlineWithJni.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/InlineTypesTest.java#force-non-tearable https://github.com/eclipse-openj9/openj9/issues/24089 generic-all
+runtime/valhalla/inlinetypes/InlineWithJni.java https://github.com/eclipse-openj9/openj9/issues/24013 generic-all
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/23952 generic-all
 
 ############################################################################
@@ -55,11 +54,10 @@ runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.c
 # serviceability_valhalla_j9 - serviceability/jvmti/valhalla
 
 ############################################################################
-serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
 serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
-serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java https://github.com/eclipse-openj9/openj9/issues/23993 generic-all
 serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-serviceability/jvmti/valhalla/VMObjectAllocValue/VMObjectAllocValueTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/VMObjectAllocValue/VMObjectAllocValueTest.java https://github.com/eclipse-openj9/openj9/issues/23992 generic-all
 
 ############################################################################
 
@@ -67,16 +65,16 @@ serviceability/jvmti/valhalla/VMObjectAllocValue/VMObjectAllocValueTest.java htt
 
 ############################################################################
 runtime/valhalla/inlinetypes/ArrayQueryTest.java https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
-runtime/valhalla/inlinetypes/FlatArraysTest.java#default https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/FlatArraysTest.java#no-array-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/InlineTypeArray.java#default https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/InlineTypeArray.java#no-array-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/InlineTypeArray.java#no-tearable https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/InlineTypeArray.java#nullable-value-flattening https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
-runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+runtime/valhalla/inlinetypes/FlatArraysTest.java#default https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
+runtime/valhalla/inlinetypes/FlatArraysTest.java#no-array-flattening https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
+runtime/valhalla/inlinetypes/InlineTypeArray.java#default https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
+runtime/valhalla/inlinetypes/InlineTypeArray.java#no-array-flattening https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
+runtime/valhalla/inlinetypes/InlineTypeArray.java#no-tearable https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
+runtime/valhalla/inlinetypes/InlineTypeArray.java#nullable-value-flattening https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
+runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
+valhalla/valuetypes/NullRestrictedArraysTest.java https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
 runtime/valhalla/inlinetypes/classfileparser/NullRestrictionWithoutPreview.java https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
-valhalla/valuetypes/NullRestrictedArraysTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
-valhalla/valuetypes/NullRestrictedTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
+valhalla/valuetypes/Reflection.java https://github.com/eclipse-openj9/openj9/issues/23555 generic-all
 
 ############################################################################
 
@@ -136,6 +134,7 @@ runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#parallel https://github.c
 runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#g1 https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#serial https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/FlatFieldAccessorMethods.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+runtime/valhalla/inlinetypes/HashOverflowTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/InheritedFlatFieldTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/InlineTypeDensity.java#compressed-oops https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/InlineTypeDensity.java#force-non-tearable https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -156,4 +155,5 @@ runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java#id2 https://github
 runtime/valhalla/inlinetypes/TestFlatteningBudget.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/ValuePreloadTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/VolatileTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+valhalla/valuetypes/SubstitutabilityTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 valhalla/valuetypes/LayoutIterationTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
- valhalla/valuetypes/Reflection.java: revisit when null-restricted is finalized. This is failing an array class equality test because OpenJ9 creates separate RAM classes for null-restricted and non-null-restricted arrays.
- valhalla/valuetypes/SubstitutabilityTest.java: permanently disable, the test directly calls ValueObjectMethods.isSubstitutable method which is not used by OpenJ9
- valhalla/valuetypes/ValueObjectMethodsTest.java: disable with issue https://github.com/eclipse-openj9/openj9/issues/24087
- valhalla/valuetypes/ValueClassPreviewTest.java: update issue to https://github.com/eclipse-openj9/openj9/issues/24086
- valhalla/valuetypes/NullRestrictedTest.java: enable, this test is passing after recent hashcode changes
- runtime/valhalla/inlinetypes/InlineTypesTest.java#force-non-tearable: disable with issue https://github.com/eclipse-openj9/openj9/issues/24089
- runtime/valhalla/inlinetypes/InlineWithJni.java: update issue to https://github.com/eclipse-openj9/openj9/issues/24013
- runtime/valhalla/inlinetypes/HashOverflowTest.java: permanently disable, this test doesn't apply to OpenJ9
- serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java: enable, this test is passing now
- serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java: update issue to https://github.com/eclipse-openj9/openj9/issues/23993
- serviceability/jvmti/valhalla/VMObjectAllocValue/VMObjectAllocValueTest.java: update issue to https://github.com/eclipse-openj9/openj9/issues/23992
- correct associated issue for `Tests to revisit after JEP for null-restricted value types is finalized.`