### PR TITLE
Run disabledTestsLinter when related files are modified

### DIFF
--- a/.github/workflows/disabledTestsLinter.yml
+++ b/.github/workflows/disabledTestsLinter.yml
@@ -4,6 +4,8 @@ on:
     paths:
     - 'openjdk/excludes/**'
     - '**/playlist.xml'
+    - 'scripts/disabled_tests/**'
+    - '.github/workflows/disabledTestsLinter.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
To ensure appropriate testing is performed when updating the associated scripts, or the workflow file itself.