### PR TITLE
Playlist linter update and playlist comments healthcheck

### DIFF
--- a/docs/pages/userGuide.md
+++ b/docs/pages/userGuide.md
@@ -419,7 +419,7 @@ To exclude the 2nd variation listed which is assigned suffix_1 ```-Xmx1024m``` a
 After the comment is left, there will be a auto PR created with the exclude change in the playlist.xml. The PR will be linked to issue. If the testName can not be found in the repo, no PR will be created and there will be a comment left in the issue linking to the failed workflow run for more details. In the case where the parameter contains space separated values, use single quotes to group the parameter.
 
 #### Manually exclude a test target
-Search the test name to find its playlist.xml file. Add a ```<disables>``` element after ```<testCaseName>``` element. The ```<disables>``` element is used to capsulate all ```<disable>``` elements. The ```<disable>``` element should always contain a ```<comment>``` element to specify the related issue url (or issue comment url). Comments that are not URLs must begin with a hash.
+Search the test name to find its playlist.xml file. Add a ```<disables>``` element after ```<testCaseName>``` element. The ```<disables>``` element is used to capsulate all ```<disable>``` elements. The ```<disable>``` element should always contain a ```<comment>``` element to specify the related issue url (or issue comment url).
 
 For example:
 

--- a/external/aot/playlist.xml
+++ b/external/aot/playlist.xml
@@ -21,8 +21,7 @@
 		</command>
 		<disables>
 			<disable>
-				<comment># semeru docker image has no support for P8 machines
-				https://github.ibm.com/runtimes/backlog/issues/917</comment>
+				<comment>semeru docker image has no support for P8 machines - https://github.ibm.com/runtimes/backlog/issues/917</comment>
 				<platform>ppc64le_linux</platform>
 			</disable>
 		</disables>

--- a/external/criu-portable-restore/playlist.xml
+++ b/external/criu-portable-restore/playlist.xml
@@ -22,8 +22,7 @@
 		</command>
 		<disables>
 			<disable>
-				<comment># semeru docker image has no support for plinux ubuntu22
-				https://github.ibm.com/runtimes/backlog/issues/1099</comment>
+				<comment>semeru docker image has no support for plinux ubuntu22 - https://github.ibm.com/runtimes/backlog/issues/1099</comment>
 				<platform>ppc64le_linux</platform>
 			</disable>
 		</disables>

--- a/external/openliberty-mp-tck/playlist.xml
+++ b/external/openliberty-mp-tck/playlist.xml
@@ -24,8 +24,7 @@
 		</versions>
 		<disables>
 			<disable>
-				<comment># To enable later, also remove disable in build.xml
-				https://github.ibm.com/runtimes/backlog/issues/945</comment>
+				<comment># To enable later, also remove disable in build.xml - https://github.ibm.com/runtimes/backlog/issues/945</comment>
 			</disable>
 		</disables>
 		<impls>

--- a/external/quarkus_quickstarts/playlist.xml
+++ b/external/quarkus_quickstarts/playlist.xml
@@ -26,8 +26,7 @@
 				<impl>hotspot</impl>
 			</disable>
 			<disable>
-				<comment>https://github.ibm.com/runtimes/backlog/issues/776
-				https://github.ibm.com/runtimes/backlog/issues/1169</comment>
+				<comment>https://github.ibm.com/runtimes/backlog/issues/776, https://github.ibm.com/runtimes/backlog/issues/1169</comment>
 				<impl>openj9</impl>
 			</disable>
 		</disables>		

--- a/functional/security/Crypto/playlist.xml
+++ b/functional/security/Crypto/playlist.xml
@@ -41,8 +41,7 @@
 				<platform>.*solaris</platform>
 			</disable>
 			<disable>
-				<comment># This target is for those using GH actions or the Jenkins jtreg-plugin. The run.sh script provides extra functionality, tarring of results, downloading of bespoke jtreg.jar from a particular untagged commit SHA that is not yet upstreamed to a release version of jtreg that is used to see complete output in jtr.xml files. In addition, it simplifies enable/disable of kerberos-based tests which needs remote, pre-set KDC.
-				</comment>
+				<comment># This target is for those using GH actions or the Jenkins jtreg-plugin. The run.sh script provides extra functionality, tarring of results, downloading of bespoke jtreg.jar from a particular untagged commit SHA that is not yet upstreamed to a release version of jtreg that is used to see complete output in jtr.xml files. In addition, it simplifies enable/disable of kerberos-based tests which needs remote, pre-set KDC.</comment>
 			</disable>
 		</disables>
 		<command>

--- a/jck/compiler.api/playlist.xml
+++ b/jck/compiler.api/playlist.xml
@@ -35,13 +35,11 @@
 		<testCaseName>jck-compiler-api-java_rmi</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on all platforms and Java levels due to backlog/issues/559. To be run manually by CR team
-				https://github.ibm.com/runtimes/backlog/issues/559</comment>
+				<comment># Disabled on all platforms and Java levels due to backlog/issues/559. To be run manually by CR team - https://github.ibm.com/runtimes/backlog/issues/559</comment>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
-				<comment># Disabled on all platforms and Java levels due to backlog/issues/559. To be run manually by CR team
-				https://github.ibm.com/runtimes/backlog/issues/559</comment>
+				<comment># Disabled on all platforms and Java levels due to backlog/issues/559. To be run manually by CR team - https://github.ibm.com/runtimes/backlog/issues/559</comment>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -102,8 +100,7 @@
 		<testCaseName>jck-compiler-api-javax_tools</testCaseName>
 		<disables>
 			<disable>
-				<comment># Temporarily disabled on z/OS for backlog/issues/669
-				https://github.ibm.com/runtimes/backlog/issues/669</comment>
+				<comment># Temporarily disabled on z/OS for https://github.ibm.com/runtimes/backlog/issues/669</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>11</version>
@@ -128,8 +125,7 @@
 		<testCaseName>jck-compiler-api-signaturetest</testCaseName>
 		<disables>
 			<disable>
-				<comment># Temporarily disabled on aix on JDK8 for test setup issue: backlog/issues/506
-				https://github.ibm.com/runtimes/backlog/issues/506</comment>
+				<comment># Temporarily disabled on aix on JDK8 for test setup issue: https://github.ibm.com/runtimes/backlog/issues/506</comment>
 				<platform>ppc64_aix</platform>
 				<version>8</version>
 				<impl>openj9</impl>

--- a/jck/compiler.lang/playlist.xml
+++ b/jck/compiler.lang/playlist.xml
@@ -650,8 +650,7 @@
 		<testCaseName>jck-compiler-lang-ANNOT</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/487</comment>
+				<comment># Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually - https://github.ibm.com/runtimes/backlog/issues/487</comment>
 				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>

--- a/jck/runtime.api/playlist.xml
+++ b/jck/runtime.api/playlist.xml
@@ -342,8 +342,7 @@
 		<testCaseName>jck-runtime-api-signaturetest</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on aarch64_mac due to backlog/issues/1300.
-				https://github.ibm.com/runtimes/backlog/issues/1300</comment>
+				<comment># Disabled on aarch64_mac due to backlog/issues/1300 - https://github.ibm.com/runtimes/backlog/issues/1300</comment>
 				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
@@ -387,8 +386,7 @@
 		<testCaseName>jck-runtime-api-java_util-regex</testCaseName>
 		<disables>
 			<disable>
-				<comment># Temporarily disabled on z/OS for backlog/issues/669
-				https://github.ibm.com/runtimes/backlog/issues/669</comment>
+				<comment># Temporarily disabled on z/OS for https://github.ibm.com/runtimes/backlog/issues/669</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>11</version>
@@ -450,8 +448,7 @@
 		</versions>
 		<disables>
 			<disable>
-				<comment># Disabled on aix for backlog/issues/486 Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/486</comment>
+				<comment># Disabled on aix for backlog/issues/486 Awaiting some automation improvements, in the interim these targets will be run manually - https://github.ibm.com/runtimes/backlog/issues/486</comment>
 				<platform>ppc64_aix</platform>
 				<impl>openj9</impl>
 			</disable>
@@ -462,8 +459,7 @@
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-				<comment># Disabled on aarch64_mac due to backlog/issues/1300.
-				https://github.ibm.com/runtimes/backlog/issues/1300</comment>
+				<comment># Disabled on aarch64_mac due to https://github.ibm.com/runtimes/backlog/issues/1300</comment>
 				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
@@ -487,13 +483,11 @@
 		<testCaseName>jck-runtime-api-java_awt</testCaseName>
 		<disables>
 			<disable>
-				<comment># backlog/issues/608 : To be run manually
-				https://github.ibm.com/runtimes/backlog/issues/608</comment>
+				<comment># backlog/issues/608 : To be run manually - https://github.ibm.com/runtimes/backlog/issues/608</comment>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
-				<comment># backlog/issues/608 : To be run manually
-				https://github.ibm.com/runtimes/backlog/issues/608</comment>
+				<comment># backlog/issues/608 : To be run manually - https://github.ibm.com/runtimes/backlog/issues/608</comment>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -516,13 +510,11 @@
                 <testCaseName>jck-runtime-api-java_awt-robot</testCaseName>
                 <disables>
                         <disable>
-                                <comment># backlog/issues/608 : To be run manually
-                                https://github.ibm.com/runtimes/backlog/issues/608</comment>
+                                <comment># backlog/issues/608 : To be run manually - https://github.ibm.com/runtimes/backlog/issues/608</comment>
                                 <impl>ibm</impl>
                         </disable>
                         <disable>
-                                <comment># backlog/issues/608 : To be run manually
-                                https://github.ibm.com/runtimes/backlog/issues/608</comment>
+                                <comment># backlog/issues/608 : To be run manually - https://github.ibm.com/runtimes/backlog/issues/608</comment>
                                 <impl>openj9</impl>
                         </disable>
                         <disable>
@@ -550,15 +542,13 @@
 		<testCaseName>jck-runtime-api-java_beans</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/486</comment>
+				<comment># Disabled on aix for https://github.ibm.com/runtimes/backlog/issues/486 - Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>ppc64_aix</platform>
 				<version>11</version>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-				<comment># Disabled on aarch64_mac due to backlog/issues/1300.
-				https://github.ibm.com/runtimes/backlog/issues/1300</comment>
+				<comment># Disabled on aarch64_mac due to https://github.ibm.com/runtimes/backlog/issues/1300</comment>
 				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
@@ -634,15 +624,11 @@
 		<testCaseName>jck-runtime-api-java_net</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on all platforms due to backlog/issues/462. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/462</comment>
+				<comment># Disabled on all platforms due to https://github.ibm.com/runtimes/backlog/issues/462. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>.*zos.*</platform>
 			</disable>
 			<disable>
-				<comment># Disabled due to backlog/issues/921,923,750. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/921
-				https://github.ibm.com/runtimes/backlog/issues/923
-				https://github.ibm.com/runtimes/backlog/issues/750</comment>
+				<comment># Disabled due to https://github.ibm.com/runtimes/backlog/issues/921,https://github.ibm.com/runtimes/backlog/issues/923,https://github.ibm.com/runtimes/backlog/issues/750. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>ppc64_aix|x86-64_mac|x86-64_windows|x86-32_windows</platform>
 				<impl>openj9</impl>
 			</disable>
@@ -683,8 +669,7 @@
 		<testCaseName>jck-runtime-api-java_rmi</testCaseName>
 		<disables>
 			<disable>
-				<comment># Temporarily disabled on z/OS for backlog/issues/744
-				https://github.ibm.com/runtimes/backlog/issues/744</comment>
+				<comment># Temporarily disabled on z/OS for https://github.ibm.com/runtimes/backlog/issues/744</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>11</version>
@@ -709,8 +694,7 @@
 		<testCaseName>jck-runtime-api-java_security</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on win for backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/488</comment>
+				<comment># Disabled on win for https://github.ibm.com/runtimes/backlog/issues/488. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows|x86-32_windows</platform>
 				<version>8+</version>
 				<impl>openj9</impl>
@@ -792,8 +776,7 @@
 		<testCaseName>jck-runtime-api-java_util</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on z/OS due to backlog/issues/732
-				https://github.ibm.com/runtimes/backlog/issues/732</comment>
+				<comment># Disabled on z/OS due to https://github.ibm.com/runtimes/backlog/issues/732</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>11</version>
@@ -818,14 +801,12 @@
 		<testCaseName>jck-runtime-api-javax_accessibility</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on aix for backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/486</comment>
+				<comment># Disabled on aix for https://github.ibm.com/runtimes/backlog/issues/486. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>ppc64_aix</platform>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-				<comment># Disabled on aarch64_mac due to backlog/issues/1300.
-				https://github.ibm.com/runtimes/backlog/issues/1300</comment>
+				<comment># Disabled on aarch64_mac due to https://github.ibm.com/runtimes/backlog/issues/1300</comment>
 				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
@@ -906,8 +887,7 @@
 		<testCaseName>jck-runtime-api-javax_crypto</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on z/OS due to backlog/issues/730
-				https://github.ibm.com/runtimes/backlog/issues/730</comment>
+				<comment># Disabled on z/OS due to https://github.ibm.com/runtimes/backlog/issues/730</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>11</version>
@@ -932,8 +912,7 @@
 		<testCaseName>jck-runtime-api-javax_imageio</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on aarch64_mac due to backlog/issues/1300.
-				https://github.ibm.com/runtimes/backlog/issues/1300</comment>
+				<comment># Disabled on aarch64_mac due to https://github.ibm.com/runtimes/backlog/issues/1300</comment>
 				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>
@@ -974,8 +953,7 @@
 		<testCaseName>jck-runtime-api-javax_management</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on z/OS due to backlog/issues/730
-				https://github.ibm.com/runtimes/backlog/issues/730</comment>
+				<comment># Disabled on z/OS due to https://github.ibm.com/runtimes/backlog/issues/730</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>11</version>
@@ -1017,15 +995,13 @@
 		<testCaseName>jck-runtime-api-javax_net</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on z/OS due to backlog/issues/461
-				https://github.ibm.com/runtimes/backlog/issues/461</comment>
+				<comment># Disabled on z/OS due to https://github.ibm.com/runtimes/backlog/issues/461</comment>
 				<version>8</version>
 				<impl>ibm</impl>
 				<platform>.*zos.*</platform>
 			</disable>
 			<disable>
-				<comment># Disabled on z/OS due to backlog/issues/744
-				https://github.ibm.com/runtimes/backlog/issues/744</comment>
+				<comment># Disabled on z/OS due to https://github.ibm.com/runtimes/backlog/issues/744</comment>
 				<version>11</version>
 				<impl>ibm</impl>
 				<platform>s390x_zos</platform>
@@ -1050,14 +1026,12 @@
 		<testCaseName>jck-runtime-api-javax_print</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on all platforms on 17 for backlog/issues/633 (intermittent machine issue). To be run manually
-				https://github.ibm.com/runtimes/backlog/issues/633</comment>
+				<comment># Disabled on all platforms on 17 for https://github.ibm.com/runtimes/backlog/issues/633 (intermittent machine issue). To be run manually</comment>
 				<version>17+</version>
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-				<comment># Disabled on all platforms on 17 for backlog/issues/633 (intermittent machine issue). To be run manually
-				https://github.ibm.com/runtimes/backlog/issues/633</comment>
+				<comment># Disabled on all platforms on 17 for https://github.ibm.com/runtimes/backlog/issues/633 (intermittent machine issue). To be run manually</comment>
 				<version>17+</version>
 				<impl>ibm</impl>
 			</disable>
@@ -1081,8 +1055,7 @@
 		<testCaseName>jck-runtime-api-javax_rmi</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on z/OS due to backlog/issues/744
-				https://github.ibm.com/runtimes/backlog/issues/744</comment>
+				<comment># Disabled on z/OS due to https://github.ibm.com/runtimes/backlog/issues/744</comment>
 				<version>11</version>
 				<impl>ibm</impl>
 				<platform>s390x_zos</platform>
@@ -1141,8 +1114,7 @@
 		<testCaseName>jck-runtime-api-javax_sound</testCaseName>
 		<disables>
 			<disable>
-				<comment># Temporarily disabled on x64 + aarch64 Mac for backlog/issues/718
-				https://github.ibm.com/runtimes/backlog/issues/718</comment>
+				<comment># Temporarily disabled on x64 + aarch64 Mac for https://github.ibm.com/runtimes/backlog/issues/718</comment>
 				<platform>(aarch64_mac|x86-64_mac).*</platform>
 				<impl>openj9</impl>
 				<version>11+</version>
@@ -1184,13 +1156,11 @@
 		<testCaseName>jck-runtime-api-javax_swing</testCaseName>
 		<disables>
 			<disable>
-				<comment># backlog/issues/608 : To be run manually
-				https://github.ibm.com/runtimes/backlog/issues/608</comment>
+				<comment>https://github.ibm.com/runtimes/backlog/issues/608 : To be run manually</comment>
 				<impl>ibm</impl>
 			</disable>
 			<disable>
-				<comment># backlog/issues/608 : To be run manually
-				https://github.ibm.com/runtimes/backlog/issues/608</comment>
+				<comment>https://github.ibm.com/runtimes/backlog/issues/608 : To be run manually</comment>
 				<impl>openj9</impl>
 			</disable>
 		</disables>
@@ -1213,8 +1183,7 @@
 		<testCaseName>jck-runtime-api-javax_tools</testCaseName>
 		<disables>
 			<disable>
-				<comment># Temporarily disabled on z/OS for backlog/issues/669
-				https://github.ibm.com/runtimes/backlog/issues/669</comment>
+				<comment># Temporarily disabled on z/OS for https://github.ibm.com/runtimes/backlog/issues/669</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>11</version>
@@ -1398,8 +1367,7 @@
 		<testCaseName>jck-runtime-api-serializabletypes</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on aarch64_mac due to backlog/issues/1300.
-				https://github.ibm.com/runtimes/backlog/issues/1300</comment>
+				<comment># Disabled on aarch64_mac due to https://github.ibm.com/runtimes/backlog/issues/1300</comment>
 				<platform>aarch64_mac.*</platform>
 				<impl>openj9</impl>
 			</disable>

--- a/jck/runtime.vm/playlist.xml
+++ b/jck/runtime.vm/playlist.xml
@@ -18,8 +18,7 @@
 		<testCaseName>jck-runtime-vm-constantpool</testCaseName>
 		<disables>
 			<disable>
-				<comment># Temporarily disabled on z/OS for backlog/issues/670
-				https://github.ibm.com/runtimes/backlog/issues/670</comment>
+				<comment># Temporarily disabled on z/OS for https://github.ibm.com/runtimes/backlog/issues/670</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>11</version>
@@ -97,8 +96,7 @@
 				<version>8</version>
 			</disable>
 			<disable>
-				<comment># Temporarily disabled on z/OS for backlog/issues/670
-				https://github.ibm.com/runtimes/backlog/issues/670</comment>
+				<comment># Temporarily disabled on z/OS for https://github.ibm.com/runtimes/backlog/issues/670</comment>
 				<platform>.*zos.*</platform>
 				<impl>ibm</impl>
 				<version>8+</version>

--- a/jck/runtime.xml_schema/playlist.xml
+++ b/jck/runtime.xml_schema/playlist.xml
@@ -35,8 +35,7 @@
 		<testCaseName>jck-runtime-xml_schema-msData</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/487</comment>
+				<comment># Disabled on win due to https://github.ibm.com/runtimes/backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>
@@ -61,8 +60,7 @@
 		<testCaseName>jck-runtime-xml_schema-nistData-atomic</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/487</comment>
+				<comment># Disabled on win due to https://github.ibm.com/runtimes/backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>
@@ -87,8 +85,7 @@
 		<testCaseName>jck-runtime-xml_schema-nistData-list</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/487</comment>
+				<comment># Disabled on win due to https://github.ibm.com/runtimes/backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>
@@ -113,8 +110,7 @@
 		<testCaseName>jck-runtime-xml_schema-nistData-union</testCaseName>
 		<disables>
 			<disable>
-				<comment># Disabled on win due to backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually
-				https://github.ibm.com/runtimes/backlog/issues/487</comment>
+				<comment># Disabled on win due to https://github.ibm.com/runtimes/backlog/issues/487. Awaiting some automation improvements, in the interim these targets will be run manually</comment>
 				<platform>x86-64_windows</platform>
 				<version>11</version>
 				<impl>openj9</impl>

--- a/scripts/disabled_tests/issue_status.py
+++ b/scripts/disabled_tests/issue_status.py
@@ -465,7 +465,8 @@ def minimal_issues_check(issues: List[models.Scheme], auth, output_json):
             LOG.error(f'Uncaught exception while processing {playlist_path!r} : {e}')
             return_code = 1
 
-    if getattr(output_json, 'name', '<unknown>') == '<unknown>':
+    if not getattr(output_json, 'name', '<unknown>') in ['<unknown>', '<stdout>']:
+        LOG.info(f"Outputting JSON to {getattr(output_json, 'name', '<unknown>')}")
         json.dump(
             obj=output_json_contents,
             fp=output_json,

--- a/scripts/disabled_tests/issue_status.py
+++ b/scripts/disabled_tests/issue_status.py
@@ -329,18 +329,19 @@ def augment_with_status(issues, issue_status):
 def group_issues_by_url(issues: List[models.Scheme]) -> Dict[str, List[models.Scheme]]:
     url_to_issues = defaultdict(list)
     for issue in issues:
-        if issue["ISSUE_TRACKER"].startswith("#"):
-            url_to_issues[issue["ISSUE_TRACKER"].strip()].append(issue)
-        else: 
-            urls_list = issue["ISSUE_TRACKER"].split(",")
-            for url in urls_list:
+        possible_urls_list = issue["ISSUE_TRACKER"].replace(","," ").split()
+        for possible_url in possible_urls_list:
+            if possible_url.startswith("http"):
+                url = possible_url
+                if url.endswith("."):
+                    url = url[:-1]
                 url_to_issues[url.strip()].append(issue)
     return url_to_issues
 
 
 def should_exclude(url) -> Tuple[bool, str]:
-    if url.startswith("#"):
-        return True, "Ignoring non-url comment that starts with a hash."
+    if not url.startswith("http"):
+        return True, "Ignoring non-url."
     for exception in EXCEPTIONS:
         if exception in url:
             return True, exception
@@ -423,24 +424,22 @@ def is_known_url_format(url: str):
     return False
 
 
-def minimal_issues_check(issues: List[models.Scheme], auth):
+def minimal_issues_check(issues: List[models.Scheme], auth, output_json):
     global return_code
+    output_json_contents = []
 
     raw_url_to_issues = group_issues_by_url(issues)
 
     for url, issues in raw_url_to_issues.items():
         # Ignore urls that are actually comments.
-        if url.startswith("#"):
-            continue
-
         if not url.startswith("http"):
-            LOG.error(f"\"{url!r}\" is not a valid url.")
-            return_code = 1
             continue
 
         # If a url has a known format, only check syntax to save time.
         if is_known_url_format(url):
-            LOG.info(f"{url!r} uses a known url format.")
+            message = f"{url!r} uses a known url format."
+            LOG.info(message)
+            output_json_contents.append(message)
             continue
 
         # If this url does not match a known url format, test it directly.
@@ -451,10 +450,20 @@ def minimal_issues_check(issues: List[models.Scheme], auth):
             resp = session.head(url)
         acceptable_return_codes = [405, 429]
         if resp.status_code < 404 or resp.status_code in acceptable_return_codes:
-            LOG.info(f"{url!r} exists. Status code {resp.status_code}")
+            message = f"{url!r} exists. Status code {resp.status_code}"
+            LOG.info(message)
+            output_json_contents.append(message)
         else:
-            LOG.error(f"{url!r} cannot be found. Status code {resp.status_code}")
+            message = f"{url!r} cannot be found. Status code {resp.status_code}"
+            LOG.error(message)
+            output_json_contents.append("ERROR: " + message)
             return_code = 1
+
+    json.dump(
+        obj=output_json_contents,
+        fp=output_json,
+        indent=2,
+    )
 
 
 def main():
@@ -502,7 +511,7 @@ def main():
         auth = None
         if all([args.github_user, args.github_token]):
             auth = requests.auth.HTTPBasicAuth(username=args.github_user, password=args.github_token)
-        minimal_issues_check(issues, auth)
+        minimal_issues_check(issues, auth, args.outfile)
         LOG.info("Script complete.")
         return return_code
 

--- a/scripts/disabled_tests/issue_status.py
+++ b/scripts/disabled_tests/issue_status.py
@@ -443,20 +443,26 @@ def minimal_issues_check(issues: List[models.Scheme], auth, output_json):
             continue
 
         # If this url does not match a known url format, test it directly.
-        session = requests.Session()
-        if url.startswith("https://github.com/"):
-            resp = session.head(url, allow_redirects=True, auth=auth)
-        else:
-            resp = session.head(url)
-        acceptable_return_codes = [405, 429]
-        if resp.status_code < 404 or resp.status_code in acceptable_return_codes:
-            message = f"{url!r} exists. Status code {resp.status_code}"
-            LOG.info(message)
-            output_json_contents.append(message)
-        else:
-            message = f"{url!r} cannot be found. Status code {resp.status_code}"
-            LOG.error(message)
-            output_json_contents.append("ERROR: " + message)
+        try:
+            session = requests.Session()
+            if url.startswith("https://github.com/"):
+                resp = session.head(url, allow_redirects=True, auth=auth)
+            else:
+                resp = session.head(url)
+
+            acceptable_return_codes = [405, 429]
+            if resp.status_code < 404 or resp.status_code in acceptable_return_codes:
+                message = f"{url!r} exists. Status code {resp.status_code}"
+                LOG.info(message)
+                output_json_contents.append(message)
+            else:
+                message = f"{url!r} cannot be found. Status code {resp.status_code}"
+                LOG.error(message)
+                output_json_contents.append("ERROR: " + message)
+                return_code = 1
+
+        except RequestException as re:
+            LOG.error(f'Uncaught exception while processing {playlist_path!r} : {e}')
             return_code = 1
 
     json.dump(

--- a/scripts/disabled_tests/issue_status.py
+++ b/scripts/disabled_tests/issue_status.py
@@ -331,7 +331,7 @@ def group_issues_by_url(issues: List[models.Scheme]) -> Dict[str, List[models.Sc
     for issue in issues:
         possible_urls_list = issue["ISSUE_TRACKER"].replace(","," ").split()
         for possible_url in possible_urls_list:
-            if possible_url.startswith("http"):
+            if possible_url.startswith("http://", "https://"):
                 url = possible_url
                 if url.endswith("."):
                     url = url[:-1]

--- a/scripts/disabled_tests/issue_status.py
+++ b/scripts/disabled_tests/issue_status.py
@@ -465,11 +465,12 @@ def minimal_issues_check(issues: List[models.Scheme], auth, output_json):
             LOG.error(f'Uncaught exception while processing {playlist_path!r} : {e}')
             return_code = 1
 
-    json.dump(
-        obj=output_json_contents,
-        fp=output_json,
-        indent=2,
-    )
+    if getattr(output_json, 'name', '<unknown>') == '<unknown>':
+        json.dump(
+            obj=output_json_contents,
+            fp=output_json,
+            indent=2,
+        )
 
 
 def main():

--- a/scripts/disabled_tests/issue_status.py
+++ b/scripts/disabled_tests/issue_status.py
@@ -331,7 +331,7 @@ def group_issues_by_url(issues: List[models.Scheme]) -> Dict[str, List[models.Sc
     for issue in issues:
         possible_urls_list = issue["ISSUE_TRACKER"].replace(","," ").split()
         for possible_url in possible_urls_list:
-            if possible_url.startswith("http://", "https://"):
+            if possible_url.startswith(("http://", "https://")):
                 url = possible_url
                 if url.endswith("."):
                     url = url[:-1]

--- a/scripts/disabled_tests/playlist_parser.py
+++ b/scripts/disabled_tests/playlist_parser.py
@@ -132,10 +132,12 @@ class Disable(RawDisable):
         issue_urls: List[str] = []
         for url_node in issue_url_nodes:
             text = (url_node.text or '').strip()
-            if not text or text.startswith('#'):
+            if "\n" in text or "\r" in text:
+                raise DisableNodeProcessingException(f'disable node has a forbidden new line character inside the comment tag.')
+            if not text:
                 continue
             issue_urls.append(text)
-        issue_url = ",".join(issue_urls) if issue_urls else "# No URLs are associated with this disable node."
+        issue_url = ",".join(issue_urls) if issue_urls else "No URLs are associated with this disable node."
 
         test_name = raw_disable.parent_test.name
         custom_target = test_name + cls.get_suffix(raw_disable)

--- a/scripts/disabled_tests/playlist_parser.py
+++ b/scripts/disabled_tests/playlist_parser.py
@@ -236,7 +236,6 @@ def parse_all_files(playlist_files: Iterable[str]) -> List[Disable]:
         else:
             all_disables.extend(disables)
             LOG.info(f"Processed {playlist_path!r} : n_disables={len(disables)}")
-            sys.exit(1)
     return all_disables
 
 

--- a/scripts/disabled_tests/playlist_parser.py
+++ b/scripts/disabled_tests/playlist_parser.py
@@ -133,7 +133,8 @@ class Disable(RawDisable):
         for url_node in issue_url_nodes:
             text = (url_node.text or '').strip()
             if "\n" in text or "\r" in text:
-                raise DisableNodeProcessingException(f'disable node has a forbidden new line character inside the comment tag.')
+                LOG.error('disable node has a forbidden new line character inside the comment tag.')
+                sys.exit(1)
             if not text:
                 continue
             issue_urls.append(text)
@@ -205,6 +206,7 @@ def parse_test(raw_test: RawTest) -> List[Disable]:
             disables.append(disable)
         except DisableNodeProcessingException as e:
             LOG.error(f'{raw_test.playlist_file.path}:{raw_disable.node.sourceline} : {e}')
+            sys.exit(1)
     return disables
 
 
@@ -218,6 +220,7 @@ def parse_file(playlist_path: str) -> List[Disable]:
             disables_from_file.extend(disables)
         except TestNodeProcessingException as e:
             LOG.error(f'{playlist_path}:{test.node.sourceline} : {e}')
+            sys.exit(1)
     return disables_from_file
 
 
@@ -229,9 +232,11 @@ def parse_all_files(playlist_files: Iterable[str]) -> List[Disable]:
             disables = parse_file(playlist_path)
         except Exception as e:
             LOG.error(f'Uncaught exception while processing {playlist_path!r} : {e}')
+            sys.exit(1)
         else:
             all_disables.extend(disables)
             LOG.info(f"Processed {playlist_path!r} : n_disables={len(disables)}")
+            sys.exit(1)
     return all_disables
 
 

--- a/system/otherLoadTest/playlist.xml
+++ b/system/otherLoadTest/playlist.xml
@@ -144,8 +144,7 @@
 				<platform>x86-64_.*</platform>
 			</disable>
 			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/14165,
-				https://github.com/adoptium/aqa-tests/issues/3230</comment>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14165,https://github.com/adoptium/aqa-tests/issues/3230</comment>
 				<platform>x86-32_windows</platform>
 			</disable>
 			<disable>

--- a/system/security/playlist.xml
+++ b/system/security/playlist.xml
@@ -22,8 +22,7 @@
 				<impl>openj9</impl>
 			</disable>
 			<disable>
-				<comment>https://github.com/adoptium/aqa-systemtest/issues/474,
-				https://github.com/adoptium/aqa-tests/issues/3237</comment>
+				<comment>https://github.com/adoptium/aqa-systemtest/issues/474,https://github.com/adoptium/aqa-tests/issues/3237</comment>
 				<version>11+</version>
 			</disable>
 			<disable>


### PR DESCRIPTION
Playlist change: New line characters removed from playlist comments.

Playlist linter updates:
- URLs can now be separated by commas, whitespace, or both.
- Treat any word that starts with http as a url
- Remove requirement for non-url comments to start with a hash
- Add check to ensure no comment has a new line character inside it
- Remove full stops from the end of a url

Resolves https://github.com/adoptium/aqa-tests/issues/7195