### PR TITLE
Limit external Tomcat & Derby tests to startup verification

### DIFF
--- a/external/derby/playlist.xml
+++ b/external/derby/playlist.xml
@@ -15,7 +15,12 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<test>
 		<testCaseName>derby_test_junit_all</testCaseName>
-		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir derby --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/7243</comment>
+			</disable>
+		</disables>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir derby --testtarget full --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir derby
 		</command>

--- a/external/derby/playlist.xml
+++ b/external/derby/playlist.xml
@@ -14,6 +14,22 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<test>
+		<testCaseName>derby_startup_test</testCaseName>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir derby --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir derby
+		</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<versions>
+			<version>9+</version>
+		</versions>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>derby_test_junit_all</testCaseName>
 		<disables>
 			<disable>

--- a/external/derby/test.sh
+++ b/external/derby/test.sh
@@ -29,9 +29,14 @@ export CLASSPATH="${jardir}/derbyrun.jar:${jardir}/derbyTesting.jar:${tstjardir}
 TEST_TARGET="${1:-smoke}"
 
 set -e
+java -jar "${TEST_HOME}/jars/sane/derbyrun.jar" sysinfo
+set +e
+
 if [ "$TEST_TARGET" = "full" ]; then
 	#Run all tests
 	ant -Dderby.tests.basePort=1690 -Dderby.system.durability=test -DderbyTesting.oldReleasePath=${TEST_HOME}/jars junit-all
-else
-	java -jar "${TEST_HOME}/jars/sane/derbyrun.jar" sysinfo
+	test_exit_code=$?
+	#Run only derbylang suite
+	#java -Dverbose=true -cp ${jardir}/derbyrun.jar:${jardir}/derbyTesting.jar:$tstjardir/junit.jar org.apache.derbyTesting.functionTests.harness.RunSuite #derbylang
+	exit $test_exit_code
 fi

--- a/external/derby/test.sh
+++ b/external/derby/test.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/external/derby/test.sh
+++ b/external/derby/test.sh
@@ -15,22 +15,23 @@
 source $(dirname "$0")/test_base_functions.sh
 #Set up Java to be used by the derby test
 echo_setup
-#clean previous build artifacts 
+#clean previous build artifacts
 ant -f build.xml clobber
 #build all
 ant -f build.xml all
 #create jars
 ant -f build.xml buildjars
 
-export jardir ${TEST_HOME}/jars/sane 
-export tstjardir ${TEST_HOME}/tools/java 
-export CLASSPATH "${jardir}/derbyrun.jar:${jardir}/derbyTesting.jar:${tstjardir}/junit.jar"
-java -jar ${TEST_HOME}/jars/sane/derbyrun.jar sysinfo
+export jardir="${TEST_HOME}/jars/sane"
+export tstjardir="${TEST_HOME}/tools/java"
+export CLASSPATH="${jardir}/derbyrun.jar:${jardir}/derbyTesting.jar:${tstjardir}/junit.jar"
+
+TEST_TARGET="${1:-smoke}"
 
 set -e
-#Run all tests
-ant -Dderby.tests.basePort=1690 -Dderby.system.durability=test -DderbyTesting.oldReleasePath=${TEST_HOME}/jars junit-all
-set +e
-#Run only derbylang suite
-#java -Dverbose=true -cp ${jardir}/derbyrun.jar:${jardir}/derbyTesting.jar:$tstjardir/junit.jar org.apache.derbyTesting.functionTests.harness.RunSuite #derbylang
-
+if [ "$TEST_TARGET" = "full" ]; then
+	#Run all tests
+	ant -Dderby.tests.basePort=1690 -Dderby.system.durability=test -DderbyTesting.oldReleasePath=${TEST_HOME}/jars junit-all
+else
+	java -jar "${TEST_HOME}/jars/sane/derbyrun.jar" sysinfo
+fi

--- a/external/derby/test.sh
+++ b/external/derby/test.sh
@@ -33,10 +33,10 @@ java -jar "${TEST_HOME}/jars/sane/derbyrun.jar" sysinfo
 set +e
 
 if [ "$TEST_TARGET" = "full" ]; then
+	set -e
 	#Run all tests
 	ant -Dderby.tests.basePort=1690 -Dderby.system.durability=test -DderbyTesting.oldReleasePath=${TEST_HOME}/jars junit-all
-	test_exit_code=$?
 	#Run only derbylang suite
 	#java -Dverbose=true -cp ${jardir}/derbyrun.jar:${jardir}/derbyTesting.jar:$tstjardir/junit.jar org.apache.derbyTesting.functionTests.harness.RunSuite #derbylang
-	exit $test_exit_code
+	set +e
 fi

--- a/external/tomcat/playlist.xml
+++ b/external/tomcat/playlist.xml
@@ -15,7 +15,12 @@
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<test>
 		<testCaseName>tomcat_test</testCaseName>
-		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir tomcat --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
+		<disables>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/7243</comment>
+			</disable>
+		</disables>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir tomcat --testtarget full --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
 		$(TEST_STATUS); \
 		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir tomcat
 		</command>

--- a/external/tomcat/playlist.xml
+++ b/external/tomcat/playlist.xml
@@ -14,6 +14,19 @@
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/resources/playlist.xsd">
 	<test>
+		<testCaseName>tomcat_startup_test</testCaseName>
+		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --dir tomcat --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)" ; \
+		$(TEST_STATUS); \
+		$(TEST_ROOT)$(D)external$(D)external.sh --clean --tag "${DOCKERIMAGE_TAG}" --dir tomcat
+		</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>external</group>
+		</groups>
+	</test>
+	<test>
 		<testCaseName>tomcat_test</testCaseName>
 		<disables>
 			<disable>

--- a/external/tomcat/test.properties
+++ b/external/tomcat/test.properties
@@ -1,6 +1,6 @@
 github_url="https://github.com/apache/tomcat.git"
 tag_version="10.0.7"
-generic_packages="openssl make gcc perl automake autoconf subversion git wget tar"
+generic_packages="openssl make gcc perl automake autoconf subversion git wget tar curl"
 ubuntu_packages="ant-optional linux-libc-dev libc6-dev build-essential libssl-dev libtool-bin"
 fedora_packages="glibc glibc-devel openssl-devel libtool"
 (fedora|ubi|rhel|centos)_packages=make automake gcc gcc-c++ kernel-devel

--- a/external/tomcat/test.sh
+++ b/external/tomcat/test.sh
@@ -49,6 +49,7 @@ if [ "$TEST_TARGET" = "full" ]; then
 	echo "Running tomcat tests"
 	#Run tests
 	ant test
+	set +e
 else
 	echo "Building tomcat" && \
 	ant

--- a/external/tomcat/test.sh
+++ b/external/tomcat/test.sh
@@ -16,34 +16,62 @@ source $(dirname "$0")/test_base_functions.sh
 #Set up Java to be used by the tomcat test
 echo_setup
 
-git clone -q -b 1.6.x --single-branch https://github.com/apache/apr.git $TEST_HOME/tmp/apr
-cd $TEST_HOME/tmp/apr
-./buildconf
-./configure --prefix=$TEST_HOME/tmp/apr-build
-make
-make install
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$TEST_HOME/tmp/apr-build/lib"
-
-git clone -q https://github.com/apache/tomcat-native.git $TEST_HOME/tmp/tomcat-native
-cd $TEST_HOME/tmp/tomcat-native/native
-sh buildconf --with-apr=$TEST_HOME/tmp/apr
-./configure --with-apr=$TEST_HOME/tmp/apr --with-java-home=$JAVA_HOME --with-ssl=yes --prefix=$TEST_HOME/tmp/tomcat-native-build
-make
-make install
-cd $TEST_HOME
-yes | cp build.properties.default build.properties
-echo >> build.properties
-echo "test.threads=4" >> build.properties
-echo "test.relaxTiming=true" >> build.properties
-echo "test.excludePerformance=true" >> build.properties
-echo "test.openssl.path=/dev/null/openssl" >> build.properties
-echo "test.apr.loc=$TEST_HOME/tmp/tomcat-native-build/lib" >> build.properties
+TEST_TARGET="${1:-smoke}"
 
 set -e
-echo "Building tomcat" && \
-ant && \
+if [ "$TEST_TARGET" = "full" ]; then
+	git clone -q -b 1.6.x --single-branch https://github.com/apache/apr.git $TEST_HOME/tmp/apr
+	cd $TEST_HOME/tmp/apr
+	./buildconf
+	./configure --prefix=$TEST_HOME/tmp/apr-build
+	make
+	make install
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$TEST_HOME/tmp/apr-build/lib"
 
-echo "Running tomcat tests" 
-#Run tests
-ant test
-set +e
+	git clone -q https://github.com/apache/tomcat-native.git $TEST_HOME/tmp/tomcat-native
+	cd $TEST_HOME/tmp/tomcat-native/native
+	sh buildconf --with-apr=$TEST_HOME/tmp/apr
+	./configure --with-apr=$TEST_HOME/tmp/apr --with-java-home=$JAVA_HOME --with-ssl=yes --prefix=$TEST_HOME/tmp/tomcat-native-build
+	make
+	make install
+	cd $TEST_HOME
+	yes | cp build.properties.default build.properties
+	echo >> build.properties
+	echo "test.threads=4" >> build.properties
+	echo "test.relaxTiming=true" >> build.properties
+	echo "test.excludePerformance=true" >> build.properties
+	echo "test.openssl.path=/dev/null/openssl" >> build.properties
+	echo "test.apr.loc=$TEST_HOME/tmp/tomcat-native-build/lib" >> build.properties
+
+	echo "Building tomcat" && \
+	ant && \
+
+	echo "Running tomcat tests"
+	#Run tests
+	ant test
+else
+	echo "Building tomcat" && \
+	ant
+	set +e
+
+	TOMCAT_BUILD_DIR="${TEST_HOME}/output/build"
+
+	cleanup() {
+		"${TOMCAT_BUILD_DIR}/bin/catalina.sh" stop || true
+	}
+	trap cleanup EXIT
+
+	echo "Starting Tomcat"
+	cd "${TOMCAT_BUILD_DIR}"
+	bin/catalina.sh start
+
+	echo "Waiting for Tomcat to respond at ${TOMCAT_URL:-http://localhost:8080/}"
+	if timeout "${STARTUP_TIMEOUT:-120}" bash -c "until curl -sf '${TOMCAT_URL:-http://localhost:8080/}' >/dev/null; do sleep 2; done"; then
+		echo "Tomcat startup verification PASSED"
+		exit 0
+	else
+		echo "Tomcat startup verification FAILED"
+		tail -n 200 logs/catalina.out || true
+		exit 1
+	fi
+fi

--- a/external/tomcat/test.sh
+++ b/external/tomcat/test.sh
@@ -43,17 +43,18 @@ if [ "$TEST_TARGET" = "full" ]; then
 	echo "test.openssl.path=/dev/null/openssl" >> build.properties
 	echo "test.apr.loc=${TEST_HOME}/tmp/tomcat-native-build/lib" >> build.properties
 
-	echo "Building tomcat" && \
-	ant && \
+	echo "Building tomcat"
+	ant
 
 	echo "Running tomcat tests"
 	#Run tests
 	ant test
+	test_exit_code=$?
 	set +e
+	exit $test_exit_code
 else
-	echo "Building tomcat" && \
+	echo "Building tomcat"
 	ant
-	set +e
 
 	TOMCAT_BUILD_DIR="${TEST_HOME}/output/build"
 
@@ -65,6 +66,7 @@ else
 	echo "Starting Tomcat"
 	cd "${TOMCAT_BUILD_DIR}"
 	bin/catalina.sh start
+	set +e
 
 	echo "Waiting for Tomcat to respond at ${TOMCAT_URL:-http://localhost:8080/}"
 	if timeout "${STARTUP_TIMEOUT:-120}" bash -c "until curl -sf '${TOMCAT_URL:-http://localhost:8080/}' >/dev/null; do sleep 2; done"; then

--- a/external/tomcat/test.sh
+++ b/external/tomcat/test.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -20,28 +20,28 @@ TEST_TARGET="${1:-smoke}"
 
 set -e
 if [ "$TEST_TARGET" = "full" ]; then
-	git clone -q -b 1.6.x --single-branch https://github.com/apache/apr.git $TEST_HOME/tmp/apr
-	cd $TEST_HOME/tmp/apr
+	git clone -q -b 1.6.x --single-branch https://github.com/apache/apr.git "${TEST_HOME}/tmp/apr"
+	cd "${TEST_HOME}/tmp/apr"
 	./buildconf
-	./configure --prefix=$TEST_HOME/tmp/apr-build
+	./configure --prefix="${TEST_HOME}/tmp/apr-build"
 	make
 	make install
-	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$TEST_HOME/tmp/apr-build/lib"
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${TEST_HOME}/tmp/apr-build/lib"
 
-	git clone -q https://github.com/apache/tomcat-native.git $TEST_HOME/tmp/tomcat-native
-	cd $TEST_HOME/tmp/tomcat-native/native
-	sh buildconf --with-apr=$TEST_HOME/tmp/apr
-	./configure --with-apr=$TEST_HOME/tmp/apr --with-java-home=$JAVA_HOME --with-ssl=yes --prefix=$TEST_HOME/tmp/tomcat-native-build
+	git clone -q https://github.com/apache/tomcat-native.git "${TEST_HOME}/tmp/tomcat-native"
+	cd "${TEST_HOME}/tmp/tomcat-native/native"
+	sh buildconf --with-apr="${TEST_HOME}/tmp/apr"
+	./configure --with-apr="${TEST_HOME}/tmp/apr" --with-java-home=$JAVA_HOME --with-ssl=yes --prefix="${TEST_HOME}/tmp/tomcat-native-build"
 	make
 	make install
-	cd $TEST_HOME
+	cd "${TEST_HOME}"
 	yes | cp build.properties.default build.properties
 	echo >> build.properties
 	echo "test.threads=4" >> build.properties
 	echo "test.relaxTiming=true" >> build.properties
 	echo "test.excludePerformance=true" >> build.properties
 	echo "test.openssl.path=/dev/null/openssl" >> build.properties
-	echo "test.apr.loc=$TEST_HOME/tmp/tomcat-native-build/lib" >> build.properties
+	echo "test.apr.loc=${TEST_HOME}/tmp/tomcat-native-build/lib" >> build.properties
 
 	echo "Building tomcat" && \
 	ant && \

--- a/external/tomcat/test.sh
+++ b/external/tomcat/test.sh
@@ -49,9 +49,7 @@ if [ "$TEST_TARGET" = "full" ]; then
 	echo "Running tomcat tests"
 	#Run tests
 	ant test
-	test_exit_code=$?
 	set +e
-	exit $test_exit_code
 else
 	echo "Building tomcat"
 	ant


### PR DESCRIPTION
## Summary
Implements startup-only verification for two external tests (Tomcat and Derby). This addresses the roadmap item listed in external/README.md — "Startup-only testing (application startup, but not full runs of app functional testing)" — and tracks issue #7243.

## Changes
'external/tomcat/' - server-style startup verification
- test.sh: Replaces ant test (full upstream Tomcat test suite) with a start/curl/stop sequence.
- Builds Tomcat from source with ant, starts the server via catalina.sh start, polls http://localhost:8080/ until it responds, then shuts down. A trap cleanup EXIT ensures the servers always stopped. Exits 0 on success, 1 on timeout.
- test.properties: Adds curl to generic_packages (required for the HTTP readiness check).
playlist.xml: Keeps tomcat_test at extended level, disabled. Remove disables block to reenable

'external/derby/' — tool-style startup verification
- test.sh: Retains the full build sequence (ant clobber, ant all, ant buildjars) The startup signal is java -jar derbyrun.jar sysinfo — Derby's own JVM diagnostic tool, which exercises class loading and runtime reflection.
- playlist.xml: Adds derby_startup_test at extended level. derby_test_junit_all is at extended level, disabled

## Reason
The full upstream test suites test the applications themselves, not the JDK. A failure in a Tomcat or Derby unit test is almost certainly an application-level issue, not a JDK defect. What Adoptium needs to verify is: can this JDK launch this application without crashing? A startup check that's much faster than running entire test suite

This is the first "attempt/implementation" of the startup-only pattern listed in 'external/README.md' as planned improvement

## Phase 2 -> extending to the other tests that follow similar patterns
The tool-style pattern extends directly to:
- JaCoCo — mvn install -DskipTests then java -javaagent:org.jacoco.agent.jar -version to verify the agent attaches
- Kafka — remove ./gradlew test; verify the built JAR loads cleanly
- Zookeeper — mvn package -DskipTests then verify the built JAR

The server-style pattern extends directly to:
- WildFly — start standalone.sh, curl management port 9990, stop
- Elasticsearch — ./gradlew assemble already exists in the script; start the node, curl port 9200, stop

Parts assisted by IBM Bob