### PR TITLE
Update temurin ACTIVE_NODE_TIMEOUT to 10mins

### DIFF
--- a/buildenv/jenkins/config/temurin/default.json
+++ b/buildenv/jenkins/config/temurin/default.json
@@ -13,7 +13,7 @@
             "NUM_MACHINES": "3",
             "TEST_TIME": "120",
             "USE_TESTENV_PROPERTIES": false,
-            "ACTIVE_NODE_TIMEOUT": "7",
+            "ACTIVE_NODE_TIMEOUT": "10",
             "DYNAMIC_COMPILE": false,
             "RERUN_FAILURE": true,
             "RERUN_ITERATIONS": "1",

--- a/buildenv/jenkins/config/temurin/default.json
+++ b/buildenv/jenkins/config/temurin/default.json
@@ -13,7 +13,7 @@
             "NUM_MACHINES": "3",
             "TEST_TIME": "120",
             "USE_TESTENV_PROPERTIES": false,
-            "ACTIVE_NODE_TIMEOUT": "1",
+            "ACTIVE_NODE_TIMEOUT": "7",
             "DYNAMIC_COMPILE": false,
             "RERUN_FAILURE": true,
             "RERUN_ITERATIONS": "1",


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/7233

Increased temurin default ACTIVE_NODE_TIMEOUT to 10 mins