### PR TITLE
Update testJobTemplate to use git sparse checkout for non-lightweight checkout

### DIFF
--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -153,12 +153,11 @@ def SETUP_JCK_RUN = false
 // If LIGHT_WEIGHT_CHECKOUT is set to true, set Repository URL to its explicit value and keep Branch Specifier as parameter
 def ADOPTOPENJDK_REPO_BUILD_PARAM = '${ADOPTOPENJDK_REPO}'
 def ADOPTOPENJDK_BRANCH_BUILD_PARAM = '${ADOPTOPENJDK_BRANCH}'
-def SCRIPT_PATH = "aqa-tests/buildenv/jenkins/openjdk_tests"
+def SCRIPT_PATH = "buildenv/jenkins/openjdk_tests"
 
 LIGHT_WEIGHT_CHECKOUT = LIGHT_WEIGHT_CHECKOUT.toBoolean()
 if (LIGHT_WEIGHT_CHECKOUT) {
 	ADOPTOPENJDK_REPO_BUILD_PARAM = ADOPTOPENJDK_REPO
-	SCRIPT_PATH = "buildenv/jenkins/openjdk_tests"
 }
 
 String sectionHeaderStyleCss = ' color: blue; font-family: Roboto, sans-serif !important; padding: 5px; font-weight: bold; margin-top: 0.5rem; font-size: 1rem; outline: 0; '

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -449,7 +449,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							booleanParam('GENERATE_JOBS', GENERATE_JOBS.toBoolean(), "Force generate child jobs?")
 							booleanParam('LIGHT_WEIGHT_CHECKOUT', LIGHT_WEIGHT_CHECKOUT.toBoolean(), '''Optional. It takes effects if GENERATE_JOBS sets to true. <br>
 							If LIGHT_WEIGHT_CHECKOUT sets to true, generated job will check out faster. But the generated child job will NOT take ADOPTOPENJDK_REPO and ADOPTOPENJDK_BRANCH as parameters in job configure. <br>
-							If LIGHT_WEIGHT_CHECKOUT sets to false, the generated child job will take user-provided ADOPTOPENJDK_REPO and ADOPTOPENJDK_BRANCH in job configure. The SCM checkout will be done via a sparse checkout of SCRIPT_PATH.<br>
+							If LIGHT_WEIGHT_CHECKOUT sets to false, the generated child job will take user-provided ADOPTOPENJDK_REPO and ADOPTOPENJDK_BRANCH in job configure. The SCM checkout will be done via a sparse checkout of SCRIPT_NAME.<br>
 							LIGHT_WEIGHT_CHECKOUT is expected to be set to false for Grinder. For regular nightly/weekly runs, the value is expected to be set to true.<br>''')
 
 							parameterSeparatorDefinition {

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -448,7 +448,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 							booleanParam('GENERATE_JOBS', GENERATE_JOBS.toBoolean(), "Force generate child jobs?")
 							booleanParam('LIGHT_WEIGHT_CHECKOUT', LIGHT_WEIGHT_CHECKOUT.toBoolean(), '''Optional. It takes effects if GENERATE_JOBS sets to true. <br>
 							If LIGHT_WEIGHT_CHECKOUT sets to true, generated job will check out faster. But the generated child job will NOT take ADOPTOPENJDK_REPO and ADOPTOPENJDK_BRANCH as parameters in job configure. <br>
-							If LIGHT_WEIGHT_CHECKOUT sets to false, the generated child job will take user-provided ADOPTOPENJDK_REPO and ADOPTOPENJDK_BRANCH in job configure. <br>
+							If LIGHT_WEIGHT_CHECKOUT sets to false, the generated child job will take user-provided ADOPTOPENJDK_REPO and ADOPTOPENJDK_BRANCH in job configure. The SCM checkout will be done via a sparse checkout of SCRIPT_PATH.<br>
 							LIGHT_WEIGHT_CHECKOUT is expected to be set to false for Grinder. For regular nightly/weekly runs, the value is expected to be set to true.<br>''')
 
 							parameterSeparatorDefinition {
@@ -494,6 +494,14 @@ ARCH_OS_LIST.each { ARCH_OS ->
 											depth(1)
 											shallow(true)
 											timeout(60)
+										}
+										// If not LIGHT_WEIGHT_CHECKOUT, then use SCM git plugin sparse checkout to keep Jenkins controller workspace @script folder usage to a minimum.
+										if (!LIGHT_WEIGHT_CHECKOUT.toBoolean()) {
+											sparseCheckoutPaths {
+												sparseCheckoutPath {
+													path(SCRIPT_PATH)
+												}
+											}
 										}
 									}
 								}

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -153,11 +153,13 @@ def SETUP_JCK_RUN = false
 // If LIGHT_WEIGHT_CHECKOUT is set to true, set Repository URL to its explicit value and keep Branch Specifier as parameter
 def ADOPTOPENJDK_REPO_BUILD_PARAM = '${ADOPTOPENJDK_REPO}'
 def ADOPTOPENJDK_BRANCH_BUILD_PARAM = '${ADOPTOPENJDK_BRANCH}'
-def SCRIPT_PATH = "buildenv/jenkins/openjdk_tests"
+def SCRIPT_NAME = "buildenv/jenkins/openjdk_tests"
+def SCRIPT_PATH = "aqa-tests/${SCRIPT_NAME}"
 
 LIGHT_WEIGHT_CHECKOUT = LIGHT_WEIGHT_CHECKOUT.toBoolean()
 if (LIGHT_WEIGHT_CHECKOUT) {
 	ADOPTOPENJDK_REPO_BUILD_PARAM = ADOPTOPENJDK_REPO
+	SCRIPT_PATH = "${SCRIPT_NAME}"
 }
 
 String sectionHeaderStyleCss = ' color: blue; font-family: Roboto, sans-serif !important; padding: 5px; font-weight: bold; margin-top: 0.5rem; font-size: 1rem; outline: 0; '
@@ -499,7 +501,7 @@ ARCH_OS_LIST.each { ARCH_OS ->
 											sparseCheckoutPaths { 
 												sparseCheckoutPaths {
 													sparseCheckoutPath {
-														path(SCRIPT_PATH)
+														path(SCRIPT_NAME)
 													}
 												}
 											}

--- a/buildenv/jenkins/testJobTemplate
+++ b/buildenv/jenkins/testJobTemplate
@@ -497,9 +497,11 @@ ARCH_OS_LIST.each { ARCH_OS ->
 										}
 										// If not LIGHT_WEIGHT_CHECKOUT, then use SCM git plugin sparse checkout to keep Jenkins controller workspace @script folder usage to a minimum.
 										if (!LIGHT_WEIGHT_CHECKOUT.toBoolean()) {
-											sparseCheckoutPaths {
-												sparseCheckoutPath {
-													path(SCRIPT_PATH)
+											sparseCheckoutPaths { 
+												sparseCheckoutPaths {
+													sparseCheckoutPath {
+														path(SCRIPT_PATH)
+													}
 												}
 											}
 										}


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/7163

This PR updates testJobTemplate to use git sparse checkout for non-lightweight checkout, so that git checkout by Parameter repo & branch is supported, but the @script Jenkins controller workspace is still kept to a minimum.

- Non-lightweight auto gen test: https://ci.adoptium.net/view/work-in-progress/job/andrew-Test_Job_Auto_Gen/4/
  - Run of generated test job https://ci.adoptium.net/job/andrew-test-sparse/2/ - Sparse checkout success, @script 69MB
  - Run of generated job using release tag branch: https://ci.adoptium.net/job/andrew-test-sparse/4/ - Sparse checkout from release tag
- Lightweight auto gen test https://ci.adoptium.net/view/work-in-progress/job/andrew-Test_Job_Auto_Gen/5/
  - Run of generated test job https://ci.adoptium.net/job/andrew-test-sparse/3/ - Lightweight checkout