### PR TITLE
Add missing Jpackage Excludes - Due to unsupported wix version

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -309,6 +309,7 @@ tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/
 tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
 tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -303,7 +303,12 @@ tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/inf
 tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/launcher/JliLaunchTest.java https://github.com/adoptium/aqa-tests/issues/5010 aix-all
-
+tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/ProblemList_openjdk26.txt
+++ b/openjdk/excludes/ProblemList_openjdk26.txt
@@ -309,6 +309,7 @@ tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/
 tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
 tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/ProblemList_openjdk26.txt
+++ b/openjdk/excludes/ProblemList_openjdk26.txt
@@ -303,6 +303,12 @@ tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/inf
 tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/launcher/JliLaunchTest.java https://github.com/adoptium/aqa-tests/issues/5010 aix-all
+tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/ProblemList_openjdk27.txt
+++ b/openjdk/excludes/ProblemList_openjdk27.txt
@@ -309,6 +309,7 @@ tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/
 tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
 tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+
 ############################################################################
 
 # jdk_jdi

--- a/openjdk/excludes/ProblemList_openjdk27.txt
+++ b/openjdk/excludes/ProblemList_openjdk27.txt
@@ -303,6 +303,12 @@ tools/jpackage/windows/WinInstallerIconTest.java https://github.com/adoptium/inf
 tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/launcher/JliLaunchTest.java https://github.com/adoptium/aqa-tests/issues/5010 aix-all
+tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
 ############################################################################
 
 # jdk_jdi


### PR DESCRIPTION
Fixes #7197 

The following tests need to be excluded on JDK25+ ( already excluded where necessary on earlier versions ), due to them being pinned to an old/out of date version of WiX , which we currently do not install on our test machines.

These tests should be excluded until the tests support newer versions of the wix toolset.