### PR TITLE
Force child jobs to use USE_TESTENV_PROPERTIES=true

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -22,7 +22,7 @@ def MODE = params.MODE ? params.MODE : "ENTRYPOINT"
 SDK_RESOURCE = params.SDK_RESOURCE ? params.SDK_RESOURCE : "releases"
 TIME_LIMIT = params.TIME_LIMIT ? params.TIME_LIMIT : 10
 AUTO_AQA_GEN = params.AUTO_AQA_GEN ? params.AUTO_AQA_GEN.toBoolean() : false
-LIGHT_WEIGHT_CHECKOUT = params.LIGHT_WEIGHT_CHECKOUT ?: true
+LIGHT_WEIGHT_CHECKOUT = params.LIGHT_WEIGHT_CHECKOUT != null ? params.LIGHT_WEIGHT_CHECKOUT.toBoolean() : true
 
 // Use BUILD_USER_ID if set and jdk-JDK_VERSIONS
 def DEFAULT_SUFFIX = (env.BUILD_USER_ID) ? "${env.BUILD_USER_ID} - jdk-${params.JDK_VERSIONS}" : "jdk-${params.JDK_VERSIONS}"
@@ -525,7 +525,7 @@ def generateJobs(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets, globalBui
                 def childParams = []
                 // loop through all the params and change the parameters if needed
                 params.each { param ->
-                    if ( param.key == "PLATFORMS" || param.key == "TARGETS" || param.key == "TOP_LEVEL_SDK_URL" 
+                    if ( param.key == "PLATFORMS" || param.key == "TARGETS" || param.key == "TOP_LEVEL_SDK_URL"
                     || param.key == "AUTO_AQA_GEN" || param.key == "JDK_VERSIONS" || param.key == "VARIANT" || param.key == "PIPELINE_DISPLAY_NAME") {
                         // do not need to pass the param to child jobs
                     } else if (param.key == "SDK_RESOURCE") {
@@ -540,6 +540,10 @@ def generateJobs(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets, globalBui
                         childParams << booleanParam(name: param.key, value: LIGHT_WEIGHT_CHECKOUT.toBoolean())
                     } else if (param.key == "TIME_LIMIT") {
                         childParams << string(name: param.key, value: TIME_LIMIT.toString())
+                    } else if (param.key == "USE_TESTENV_PROPERTIES") {
+                        // Pipeline parameter true always wins; otherwise fall back to JSON config value.
+                        def useTestEnv = params.USE_TESTENV_PROPERTIES ? true : (buildConfig.USE_TESTENV_PROPERTIES != null ? buildConfig.USE_TESTENV_PROPERTIES.toBoolean() : false)
+                        childParams << booleanParam(name: param.key, value: useTestEnv)
                     } else {
                         def value = param.value.toString()
                         if (value == "true" || value == "false") {
@@ -582,9 +586,6 @@ def generateJobs(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets, globalBui
                 }
                 if (buildConfig.ACTIVE_NODE_TIMEOUT) {
                     childParams << string(name: "ACTIVE_NODE_TIMEOUT", value: buildConfig.ACTIVE_NODE_TIMEOUT.toString())
-                }
-                if (buildConfig.USE_TESTENV_PROPERTIES != null) {
-                    childParams << booleanParam(name: "USE_TESTENV_PROPERTIES", value: buildConfig.USE_TESTENV_PROPERTIES.toBoolean())
                 }
                 if (buildConfig.ADOPTOPENJDK_BRANCH) {
                     childParams << string(name: "ADOPTOPENJDK_BRANCH", value: buildConfig.ADOPTOPENJDK_BRANCH)

--- a/buildenv/jenkins/config/openj9/default.json
+++ b/buildenv/jenkins/config/openj9/default.json
@@ -17,7 +17,7 @@
             "PARALLEL": "Dynamic",
             "NUM_MACHINES": "3",
             "TEST_TIME": "120",
-            "USE_TESTENV_PROPERTIES": false,
+            "USE_TESTENV_PROPERTIES": true,
             "ACTIVE_NODE_TIMEOUT": "1",
             "DYNAMIC_COMPILE": false,
             "RERUN_FAILURE": true,


### PR DESCRIPTION
- Addresses regression introduced by PR https://github.com/adoptium/aqa-tests/pull/7087 where openj9/default.json
was created with USE_TESTENV_PROPERTIES: false, causing child jobs to
fall back to stale getDependencies.xml instead of testenv.properties

fixes: https://github.com/eclipse-openj9/openj9/issues/24276