### PR TITLE
Enable ValueClassPreviewTest.java and TestArrayFactories.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -19,7 +19,6 @@
 # jdk_valhalla_j9 - valhalla
 
 ############################################################################
-valhalla/valuetypes/ValueClassPreviewTest.java https://github.com/eclipse-openj9/openj9/issues/24086 generic-all
 valhalla/valuetypes/ValueObjectMethodsTest.java https://github.com/eclipse-openj9/openj9/issues/24087 generic-all
 
 ############################################################################
@@ -46,7 +45,6 @@ com/sun/jdi/valhalla/ValueClassTypeTest.java https://github.com/adoptium/aqa-tes
 ############################################################################
 runtime/valhalla/inlinetypes/ArrayCopyStoreNull.java https://github.com/eclipse-openj9/openj9/issues/24255 generic-all
 runtime/valhalla/inlinetypes/InlineTypesTest.java#force-non-tearable https://github.com/eclipse-openj9/openj9/issues/24089 generic-all
-runtime/valhalla/inlinetypes/TestArrayFactories.java https://github.com/eclipse-openj9/openj9/issues/24086 generic-all
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/23952 generic-all
 
 ############################################################################


### PR DESCRIPTION
Enable ValueClassPreviewTest.java
Enable TestArrayFactories.java

Fixed by:eclipse-openj9/openj9/pull/24228

Passing test:

ValueClassPreviewTest.java:https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/61200/
TestArrayFactories.java: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/61206/
