### PR TITLE
Enable InlineTypesTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -44,7 +44,6 @@ com/sun/jdi/valhalla/ValueClassTypeTest.java https://github.com/adoptium/aqa-tes
 
 ############################################################################
 runtime/valhalla/inlinetypes/ArrayCopyStoreNull.java https://github.com/eclipse-openj9/openj9/issues/24255 generic-all
-runtime/valhalla/inlinetypes/InlineTypesTest.java#force-non-tearable https://github.com/eclipse-openj9/openj9/issues/24089 generic-all
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/23952 generic-all
 
 ############################################################################


### PR DESCRIPTION
Fixed by: eclipse-openj9/openj9#24170

Passing Test: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/61268/testReport/runtime_valhalla_inlinetypes_InlineTypesTest/java_force-non-tearable/