### PR TITLE
Exclude jdk27+ tests that depend upon WhiteBox

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -72,6 +72,8 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java https://github.com/
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/LazyConstant/LazyConstantClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
+java/lang/LazyConstant/ThrowablesClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all

--- a/openjdk/excludes/ProblemList_openjdk28-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk28-openj9.txt
@@ -72,6 +72,8 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java https://github.com/
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/LazyConstant/LazyConstantClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
+java/lang/LazyConstant/ThrowablesClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all


### PR DESCRIPTION
The related native methods are not available with OpenJ9.