### PR TITLE
Exclude a few jdk_vector tests on AIX and zLinux

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -501,7 +501,16 @@ java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/
 
 # jdk_vector
 
+jdk/incubator/vector/Byte128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/24071 aix-all
+jdk/incubator/vector/ByteMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/24072 linux-s390x
 jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/20389 linux-aarch64
+jdk/incubator/vector/DoubleMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/24072 linux-s390x
+jdk/incubator/vector/FloatMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/24072 linux-s390x
+jdk/incubator/vector/Int128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/24071 aix-all
+jdk/incubator/vector/IntMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/24072 linux-s390x
+jdk/incubator/vector/LongMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/24072 linux-s390x
+jdk/incubator/vector/Short128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/24071 aix-all
+jdk/incubator/vector/ShortMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/24072 linux-s390x
 
 ############################################################################
 


### PR DESCRIPTION
[Exclude a few jdk_vector tests on AIX and zLinux](https://github.com/adoptium/aqa-tests/commit/a4ef3178d450a8fe7992028febbe9cf25bb75e26) 

Related to
* https://github.com/eclipse-openj9/openj9/issues/24071
* https://github.com/eclipse-openj9/openj9/issues/24072

Signed-off-by: Jason Feng <fengj@ca.ibm.com>