### PR TITLE
Exclude MonitorPinnedEvents Test

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -71,6 +71,7 @@ java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tes
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
 java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
+java/lang/Thread/virtual/MonitorPinnedEvents.java https://bugs.openjdk.org/browse/JDK-8386675 windows-all
 java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 

--- a/openjdk/excludes/ProblemList_openjdk26.txt
+++ b/openjdk/excludes/ProblemList_openjdk26.txt
@@ -71,6 +71,7 @@ java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tes
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
 java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
+java/lang/Thread/virtual/MonitorPinnedEvents.java https://bugs.openjdk.org/browse/JDK-8386675 windows-all
 java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 java/lang/instrument/RetransformRecordTypeAnn/TestRetransformRecord.java https://github.com/adoptium/aqa-tests/issues/7039 generic-all

--- a/openjdk/excludes/ProblemList_openjdk27.txt
+++ b/openjdk/excludes/ProblemList_openjdk27.txt
@@ -71,6 +71,7 @@ java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tes
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
 java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
+java/lang/Thread/virtual/MonitorPinnedEvents.java https://bugs.openjdk.org/browse/JDK-8386675 windows-all
 java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 java/lang/instrument/RetransformRecordTypeAnn/TestRetransformRecord.java https://github.com/adoptium/aqa-tests/issues/7039 generic-all


### PR DESCRIPTION
Fixes #7179 

For JDK25+

Exclude intermittent/unstable/unreliable windows test due to upstream bug:

https://bugs.openjdk.org/browse/JDK-8386675

