### PR TITLE
Enable InlineWithJni.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -46,7 +46,6 @@ com/sun/jdi/valhalla/ValueClassTypeTest.java https://github.com/adoptium/aqa-tes
 
 ############################################################################
 runtime/valhalla/inlinetypes/InlineTypesTest.java#force-non-tearable https://github.com/eclipse-openj9/openj9/issues/24089 generic-all
-runtime/valhalla/inlinetypes/InlineWithJni.java https://github.com/eclipse-openj9/openj9/issues/24013 generic-all
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/23952 generic-all
 
 ############################################################################


### PR DESCRIPTION
Enable InlineWithJni.java
Fixed by: eclipse-openj9/openj9/pull/24130

Passing test:https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/60924/