### PR TITLE
OpenJ9 Valhalla weekly build update

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -21,6 +21,7 @@
 ############################################################################
 valhalla/valuetypes/ValueClassPreviewTest.java https://github.com/eclipse-openj9/openj9/issues/24086 generic-all
 valhalla/valuetypes/ValueObjectMethodsTest.java https://github.com/eclipse-openj9/openj9/issues/24087 generic-all
+valhalla/valuetypes/MethodHandleTest.java https://github.com/eclipse-openj9/openj9/issues/24155 generic-all
 
 ############################################################################
 
@@ -53,9 +54,9 @@ runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.c
 # serviceability_valhalla_j9 - serviceability/jvmti/valhalla
 
 ############################################################################
-serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
+serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java https://github.com/eclipse-openj9/openj9/issues/24133 generic-all
 serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java https://github.com/eclipse-openj9/openj9/issues/23993 generic-all
-serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java https://github.com/eclipse-openj9/openj9/issues/24134 generic-all
 serviceability/jvmti/valhalla/VMObjectAllocValue/VMObjectAllocValueTest.java https://github.com/eclipse-openj9/openj9/issues/23992 generic-all
 
 ############################################################################
@@ -131,6 +132,7 @@ runtime/valhalla/inlinetypes/field_layout/ValueObjectContainerTest.java https://
 runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#parallel https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#g1 https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/FlatArrayCopyingTest.java#serial https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+runtime/valhalla/inlinetypes/FlatArrayLargeOverlapCopyTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/FlatFieldAccessorMethods.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/HashOverflowTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/InheritedFlatFieldTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
- exclude valhalla/valuetypes/MethodHandleTest.java with issue
- update issues for serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java and serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java
- permanently exclude runtime/valhalla/inlinetypes/FlatArrayLargeOverlapCopyTest.java