### PR TITLE
Update OpenJ9 Valhalla test failures

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -44,7 +44,9 @@ com/sun/jdi/valhalla/ValueClassTypeTest.java https://github.com/adoptium/aqa-tes
 # hotspot_valhalla_runtime_j9 - runtime/valhalla
 
 ############################################################################
+runtime/valhalla/inlinetypes/ArrayCopyStoreNull.java https://github.com/eclipse-openj9/openj9/issues/24255 generic-all
 runtime/valhalla/inlinetypes/InlineTypesTest.java#force-non-tearable https://github.com/eclipse-openj9/openj9/issues/24089 generic-all
+runtime/valhalla/inlinetypes/TestArrayFactories.java https://github.com/eclipse-openj9/openj9/issues/24086 generic-all
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/23952 generic-all
 
 ############################################################################
@@ -157,6 +159,7 @@ runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java#id0 https://github
 runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java#id1 https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/TestFlatArrayElementMaxOops.java#id2 https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/TestFlatteningBudget.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+runtime/valhalla/inlinetypes/TestFinalizableValues.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/ValuePreloadTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 runtime/valhalla/inlinetypes/VolatileTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 valhalla/valuetypes/SubstitutabilityTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
- exclude runtime/valhalla/inlinetypes/ArrayCopyStoreNull.java until https://github.com/eclipse-openj9/openj9/issues/24255 is resolved
- exclude runtime/valhalla/inlinetypes/TestArrayFactories.java until https://github.com/eclipse-openj9/openj9/issues/24086 is resolved
- permanently exclude runtime/valhalla/inlinetypes/TestFinalizableValues.java which can't be run by OpenJ9

Failures from internal test run: https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Test_JDKnext_valhalla_openjdk_x86-64_linux/128/