### PR TITLE
Update section for tests with failures unrelated to Valhalla

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -54,10 +54,16 @@ runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.c
 # serviceability_valhalla_j9 - serviceability/jvmti/valhalla
 
 ############################################################################
-serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java https://github.com/eclipse-openj9/openj9/issues/24133 generic-all
-serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java https://github.com/eclipse-openj9/openj9/issues/23993 generic-all
-serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java https://github.com/eclipse-openj9/openj9/issues/24134 generic-all
-serviceability/jvmti/valhalla/VMObjectAllocValue/VMObjectAllocValueTest.java https://github.com/eclipse-openj9/openj9/issues/23992 generic-all
+serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java https://github.com/eclipse-openj9/openj9/issues/15768 generic-all
+serviceability/jvmti/valhalla/SampledObjectAllocValue/SampledObjectAllocValue.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java https://github.com/eclipse-openj9/openj9/issues/13182 generic-all
+
+############################################################################
+
+# Tests with known failures that are unrelated to Valhalla.
+
+############################################################################
+serviceability/jvmti/valhalla/VMObjectAllocValue/VMObjectAllocValueTest.java https://github.com/eclipse-openj9/openj9/issues/15994 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Add VMObjectAllocValueTest.java to a new section for problems with failures unrelated to Valhalla