### PR TITLE
Restore default temurin time limit to the standard 25 hours

### DIFF
--- a/buildenv/jenkins/config/temurin/default.json
+++ b/buildenv/jenkins/config/temurin/default.json
@@ -18,7 +18,7 @@
             "RERUN_FAILURE": true,
             "RERUN_ITERATIONS": "1",
             "BUILD_LIST": "",
-            "TIME_LIMIT": "10",
+            "TIME_LIMIT": "25",
             "GENERATE_JOBS": false,
             "ADDITIONAL_TEST_PARAMS": {}
         },


### PR DESCRIPTION
The upgrade to decoupled test execution has decreased the time limit from 25 hours to 10, and timeouts have subsequently been noticed on windows.

Restoring the original 25 hours as a cross-platform default.