### PR TITLE
Exclude Wix Tests

### DIFF
--- a/openjdk/excludes/vendors/eclipse/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/vendors/eclipse/ProblemList_openjdk25.txt
@@ -145,6 +145,12 @@ tools/jpackage/windows/WinLongVersionTest.java#id1 https://github.com/adoptium/a
 tools/jpackage/windows/WinOSConditionTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 tools/jpackage/windows/WinResourceTest.java https://github.com/adoptium/aqa-tests/issues/6692 windows-all
 jdk/jshell/UserJdiUserRemoteTest.java https://github.com/adoptium/infrastructure/issues/4326 macosx-x64
+tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/MultiLauncherTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/share/MultiNameTwoPhaseTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all,linux-aarch64
+tools/jpackage/windows/WinPerUserInstallTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/windows/WinUpgradeUUIDTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
 
 ############################################################################
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/7197

The following tests need to be excluded on JDK25 ( already excluded where necessary on earlier & later versions ), due to them being pinned to an old/out of date version of WiX , which we currently do not install on our test machines.

These tests should be excluded until the tests support newer versions of the wix toolset