### PR TITLE
[v1.0.14-release] Skip download tap.zip

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -337,7 +337,7 @@ getBinaryOpenjdk()
 						if [ "$TEST_IMAGES_REQUIRED" == "true" ]; then
 							download_url+=" ${download_url_base}${n}"
 						fi
-					elif [[ $n != *"install"* && $n != *"unsigned"* ]]; then
+					elif [[ $n != *"install"* && $n != *"unsigned"* && $n != *"tap"* ]]; then
 						download_url+=" ${download_url_base}${n}"
 					fi
 				done


### PR DESCRIPTION
Exclude the tap.zip name from download because in test pipeline unrecognized zip is treated as SDK. 

Cherry-pick of https://github.com/adoptium/aqa-tests/pull/7152 to v1.0.14-release.

Triggered by @Amrutha-Kanhirathingal  via https://github.com/adoptium/aqa-tests/pull/7152#issuecomment-4846697127