### PR TITLE
Phase3 dynamic lib

### DIFF
--- a/functional/MBCS_Tests/codepoint/build.xml
+++ b/functional/MBCS_Tests/codepoint/build.xml
@@ -19,6 +19,7 @@ limitations under the License.
         </description>
 
 	<import file="${TEST_ROOT}/functional/MBCS_Tests/buildDependencies.xml"/>
+	<import file="${TEST_ROOT}/functional/MBCS_Tests/unicodeVers.xml"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
 	<!-- set global properties for this build -->
@@ -27,30 +28,6 @@ limitations under the License.
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
 	<property name="build" location="./bin" />
-
-	<macrodef name="resolve-unicode-version">
-		<attribute name="jdk-version"/>
-		<sequential>
-			<condition property="unicode.ver" value="17.0.0"><matches string="@{jdk-version}" pattern="^(2[6-9]|[3-9][0-9])$"/></condition>
-			<condition property="unicode.ver" value="16.0.0"><matches string="@{jdk-version}" pattern="^2[4-5]$"/></condition>
-			<condition property="unicode.ver" value="15.1.0"><matches string="@{jdk-version}" pattern="^2[2-3]$"/></condition>
-			<condition property="unicode.ver" value="15.0.0"><matches string="@{jdk-version}" pattern="^2[0-1]$"/></condition>
-			<condition property="unicode.ver" value="14.0.0"><matches string="@{jdk-version}" pattern="^19$"/></condition>
-			<condition property="unicode.ver" value="13.0.0"><matches string="@{jdk-version}" pattern="^1[5-8]$"/></condition>
-			<condition property="unicode.ver" value="12.1.0"><matches string="@{jdk-version}" pattern="^1[3-4]$"/></condition>
-			<condition property="unicode.ver" value="11.0.0"><matches string="@{jdk-version}" pattern="^12$"/></condition>
-			<property name="unicode.ver" value="10.0.0"/>
-			<condition property="unicode.ver.key" value="17_0_0"><equals arg1="${unicode.ver}" arg2="17.0.0"/></condition>
-			<condition property="unicode.ver.key" value="16_0_0"><equals arg1="${unicode.ver}" arg2="16.0.0"/></condition>
-			<condition property="unicode.ver.key" value="15_1_0"><equals arg1="${unicode.ver}" arg2="15.1.0"/></condition>
-			<condition property="unicode.ver.key" value="15_0_0"><equals arg1="${unicode.ver}" arg2="15.0.0"/></condition>
-			<condition property="unicode.ver.key" value="14_0_0"><equals arg1="${unicode.ver}" arg2="14.0.0"/></condition>
-			<condition property="unicode.ver.key" value="13_0_0"><equals arg1="${unicode.ver}" arg2="13.0.0"/></condition>
-			<condition property="unicode.ver.key" value="12_1_0"><equals arg1="${unicode.ver}" arg2="12.1.0"/></condition>
-			<condition property="unicode.ver.key" value="11_0_0"><equals arg1="${unicode.ver}" arg2="11.0.0"/></condition>
-			<property name="unicode.ver.key" value="10_0_0"/>
-		</sequential>
-	</macrodef>
 
 	<condition property="jdk8above" value="true">
 		<not>

--- a/functional/MBCS_Tests/codepoint/build.xml
+++ b/functional/MBCS_Tests/codepoint/build.xml
@@ -27,7 +27,30 @@ limitations under the License.
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
 	<property name="build" location="./bin" />
-	<property name="LIB" value="unicode_gb18030_2022,unicode_unihan_10_0_0,unicode_unihan_11_0_0,unicode_unihan_12_1_0,unicode_unihan_13_0_0,unicode_unihan_14_0_0,unicode_unihan_15_0_0,unicode_unihan_15_1_0,unicode_unihan_16_0_0,unicode_unihan_17_0_0,unicode_ucd_unicodedata_10_0_0,unicode_ucd_unicodedata_11_0_0,unicode_ucd_unicodedata_12_1_0,unicode_ucd_unicodedata_13_0_0,unicode_ucd_unicodedata_14_0_0,unicode_ucd_unicodedata_15_0_0,unicode_ucd_unicodedata_15_1_0,unicode_ucd_unicodedata_16_0_0,unicode_ucd_unicodedata_17_0_0"/>
+
+	<macrodef name="resolve-unicode-version">
+		<attribute name="jdk-version"/>
+		<sequential>
+			<condition property="unicode.ver" value="17.0.0"><matches string="@{jdk-version}" pattern="^(2[6-9]|[3-9][0-9])$"/></condition>
+			<condition property="unicode.ver" value="16.0.0"><matches string="@{jdk-version}" pattern="^2[4-5]$"/></condition>
+			<condition property="unicode.ver" value="15.1.0"><matches string="@{jdk-version}" pattern="^2[2-3]$"/></condition>
+			<condition property="unicode.ver" value="15.0.0"><matches string="@{jdk-version}" pattern="^2[0-1]$"/></condition>
+			<condition property="unicode.ver" value="14.0.0"><matches string="@{jdk-version}" pattern="^19$"/></condition>
+			<condition property="unicode.ver" value="13.0.0"><matches string="@{jdk-version}" pattern="^1[5-8]$"/></condition>
+			<condition property="unicode.ver" value="12.1.0"><matches string="@{jdk-version}" pattern="^1[3-4]$"/></condition>
+			<condition property="unicode.ver" value="11.0.0"><matches string="@{jdk-version}" pattern="^12$"/></condition>
+			<property name="unicode.ver" value="10.0.0"/>
+			<condition property="unicode.ver.key" value="17_0_0"><equals arg1="${unicode.ver}" arg2="17.0.0"/></condition>
+			<condition property="unicode.ver.key" value="16_0_0"><equals arg1="${unicode.ver}" arg2="16.0.0"/></condition>
+			<condition property="unicode.ver.key" value="15_1_0"><equals arg1="${unicode.ver}" arg2="15.1.0"/></condition>
+			<condition property="unicode.ver.key" value="15_0_0"><equals arg1="${unicode.ver}" arg2="15.0.0"/></condition>
+			<condition property="unicode.ver.key" value="14_0_0"><equals arg1="${unicode.ver}" arg2="14.0.0"/></condition>
+			<condition property="unicode.ver.key" value="13_0_0"><equals arg1="${unicode.ver}" arg2="13.0.0"/></condition>
+			<condition property="unicode.ver.key" value="12_1_0"><equals arg1="${unicode.ver}" arg2="12.1.0"/></condition>
+			<condition property="unicode.ver.key" value="11_0_0"><equals arg1="${unicode.ver}" arg2="11.0.0"/></condition>
+			<property name="unicode.ver.key" value="10_0_0"/>
+		</sequential>
+	</macrodef>
 
 	<condition property="jdk8above" value="true">
 		<not>
@@ -52,6 +75,11 @@ limitations under the License.
 		</javac>
 	</target>
 
+	<target name="setUnicodeVersion">
+		<resolve-unicode-version jdk-version="${JDK_VERSION}"/>
+		<property name="LIB" value="unicode_gb18030_2022,unicode_unihan_${unicode.ver.key},unicode_ucd_unicodedata_${unicode.ver.key}"/>
+	</target>
+
 	<target name="dist" depends="compile,copyData,extractUnicodeData" description="generate the distribution">
 		<jar jarfile="${DEST}/codepoint.jar" filesonly="true">
 			<fileset dir="${build}" />
@@ -64,49 +92,17 @@ limitations under the License.
 			<fileset dir="../tools/" includes="*" />
 		</copy>
 	</target>
-	
-	<target name="extractUnicodeData" depends="getDependentLibs,init">
+
+	<target name="extractUnicodeData" depends="setUnicodeVersion,getDependentLibs,init">
 		<mkdir dir="${DEST}/data"/>
 
 		<copy todir="${DEST}/data">
-			<fileset dir="${LIB_DIR}" includes="UnicodeData-*.txt"/>
+			<fileset dir="${LIB_DIR}" includes="UnicodeData-${unicode.ver}.txt"/>
 		</copy>
 
-		<unzip src="${LIB_DIR}/Unihan-10.0.0.zip" dest="${DEST}/data">
+		<unzip src="${LIB_DIR}/Unihan-${unicode.ver}.zip" dest="${DEST}/data">
 			<patternset><include name="Unihan_IRGSources.txt"/></patternset>
-			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-10.0.0.txt"/>
-		</unzip>
-		<unzip src="${LIB_DIR}/Unihan-11.0.0.zip" dest="${DEST}/data">
-			<patternset><include name="Unihan_IRGSources.txt"/></patternset>
-			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-11.0.0.txt"/>
-		</unzip>
-		<unzip src="${LIB_DIR}/Unihan-12.1.0.zip" dest="${DEST}/data">
-			<patternset><include name="Unihan_IRGSources.txt"/></patternset>
-			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-12.1.0.txt"/>
-		</unzip>
-		<unzip src="${LIB_DIR}/Unihan-13.0.0.zip" dest="${DEST}/data">
-			<patternset><include name="Unihan_IRGSources.txt"/></patternset>
-			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-13.0.0.txt"/>
-		</unzip>
-		<unzip src="${LIB_DIR}/Unihan-14.0.0.zip" dest="${DEST}/data">
-			<patternset><include name="Unihan_IRGSources.txt"/></patternset>
-			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-14.0.0.txt"/>
-		</unzip>
-		<unzip src="${LIB_DIR}/Unihan-15.0.0.zip" dest="${DEST}/data">
-			<patternset><include name="Unihan_IRGSources.txt"/></patternset>
-			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-15.0.0.txt"/>
-		</unzip>
-		<unzip src="${LIB_DIR}/Unihan-15.1.0.zip" dest="${DEST}/data">
-			<patternset><include name="Unihan_IRGSources.txt"/></patternset>
-			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-15.1.0.txt"/>
-		</unzip>
-		<unzip src="${LIB_DIR}/Unihan-16.0.0.zip" dest="${DEST}/data">
-			<patternset><include name="Unihan_IRGSources.txt"/></patternset>
-			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-16.0.0.txt"/>
-		</unzip>
-		<unzip src="${LIB_DIR}/Unihan-17.0.0.zip" dest="${DEST}/data">
-			<patternset><include name="Unihan_IRGSources.txt"/></patternset>
-			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-17.0.0.txt"/>
+			<mapper type="glob" from="Unihan_IRGSources.txt" to="Unihan_IRGSources-${unicode.ver}.txt"/>
 		</unzip>
 
 		<copy todir="${DEST}/data">

--- a/functional/MBCS_Tests/unicode/build.xml
+++ b/functional/MBCS_Tests/unicode/build.xml
@@ -89,7 +89,7 @@ limitations under the License.
 		<mkdir dir="${DEST}/data"/>
 
 		<copy todir="${DEST}/data">
-			<fileset dir="${LIB_DIR}" includes="*.txt"/>
+			<fileset dir="${LIB_DIR}" includes="UnicodeData-${unicode.ver}.txt,Blocks-${unicode.ver}.txt,Scripts-${unicode.ver}.txt,NormalizationTest-${unicode.ver}.txt,PropertyValueAliases-${unicode.ver}.txt"/>
 		</copy>
 
 		<copy todir="${DEST}/data">

--- a/functional/MBCS_Tests/unicode/build.xml
+++ b/functional/MBCS_Tests/unicode/build.xml
@@ -26,7 +26,30 @@ limitations under the License.
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
 	<property name="build" location="./bin" />
-	<property name="LIB" value="unicode_ucd_unicodedata_10_0_0,unicode_ucd_unicodedata_11_0_0,unicode_ucd_unicodedata_12_1_0,unicode_ucd_unicodedata_13_0_0,unicode_ucd_unicodedata_14_0_0,unicode_ucd_unicodedata_15_0_0,unicode_ucd_unicodedata_15_1_0,unicode_ucd_unicodedata_16_0_0,unicode_ucd_unicodedata_17_0_0,unicode_ucd_blocks_10_0_0,unicode_ucd_blocks_11_0_0,unicode_ucd_blocks_12_1_0,unicode_ucd_blocks_13_0_0,unicode_ucd_blocks_14_0_0,unicode_ucd_blocks_15_0_0,unicode_ucd_blocks_15_1_0,unicode_ucd_blocks_16_0_0,unicode_ucd_blocks_17_0_0,unicode_ucd_scripts_10_0_0,unicode_ucd_scripts_11_0_0,unicode_ucd_scripts_12_1_0,unicode_ucd_scripts_13_0_0,unicode_ucd_scripts_14_0_0,unicode_ucd_scripts_15_0_0,unicode_ucd_scripts_15_1_0,unicode_ucd_scripts_16_0_0,unicode_ucd_scripts_17_0_0,unicode_ucd_normalization_10_0_0,unicode_ucd_normalization_11_0_0,unicode_ucd_normalization_12_1_0,unicode_ucd_normalization_13_0_0,unicode_ucd_normalization_14_0_0,unicode_ucd_normalization_15_0_0,unicode_ucd_normalization_15_1_0,unicode_ucd_normalization_16_0_0,unicode_ucd_normalization_17_0_0,unicode_ucd_propvalaliases_10_0_0,unicode_ucd_propvalaliases_11_0_0,unicode_ucd_propvalaliases_12_1_0,unicode_ucd_propvalaliases_13_0_0,unicode_ucd_propvalaliases_14_0_0,unicode_ucd_propvalaliases_15_0_0,unicode_ucd_propvalaliases_15_1_0,unicode_ucd_propvalaliases_16_0_0,unicode_ucd_propvalaliases_17_0_0"/>
+
+	<macrodef name="resolve-unicode-version">
+		<attribute name="jdk-version"/>
+		<sequential>
+			<condition property="unicode.ver" value="17.0.0"><matches string="@{jdk-version}" pattern="^(2[6-9]|[3-9][0-9])$"/></condition>
+			<condition property="unicode.ver" value="16.0.0"><matches string="@{jdk-version}" pattern="^2[4-5]$"/></condition>
+			<condition property="unicode.ver" value="15.1.0"><matches string="@{jdk-version}" pattern="^2[2-3]$"/></condition>
+			<condition property="unicode.ver" value="15.0.0"><matches string="@{jdk-version}" pattern="^2[0-1]$"/></condition>
+			<condition property="unicode.ver" value="14.0.0"><matches string="@{jdk-version}" pattern="^19$"/></condition>
+			<condition property="unicode.ver" value="13.0.0"><matches string="@{jdk-version}" pattern="^1[5-8]$"/></condition>
+			<condition property="unicode.ver" value="12.1.0"><matches string="@{jdk-version}" pattern="^1[3-4]$"/></condition>
+			<condition property="unicode.ver" value="11.0.0"><matches string="@{jdk-version}" pattern="^12$"/></condition>
+			<property name="unicode.ver" value="10.0.0"/>
+			<condition property="unicode.ver.key" value="17_0_0"><equals arg1="${unicode.ver}" arg2="17.0.0"/></condition>
+			<condition property="unicode.ver.key" value="16_0_0"><equals arg1="${unicode.ver}" arg2="16.0.0"/></condition>
+			<condition property="unicode.ver.key" value="15_1_0"><equals arg1="${unicode.ver}" arg2="15.1.0"/></condition>
+			<condition property="unicode.ver.key" value="15_0_0"><equals arg1="${unicode.ver}" arg2="15.0.0"/></condition>
+			<condition property="unicode.ver.key" value="14_0_0"><equals arg1="${unicode.ver}" arg2="14.0.0"/></condition>
+			<condition property="unicode.ver.key" value="13_0_0"><equals arg1="${unicode.ver}" arg2="13.0.0"/></condition>
+			<condition property="unicode.ver.key" value="12_1_0"><equals arg1="${unicode.ver}" arg2="12.1.0"/></condition>
+			<condition property="unicode.ver.key" value="11_0_0"><equals arg1="${unicode.ver}" arg2="11.0.0"/></condition>
+			<property name="unicode.ver.key" value="10_0_0"/>
+		</sequential>
+	</macrodef>
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -45,6 +68,11 @@ limitations under the License.
 		</javac>
 	</target>
 
+	<target name="setUnicodeVersion">
+		<resolve-unicode-version jdk-version="${JDK_VERSION}"/>
+		<property name="LIB" value="unicode_ucd_unicodedata_${unicode.ver.key},unicode_ucd_blocks_${unicode.ver.key},unicode_ucd_scripts_${unicode.ver.key},unicode_ucd_normalization_${unicode.ver.key},unicode_ucd_propvalaliases_${unicode.ver.key}"/>
+	</target>
+
 	<target name="dist" depends="compile,extractUnicodeData" description="generate the distribution">
 		<jar jarfile="${DEST}/unicode.jar" filesonly="true">
 			<fileset dir="${build}" />
@@ -56,12 +84,12 @@ limitations under the License.
 			<fileset dir="../tools/" includes="*" />
 		</copy>
 	</target>
-	
-	<target name="extractUnicodeData" depends="getDependentLibs,init">
+
+	<target name="extractUnicodeData" depends="setUnicodeVersion,getDependentLibs,init">
 		<mkdir dir="${DEST}/data"/>
 
 		<copy todir="${DEST}/data">
-			<fileset dir="${LIB_DIR}" includes="UnicodeData-*.txt,Blocks-*.txt,Scripts-*.txt,NormalizationTest-*.txt,PropertyValueAliases-*.txt"/>
+			<fileset dir="${LIB_DIR}" includes="*.txt"/>
 		</copy>
 
 		<copy todir="${DEST}/data">

--- a/functional/MBCS_Tests/unicode/build.xml
+++ b/functional/MBCS_Tests/unicode/build.xml
@@ -18,6 +18,7 @@ limitations under the License.
 	MBCS_Tests/unicode
         </description>
 
+	<import file="${TEST_ROOT}/functional/MBCS_Tests/unicodeVers.xml"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
 	<!-- set global properties for this build -->
@@ -26,30 +27,6 @@ limitations under the License.
 	<!--Properties for this particular build-->
 	<property name="src" location="./src" />
 	<property name="build" location="./bin" />
-
-	<macrodef name="resolve-unicode-version">
-		<attribute name="jdk-version"/>
-		<sequential>
-			<condition property="unicode.ver" value="17.0.0"><matches string="@{jdk-version}" pattern="^(2[6-9]|[3-9][0-9])$"/></condition>
-			<condition property="unicode.ver" value="16.0.0"><matches string="@{jdk-version}" pattern="^2[4-5]$"/></condition>
-			<condition property="unicode.ver" value="15.1.0"><matches string="@{jdk-version}" pattern="^2[2-3]$"/></condition>
-			<condition property="unicode.ver" value="15.0.0"><matches string="@{jdk-version}" pattern="^2[0-1]$"/></condition>
-			<condition property="unicode.ver" value="14.0.0"><matches string="@{jdk-version}" pattern="^19$"/></condition>
-			<condition property="unicode.ver" value="13.0.0"><matches string="@{jdk-version}" pattern="^1[5-8]$"/></condition>
-			<condition property="unicode.ver" value="12.1.0"><matches string="@{jdk-version}" pattern="^1[3-4]$"/></condition>
-			<condition property="unicode.ver" value="11.0.0"><matches string="@{jdk-version}" pattern="^12$"/></condition>
-			<property name="unicode.ver" value="10.0.0"/>
-			<condition property="unicode.ver.key" value="17_0_0"><equals arg1="${unicode.ver}" arg2="17.0.0"/></condition>
-			<condition property="unicode.ver.key" value="16_0_0"><equals arg1="${unicode.ver}" arg2="16.0.0"/></condition>
-			<condition property="unicode.ver.key" value="15_1_0"><equals arg1="${unicode.ver}" arg2="15.1.0"/></condition>
-			<condition property="unicode.ver.key" value="15_0_0"><equals arg1="${unicode.ver}" arg2="15.0.0"/></condition>
-			<condition property="unicode.ver.key" value="14_0_0"><equals arg1="${unicode.ver}" arg2="14.0.0"/></condition>
-			<condition property="unicode.ver.key" value="13_0_0"><equals arg1="${unicode.ver}" arg2="13.0.0"/></condition>
-			<condition property="unicode.ver.key" value="12_1_0"><equals arg1="${unicode.ver}" arg2="12.1.0"/></condition>
-			<condition property="unicode.ver.key" value="11_0_0"><equals arg1="${unicode.ver}" arg2="11.0.0"/></condition>
-			<property name="unicode.ver.key" value="10_0_0"/>
-		</sequential>
-	</macrodef>
 
 	<target name="init">
 		<mkdir dir="${DEST}" />

--- a/functional/MBCS_Tests/unicodeVers.xml
+++ b/functional/MBCS_Tests/unicodeVers.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<project name="MBCS_Tests_unicodeVers" default="none" basedir=".">
+	<target name="none"/>
+
+	<macrodef name="resolve-unicode-version">
+		<attribute name="jdk-version"/>
+		<sequential>
+			<condition property="unicode.ver" value="17.0.0"><matches string="@{jdk-version}" pattern="^(2[6-9]|[3-9][0-9])$"/></condition>
+			<condition property="unicode.ver" value="16.0.0"><matches string="@{jdk-version}" pattern="^2[4-5]$"/></condition>
+			<condition property="unicode.ver" value="15.1.0"><matches string="@{jdk-version}" pattern="^2[2-3]$"/></condition>
+			<condition property="unicode.ver" value="15.0.0"><matches string="@{jdk-version}" pattern="^2[0-1]$"/></condition>
+			<condition property="unicode.ver" value="14.0.0"><matches string="@{jdk-version}" pattern="^19$"/></condition>
+			<condition property="unicode.ver" value="13.0.0"><matches string="@{jdk-version}" pattern="^1[5-8]$"/></condition>
+			<condition property="unicode.ver" value="12.1.0"><matches string="@{jdk-version}" pattern="^1[3-4]$"/></condition>
+			<condition property="unicode.ver" value="11.0.0"><matches string="@{jdk-version}" pattern="^12$"/></condition>
+			<property name="unicode.ver" value="10.0.0"/>
+			<loadresource property="unicode.ver.key">
+				<propertyresource name="unicode.ver"/>
+				<filterchain><tokenfilter><replacestring from="." to="_"/></tokenfilter></filterchain>
+			</loadresource>
+		</sequential>
+	</macrodef>
+</project>


### PR DESCRIPTION
Depends on adoptium/TKG#847

Replace the hard-coded `LIB` property in `codepoint/build.xml` and
`unicode/build.xml` with a `resolve-unicode-version` macrodef that maps
`JDK_VERSION` to the correct Unicode version at build time. Neither file
needs to change when a new JDK or Unicode version is added — only
`UnicodeVers.properties` and `getDependencies.pl` need updating.

**unicode/build.xml**
- Added `resolve-unicode-version` macrodef and `setUnicodeVersion` target
- Removed 45-entry hard-coded `LIB`
- Narrowed `extractUnicodeData` fileset from `*.txt` to the 5
  resolved-version filenames to avoid picking up stale cached files

**codepoint/build.xml**
- Added same macrodef and `setUnicodeVersion` target
- Removed 19-entry hard-coded `LIB`
- Collapsed 9 `<unzip>` blocks to a single `<unzip src="${LIB_DIR}/Unihan-${unicode.ver}.zip">`

**update:**
This work is PR'd to keep my working implementation in this stage while I work on the //shared file version// shared version is complete

Tested on Jenkins: (unicode/codepoint tests)
https://ci.adoptium.net/job/Grinder/17510/ 
Passed


Some portions generated by IBM Bob