### PR TITLE
Restore jckConfig variable extractions accidentally removed

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -677,7 +677,16 @@ def remoteTriggerTemurinJCK (jobJdkVersion, jobPlatforms) {
     
     // Determine if this is a release build (for SETUP_JCK_RUN)
     def isReleaseBuild = (params.BUILD_TYPE == "release")
-   
+    
+    // Required: extract config sections into local variables so the JOBS closure below can capture them.
+    // Do NOT remove these — they are not defaults, they are the only way the closure accesses jckConfig.
+    def globalConfig              = jckConfig.GLOBAL_BUILD_CONFIG ?: [:]
+    def targetSpecificConfig      = jckConfig.TARGET_SPECIFIC_CONFIG ?: [:]
+    def platformSpecificConfig    = jckConfig.PLATFORM_SPECIFIC_CONFIG ?: [:]
+    def platformApplicationOptions   = jckConfig.PLATFORM_APPLICATION_OPTIONS ?: [:]
+    def platformAdditionalTestLabels = jckConfig.PLATFORM_ADDITIONAL_TEST_LABELS ?: [:]
+    def jckGitRepoTemplate        = jckConfig.JCK_GIT_REPO_TEMPLATE
+    
     // Get platform targets from config to determine which tests run on which platforms
     def platformTargets = jckConfig.PLATFORM_TARGETS ?: []
     
@@ -693,9 +702,7 @@ def remoteTriggerTemurinJCK (jobJdkVersion, jobPlatforms) {
         
         targetsForPlatform.each { target ->
             // Create a unique job name for this JDK version+platform+target combination
-            int jobNum = JOBS.size() + 1
-            def jobName = "JCK_jdk${jobJdkVersion}_${platform}_${target}_${jobNum}"
-            
+            def jobName = "Test_openjdk${jobJdkVersion}_hs_${target}_${platform}"
             JOBS[jobName] = {
                 // Build configuration by merging: global -> target-specific -> platform-specific
                 def config = [:]


### PR DESCRIPTION
Also rename JCK Test job name to be consistent

Fix the error 

```
Also:   hudson.remoting.ProxyException: org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 79173d71-4210-4743-b224-23795cac221c
Also:   	Also:   hudson.remoting.ProxyException: org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 4ffa0e16-6251-42a3-b6c3-c3064175b091
hudson.remoting.ProxyException: groovy.lang.MissingPropertyException: No such property: globalConfig for class: WorkflowScript
Also:   	Also:   hudson.remoting.ProxyException: org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: d5726b33-b667-427e-bfc9-4092e33243b9
hudson.remoting.ProxyException: groovy.lang.MissingPropertyException: No such property: globalConfig for class: WorkflowScript
Also:   	Also:   hudson.remoting.ProxyException: org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 233edf65-7901-44a8-989b-5a32df6b7aba
hudson.remoting.ProxyException: groovy.lang.MissingPropertyException: No such property: globalConfig for class: WorkflowScript
hudson.remoting.ProxyException: groovy.lang.MissingPropertyException: No such property: globalConfig for class: WorkflowScript
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:66)
```
https://ci.adoptium.net/job/AQA_Test_Pipeline_JCK/40/console

Part of #7086 

Fix #7228 