### PR TITLE
Clean up openjdk problemlist files

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk11-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk11-openj9.txt
@@ -172,9 +172,7 @@ javax/management/security/HashedPasswordFileTest.java https://github.com/adoptiu
 java/net/DatagramSocket/SetGetSendBufferSize.java https://github.com/adoptium/aqa-tests/issues/2245 macosx-all
 java/net/Inet4Address/PingThis.java	https://github.ibm.com/runtimes/backlog/issues/1595	aix-all
 java/net/InetAddress/CheckJNI.java https://github.ibm.com/runtimes/backlog/issues/684 macosx-all
-# java/net/Inet6Address/B6206527.java on macosx-all issue https://github.com/adoptium/aqa-tests/issues/1524
-# java/net/Inet6Address/B6206527.java on macosx-all issue https://github.com/adoptium/infrastructure/issues/1085
-java/net/Inet6Address/B6206527.java https://github.com/adoptium/infrastructure/issues/1105 linux-all,macosx-all
+java/net/Inet6Address/B6206527.java	https://github.com/adoptium/aqa-tests/issues/1524,https://github.com/adoptium/infrastructure/issues/1085,https://github.com/adoptium/infrastructure/issues/1105	linux-all,macosx-all
 java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/adoptium/aqa-tests/issues/2246 aix-all,linux-s390x
 java/net/NetworkInterface/UniqueMacAddressesTest.java https://github.ibm.com/runtimes/backlog/issues/719 macosx-all
@@ -190,9 +188,7 @@ java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclip
 java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/HttpURLConnection/HttpURLConWithProxy.java  https://github.com/eclipse-openj9/openj9/issues/10860  generic-all
-# java/net/ipv6tests/B6521014.java on macosx-all issue	https://github.com/adoptium/aqa-tests/issues/1524
-# java/net/ipv6tests/B6521014.java on macosx-all issue https://github.com/adoptium/infrastructure/issues/1085
-java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issues/1105 linux-all,macosx-all
+java/net/ipv6tests/B6521014.java	https://github.com/adoptium/aqa-tests/issues/1524,https://github.com/adoptium/infrastructure/issues/1085,https://github.com/adoptium/infrastructure/issues/1105	linux-all,macosx-all
 com/sun/net/httpserver/bugs/B6361557.java	https://github.com/adoptium/aqa-tests/issues/1272	windows-all
 
 ############################################################################
@@ -220,20 +216,13 @@ java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/eclipse-openj9/openj9/issues/4473 generic-all
 java/nio/Buffer/LimitDirectMemory.java	https://github.com/eclipse-openj9/openj9/issues/8063	generic-all
 java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse-openj9/openj9/issues/8065	generic-all
-#java/nio/channels/AsyncCloseAndInterrupt.java is excluded for aix-all because of https://github.com/eclipse-openj9/openj9/issues/21777
-java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/6092 aix-all,z/OS-s390x
+java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/eclipse-openj9/openj9/issues/21777,https://github.com/adoptium/aqa-tests/issues/6092	aix-all,z/OS-s390x
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.ibm.com/runtimes/backlog/issues/1622 windows-all
-#java/nio/channels/DatagramChannel/BasicMulticastTests.java  on macosx-all under https://github.ibm.com/runtimes/backlog/issues/1053
-java/nio/channels/DatagramChannel/BasicMulticastTests.java https://github.ibm.com/runtimes/backlog/issues/1622 aix-all,macosx-all,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669  https://github.com/adoptium/aqa-tests/issues/1297
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 generic-all
+java/nio/channels/DatagramChannel/BasicMulticastTests.java	https://github.ibm.com/runtimes/backlog/issues/1053,https://github.ibm.com/runtimes/backlog/issues/1622	aix-all,macosx-all,windows-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.com/adoptium/aqa-tests/issues/1297,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/Pipe/PipeInterrupt.java https://github.com/eclipse-openj9/openj9/issues/18479 windows-all
 java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse-openj9/openj9/issues/4317 macosx-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all
@@ -256,8 +245,7 @@ java/rmi/dgc/retryDirtyCalls/RetryDirtyCalls.java	https://github.com/eclipse-ope
 java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
 java/rmi/Naming/DefaultRegistryPort.java https://github.ibm.com/runtimes/backlog/issues/867 macosx-x64
 java/rmi/server/RMISocketFactory/useSocketFactory/unicast/TCPEndpointReadBug.java	https://github.com/eclipse-openj9/openj9/issues/8515	generic-all
-#java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java on windows-x64 issue https://github.ibm.com/runtimes/backlog/issues/1024
-java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java   https://github.com/eclipse-openj9/openj9/issues/13259  aix-all,windows-x64
+java/rmi/server/RMISocketFactory/useSocketFactory/unicast/UseCustomSocketFactory.java	https://github.ibm.com/runtimes/backlog/issues/1024,https://github.com/eclipse-openj9/openj9/issues/13259	aix-all,windows-x64
 java/rmi/server/RemoteServer/AddrInUse.java		https://github.com/eclipse-openj9/openj9/issues/3377	generic-all
 java/rmi/server/UnicastRemoteObject/serialFilter/FilterUROTest.java	https://github.com/eclipse-openj9/openj9/issues/3347	generic-all
 java/rmi/server/UnicastRemoteObject/unexportObject/UnexportLeak.java https://github.com/eclipse-openj9/openj9/issues/4094 generic-all
@@ -307,7 +295,6 @@ sun/security/provider/SecureRandom/StrongSecureRandom.java	https://github.ibm.co
 sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
-#sun/security/ssl/CipherSuite/DisabledCurve.java is excluded as Invalid scenario after removing unsupported binary curves from SSLSocketTemplate.java
 sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all,z/OS-s390x
 sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
@@ -368,8 +355,7 @@ java/util/concurrent/atomic/VMSupportsCS8.java	https://github.com/adoptium/aqa-t
 java/util/concurrent/forkjoin/FJExceptionTableLeak.java	https://github.com/eclipse-openj9/openj9/issues/3209	generic-all
 java/util/concurrent/locks/Lock/TimedAcquireLeak.java	https://github.com/eclipse-openj9/openj9/issues/7125	macosx-all,linux-all,aix-all
 java/util/concurrent/TimeUnit/Basic.java https://github.com/adoptium/aqa-tests/issues/1665 windows-all
-java/util/logging/CheckZombieLockTest.java	https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all,windows-x64
-#java/util/logging/CheckZombieLockTest.java on windows https://github.com/eclipse-openj9/openj9/issues/9186
+java/util/logging/CheckZombieLockTest.java	https://github.com/eclipse-openj9/openj9/issues/9186,https://bugs.openjdk.java.net/browse/JDK-8148972	macosx-all,linux-all,windows-x64
 java/util/logging/LogManager/TestLoggerNames.java https://github.com/eclipse-openj9/openj9/issues/4561 generic-all
 java/util/logging/TestLoggerWeakRefLeak.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/util/stream/boottest/java.base/java/util/stream/NodeTest.java https://github.com/eclipse-openj9/openj9/issues/4129 macosx-all

--- a/openjdk/excludes/ProblemList_openjdk11.txt
+++ b/openjdk/excludes/ProblemList_openjdk11.txt
@@ -82,9 +82,8 @@ sun/security/krb5/auto/rcache_usemd5.sh https://bugs.openjdk.java.net/browse/JDK
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 
 ############################################################################
 
@@ -135,11 +134,8 @@ com/sun/jdi/OnJcmdTest.java https://github.com/adoptium/aqa-tests/issues/2837 wi
 java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 aix-all,linux-aarch64,linux-arm
 java/nio/file/Files/InputStreamTest.java https://github.com/adoptium/aqa-tests/issues/2789 generic-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
@@ -202,8 +198,7 @@ java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java https://github.c
 
 # jdk_tools
 
-#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java	https://github.com/adoptium/aqa-tests/issues/5871,https://github.com/adoptium/aqa-tests/issues/4155	windows-all
 sun/tools/jstatd/TestJstatdExternalRegistry.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPort.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
 sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/browse/JDK-8081569 linux-all
@@ -311,7 +306,6 @@ compiler/loopopts/TestRemoveEmptyLoop.java https://github.com/adoptium/aqa-tests
 
 # jdk_imageio
 
-# javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/aqa-tests/issues/2814 aix-all
 
 ############################################################################
 
@@ -343,8 +337,7 @@ runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tes
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378 windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/jni/nativeStack/TestNativeStack.java https://bugs.openjdk.org/browse/JDK-8311092 linux-arm
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,linux-arm
+runtime/jni/nativeStack/TestNativeStack.java	https://bugs.openjdk.org/browse/JDK-8311092,https://github.com/adoptium/aqa-tests/issues/5384	aix-all,linux-arm
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/NMT/SafepointPollingPages.java https://github.com/adoptium/aqa-tests/issues/5900 linux-arm
@@ -428,11 +421,11 @@ vmTestbase/gc/gctests/HeapUsageTest/HeapUsageTest.java https://bugs.openjdk.org/
 vmTestbase/gc/gctests/InterruptGC/InterruptGC.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
 vmTestbase/gc/gctests/JumbleGC/JumbleGC.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
 vmTestbase/gc/gctests/JumbleGC002/JumbleGC002.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
-vmTestbase/gc/gctests/LargeObjects/large001/large001.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
-vmTestbase/gc/gctests/LargeObjects/large002/TestDescription.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
-vmTestbase/gc/gctests/LargeObjects/large003/TestDescription.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
-vmTestbase/gc/gctests/LargeObjects/large004/TestDescription.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
-vmTestbase/gc/gctests/LargeObjects/large005/TestDescription.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
+vmTestbase/gc/gctests/LargeObjects/large001/large001.java	https://github.com/adoptium/aqa-tests/issues/6621,https://bugs.openjdk.org/browse/JDK-8380951	generic-all
+vmTestbase/gc/gctests/LargeObjects/large002/TestDescription.java	https://github.com/adoptium/aqa-tests/issues/6621,https://bugs.openjdk.org/browse/JDK-8380951	generic-all
+vmTestbase/gc/gctests/LargeObjects/large003/TestDescription.java	https://github.com/adoptium/aqa-tests/issues/6621,https://bugs.openjdk.org/browse/JDK-8380951	generic-all
+vmTestbase/gc/gctests/LargeObjects/large004/TestDescription.java	https://github.com/adoptium/aqa-tests/issues/6621,https://bugs.openjdk.org/browse/JDK-8380951	generic-all
+vmTestbase/gc/gctests/LargeObjects/large005/TestDescription.java	https://github.com/adoptium/aqa-tests/issues/6621,https://bugs.openjdk.org/browse/JDK-8380951	generic-all
 vmTestbase/gc/gctests/LoadUnloadGC/LoadUnloadGC.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
 vmTestbase/gc/gctests/MatrixJuggleGC/MatrixJuggleGC.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
 vmTestbase/gc/gctests/MemoryEater/TestDescription.java https://bugs.openjdk.org/browse/JDK-8380951 generic-all
@@ -604,11 +597,6 @@ vmTestbase/vm/gc/containers/TreeSet_String/TestDescription.java https://bugs.ope
 
 # Note: When the big list above is deleted, uncomment the entries below and do not delete them.
 # They appear unrelated to https://bugs.openjdk.org/browse/JDK-8380951
-# vmTestbase/gc/gctests/LargeObjects/large001/large001.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
-# vmTestbase/gc/gctests/LargeObjects/large002/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
-# vmTestbase/gc/gctests/LargeObjects/large003/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
-# vmTestbase/gc/gctests/LargeObjects/large004/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
-# vmTestbase/gc/gctests/LargeObjects/large005/TestDescription.java https://github.com/adoptium/aqa-tests/issues/6621  windows-x86
 
 ############################################################################
 
@@ -631,7 +619,7 @@ java/math/BigInteger/largeMemory/SymmetricRangeTests.java https://github.com/ado
 java/net/httpclient/http2/ConnectionReuseTest.java https://github.com/adoptium/aqa-tests/issues/6887 linux-s390x
 java/net/httpclient/StreamingBody.java https://github.com/adoptium/infrastructure/issues/3523 aix-all
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.com/adoptium/aqa-tests/issues/6888 linux-s390x
-javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/adoptium/infrastructure/issues/4243 linux-s390x,aix-all
+javax/imageio/plugins/shared/ImageWriterCompressionTest.java	https://github.com/adoptium/aqa-tests/issues/2814,https://github.com/adoptium/infrastructure/issues/4243	linux-s390x,aix-all
 tools/jmod/hashes/HashesOrderTest.java https://github.com/adoptium/aqa-tests/issues/6886 linux-aarch64,macosx-x64
 sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x

--- a/openjdk/excludes/ProblemList_openjdk12-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk12-openj9.txt
@@ -205,7 +205,7 @@ java/net/HttpURLConnection/SetAuthenticator/HTTPSetAuthenticatorTest.java https:
 java/net/InetAddress/BadDottedIPAddress.java	https://github.com/adoptium/aqa-tests/issues/585	generic-all
 java/net/InetAddress/CachedUnknownHostName.java	https://github.com/adoptium/aqa-tests/issues/585	generic-all
 java/net/InetAddress/IPv4Formats.java	https://github.com/adoptium/aqa-tests/issues/585	generic-all
-java/net/Inet6Address/B6206527.java https://github.com/adoptium/infrastructure/issues/694 linux-all
+java/net/Inet6Address/B6206527.java	https://github.com/adoptium/infrastructure/issues/694,https://github.com/adoptium/aqa-tests/issues/602	linux-all
 java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
@@ -220,7 +220,7 @@ java/net/httpclient/ssltest/CertificateTest.java	https://github.com/eclipse-open
 java/net/httpclient/ConnectExceptionTest.java	https://github.com/adoptium/aqa-tests/issues/585	generic-all
 java/net/httpclient/InvalidInputStreamSubscriptionRequest.java	https://github.com/eclipse-openj9/openj9/issues/4054	windows-all
 java/net/httpclient/RetryWithCookie.java	https://github.com/eclipse-openj9/openj9/issues/5140	windows-all
-java/net/httpclient/UnknownBodyLengthTest.java https://github.com/eclipse-openj9/openj9/issues/4593 windows-all,macosx-all
+java/net/httpclient/UnknownBodyLengthTest.java	https://github.com/eclipse-openj9/openj9/issues/4593,https://bugs.openjdk.java.net/browse/JDK-8210130	macosx-all,windows-all
 java/net/httpclient/websocket/BlowupOutputQueue.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingBinaryPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingBinaryPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
@@ -230,10 +230,7 @@ java/net/httpclient/websocket/PendingPongBinaryClose.java https://github.com/ecl
 java/net/httpclient/websocket/PendingPongTextClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPingClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
 java/net/httpclient/websocket/PendingTextPongClose.java https://github.com/eclipse-openj9/openj9/issues/4298 macosx-all
-java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issues/694 linux-all
-java/net/Inet6Address/B6206527.java	https://github.com/adoptium/aqa-tests/issues/602	linux-all
-java/net/ipv6tests/B6521014.java	https://github.com/adoptium/aqa-tests/issues/602	linux-all
-java/net/httpclient/UnknownBodyLengthTest.java	https://bugs.openjdk.java.net/browse/JDK-8210130	windows-all
+java/net/ipv6tests/B6521014.java	https://github.com/adoptium/infrastructure/issues/694,https://github.com/adoptium/aqa-tests/issues/602	linux-all
 sun/net/www/protocol/http/RedirectOnPost.java	https://github.com/eclipse-openj9/openj9/issues/5140	windows-all
 
 ############################################################################
@@ -261,8 +258,7 @@ java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.n
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
 java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/adoptium/aqa-tests/issues/585	generic-all
 java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/adoptium/aqa-tests/issues/585	generic-all
 java/nio/channels/DatagramChannel/SocketOptionTests.java	https://github.com/adoptium/aqa-tests/issues/585	generic-all
 java/nio/channels/FileChannel/TempDirectBuffersReclamation.java	https://github.com/adoptium/aqa-tests/issues/585	generic-all

--- a/openjdk/excludes/ProblemList_openjdk13-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk13-openj9.txt
@@ -27,8 +27,7 @@
 # jdk_lang
 
 java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-#java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267,https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
 java/lang/ClassLoader/Assert.java	https://github.com/eclipse-openj9/openj9/issues/6668	macosx-x64
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
@@ -223,11 +222,8 @@ java/nio/Buffer/LimitDirectMemoryNegativeTest.java	https://github.com/eclipse-op
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
 java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse-openj9/openj9/issues/4317 macosx-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all

--- a/openjdk/excludes/ProblemList_openjdk13.txt
+++ b/openjdk/excludes/ProblemList_openjdk13.txt
@@ -33,8 +33,7 @@ java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://git
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-#java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/lang/String/StringRepeat.java	https://bugs.openjdk.java.net/browse/JDK-8221400,https://github.com/adoptium/aqa-tests/issues/1272	windows-all
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
@@ -95,11 +94,8 @@ java/net/httpclient/ResponsePublisher.java	https://github.com/adoptium/temurin-b
 java/net/MulticastSocket/Promiscuous.java               https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/net/MulticastSocket/Test.java                             https://github.com/adoptium/infrastructure/issues/699    linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 ############################################################################
 
 # jdk_io

--- a/openjdk/excludes/ProblemList_openjdk14-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk14-openj9.txt
@@ -27,8 +27,7 @@
 # jdk_lang
 
 java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-#java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267,https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
 java/lang/ClassLoader/Assert.java	https://github.com/eclipse-openj9/openj9/issues/6668	macosx-x64
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
@@ -156,8 +155,7 @@ java/lang/management/MemoryMXBean/MemoryManagementConcMarkSweepGC.sh https://git
 java/lang/management/MemoryMXBean/MemoryManagementParallelGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryManagementSerialGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestAllGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
-java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
-java/lang/management/MemoryMXBean/MemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+java/lang/management/MemoryMXBean/MemoryTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/management/MemoryMXBean/LowMemoryTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 javax/management/Introspector/ClassLeakTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 java/lang/management/MemoryMXBean/MemoryTestZGC.sh https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -174,8 +172,7 @@ com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/
 
 # jdk_math
 
-java/math/BigInteger/largeMemory/SymmetricRangeTests.java https://bugs.openjdk.java.net/browse/JDK-8241097 generic-all
-java/math/BigInteger/largeMemory/SymmetricRangeTests.java https://github.com/eclipse-openj9/openj9/issues/8728 generic-all
+java/math/BigInteger/largeMemory/SymmetricRangeTests.java	https://bugs.openjdk.java.net/browse/JDK-8241097,https://github.com/eclipse-openj9/openj9/issues/8728	generic-all
 
 ############################################################################
 
@@ -225,11 +222,8 @@ java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.n
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/1153 windows-all
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x,windows-all
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/infrastructure/issues/1153,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x,windows-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse-openj9/openj9/issues/4317 macosx-all
 java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java https://github.com/eclipse-openj9/openj9/issues/8796 macosx-all

--- a/openjdk/excludes/ProblemList_openjdk14.txt
+++ b/openjdk/excludes/ProblemList_openjdk14.txt
@@ -28,8 +28,7 @@ java/lang/ProcessBuilder/Basic.java#id0	        https://github.com/adoptium/aqa-
 java/lang/ProcessBuilder/Basic.java#id1         https://github.com/adoptium/aqa-tests/issues/1864 linux-aarch64
 java/lang/ProcessBuilder/InheritIO/InheritIO.sh https://github.com/adoptium/aqa-tests/issues/1864 linux-aarch64
 java/lang/ProcessBuilder/SkipTest.java          https://github.com/adoptium/aqa-tests/issues/1864 linux-aarch64
-# java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/lang/String/StringRepeat.java	https://bugs.openjdk.java.net/browse/JDK-8221400,https://github.com/adoptium/aqa-tests/issues/1272	windows-all
 java/lang/String/nativeEncoding/StringPlatformChars.java	https://github.com/adoptium/temurin-build/issues/248	generic-all
 java/lang/System/LoggerFinder/modules/JDKLoggerForImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/System/LoggerFinder/modules/LoggerInImageTest.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
@@ -124,11 +123,8 @@ java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.n
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/1153 windows-all
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x,windows-all
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/infrastructure/issues/1153,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x,windows-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le

--- a/openjdk/excludes/ProblemList_openjdk15-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk15-openj9.txt
@@ -27,8 +27,7 @@
 # jdk_lang
 
 java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-#java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267,https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
 java/lang/ClassLoader/Assert.java	https://github.com/eclipse-openj9/openj9/issues/6668	macosx-x64
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
@@ -243,11 +242,8 @@ java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.n
 java/nio/channels/AsynchronousSocketChannel/Basic.java	https://bugs.openjdk.java.net/browse/JDK-7052549	windows-all
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse-openj9/openj9/issues/4317 macosx-all
 java/nio/file/Files/CopyAndMove.java https://github.com/adoptium/aqa-tests/issues/795 macosx-all

--- a/openjdk/excludes/ProblemList_openjdk15.txt
+++ b/openjdk/excludes/ProblemList_openjdk15.txt
@@ -32,8 +32,7 @@ java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://git
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-#java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/lang/String/StringRepeat.java	https://bugs.openjdk.java.net/browse/JDK-8221400,https://github.com/adoptium/aqa-tests/issues/1272	windows-all
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
@@ -100,11 +99,8 @@ java/net/MulticastSocket/Promiscuous.java               https://github.com/adopt
 java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/adoptium/infrastructure/issues/699    linux-s390x,aix-all
 java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/Test.java                             https://github.com/adoptium/infrastructure/issues/699    linux-s390x,aix-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 ############################################################################
 
 # jdk_io

--- a/openjdk/excludes/ProblemList_openjdk16-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk16-openj9.txt
@@ -33,8 +33,7 @@ javax/imageio/stream/DeleteOnExitTest.sh https://github.com/eclipse-openj9/openj
 # jdk_lang
 
 java/lang/Class/GetModuleTest.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
-#java/lang/Class/GetPackageBootLoaderChildLayer.java is also excluded for the issue https://github.com/adoptium/aqa-tests/issues/1267
-java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
+java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267,https://github.com/eclipse-openj9/openj9/issues/5274	generic-all
 java/lang/Class/forName/NonJavaNames.sh	https://github.com/eclipse-openj9/openj9/issues/5225	generic-all
 java/lang/ClassLoader/Assert.java	https://github.com/eclipse-openj9/openj9/issues/6668	macosx-x64
 java/lang/ClassLoader/EndorsedDirs.java	https://github.com/eclipse-openj9/openj9/issues/3055	generic-all
@@ -155,14 +154,13 @@ java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/a
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 vm/JniInvocationTest.java	https://github.com/adoptium/temurin-build/issues/248	macosx-all
-jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/9018	generic-all
 java/lang/invoke/lambda/superProtectedMethod/SuperMethodTest.java https://github.com/eclipse-openj9/openj9/issues/11783 generic-all
 java/lang/invoke/MethodHandles/publicLookup/Driver.java https://github.com/eclipse-openj9/openj9/issues/10648 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 ############################################################################
 
 # jdk_internal
-jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
 
 ############################################################################
 
@@ -273,11 +271,8 @@ java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/ec
 java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.com/eclipse-openj9/openj9/issues/13018 windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/2535 aix-all
 java/nio/channels/SocketChannel/AdaptSocket.java https://github.com/eclipse-openj9/openj9/issues/4317 macosx-all

--- a/openjdk/excludes/ProblemList_openjdk16.txt
+++ b/openjdk/excludes/ProblemList_openjdk16.txt
@@ -35,8 +35,7 @@ java/beans/XMLEncoder/Test6501431.java	https://github.com/adoptium/aqa-tests/iss
 java/beans/XMLEncoder/Test6570354.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_CardLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/java_awt_ScrollPane.java	failure on mac is tracked by https://github.com/adoptium/aqa-tests/issues/2848
-java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all
 java/beans/XMLEncoder/javax_swing_Box.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
@@ -62,8 +61,7 @@ java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://git
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-#java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all
+java/lang/String/StringRepeat.java	https://bugs.openjdk.java.net/browse/JDK-8221400,https://github.com/adoptium/aqa-tests/issues/1272	windows-all
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
@@ -141,11 +139,8 @@ java/net/MulticastSocket/Promiscuous.java               https://github.com/adopt
 java/net/MulticastSocket/SetLoopbackMode.java     https://github.com/adoptium/infrastructure/issues/699    linux-s390x,aix-all
 java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/Test.java                             https://github.com/adoptium/infrastructure/issues/699    linux-s390x,aix-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/2816 aix-all
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -129,8 +129,7 @@ java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/e
 ############################################################################
 
 # jdk_internal
-# jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
-jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/9018	generic-all
 
 ############################################################################
 
@@ -226,8 +225,7 @@ javax/imageio/plugins/shared/ImageWriterCompressionTest.java https://github.com/
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java	https://github.com/adoptium/aqa-tests/issues/1500	generic-all
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -250,13 +248,8 @@ java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.ibm.com/ru
 java/nio/channels/DatagramChannel/BasicMulticastTests.java https://github.ibm.com/runtimes/backlog/issues/1622 aix-all,macosx-all,windows-all
 java/nio/channels/DatagramChannel/Disconnect.java https://github.com/eclipse-openj9/openj9/issues/20115 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 windows-all,linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699	generic-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.ibm.com/runtimes/backlog/issues/684 aix-all
 java/nio/channels/FileChannel/directio/ReadDirect.java https://github.com/adoptium/aqa-tests/issues/1297 z/OS-s390x
@@ -347,7 +340,6 @@ sun/security/provider/SecureRandom/StrongSecureRandom.java	https://github.ibm.co
 sun/security/rsa/PrivateKeyEqualityTest.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTest2.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
 sun/security/rsa/pss/SignatureTestPSS.java	https://github.ibm.com/runtimes/backlog/issues/795	macosx-all
-#sun/security/ssl/CipherSuite/DisabledCurve.java is excluded as Invalid scenario after removing unsupported binary curves from SSLSocketTemplate.java
 sun/security/ssl/CipherSuite/DisabledCurve.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all,z/OS-s390x
 sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/ssl/CipherSuite/SupportedGroups.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all

--- a/openjdk/excludes/ProblemList_openjdk17.txt
+++ b/openjdk/excludes/ProblemList_openjdk17.txt
@@ -29,8 +29,7 @@ java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/b
 java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java failure on mac is tracked by https://github.com/adoptium/aqa-tests/issues/2848
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
@@ -38,7 +37,6 @@ java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adop
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
@@ -63,10 +61,7 @@ com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk
 sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 
 ############################################################################
 
@@ -80,9 +75,8 @@ sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 
 ############################################################################
 
@@ -117,20 +111,13 @@ java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/iss
 java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm,windows-x86
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
 java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
 sun/net/www/http/KeepAliveCache/KeepAliveProperty.java https://bugs.openjdk.org/browse/JDK-8285836 linux-ppc64le
@@ -141,8 +128,7 @@ java/net/Socket/B8312065.java https://github.com/adoptium/aqa-tests/issues/7043 
 ############################################################################
 
 # jdk_io
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 
 ############################################################################
 
@@ -171,8 +157,7 @@ java/nio/channels/AsynchronousFileChannel/Basic.java https://bugs.openjdk.java.n
 java/nio/channels/AsynchronousSocketChannel/Basic.java https://bugs.openjdk.java.net/browse/JDK-7052549 windows-all
 jdk/nio/zipfs/ZipFSTester.java https://github.com/adoptium/aqa-tests/issues/602 macosx-all,linux-ppc64le
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/FileChannel/Transfer2GPlus.java https://bugs.openjdk.java.net/browse/JDK-8272095 linux-arm,windows-all
-# java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3690 windows-all
+java/nio/channels/FileChannel/Transfer2GPlus.java	https://github.com/adoptium/aqa-tests/issues/3690,https://bugs.openjdk.java.net/browse/JDK-8272095	linux-arm,windows-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
@@ -321,8 +306,7 @@ java/util/zip/DeInflate.java https://bugs.openjdk.org/browse/JDK-8299748 linux-s
 
 java/foreign/valist/VaListTest.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
 java/foreign/malloc/TestMixedMallocFree.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
-# java/foreign/TestNative.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
-java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+java/foreign/TestNative.java	https://bugs.openjdk.org/browse/JDK-8295290,https://github.com/adoptium/aqa-tests/issues/1920	generic-all
 java/foreign/TestVarArgs.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
 java/foreign/StdLibTest.java https://bugs.openjdk.org/browse/JDK-8295290 windows-aarch64
 
@@ -472,17 +456,13 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 # hotspot_runtime
 
 runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-x86
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-x86
+runtime/cds/TestCDSVMCrash.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-x86
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
-runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86,macosx-x64
+runtime/cds/appcds/LambdaEagerInit.java	https://github.com/adoptium/adoptium-support/issues/937,https://github.com/adoptium/aqa-tests/issues/5378	windows-x86,macosx-x64
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
-runtime/cds/appcds/applications/JavacBench.java#dynamic https://github.com/adoptium/aqa-tests/issues/5869 windows-x86,macosx-x64
-#runtime/jni/nativeStack/TestNativeStack.java https://bugs.openjdk.org/browse/JDK-8311092 linux-arm
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,linux-arm
+runtime/cds/appcds/applications/JavacBench.java#dynamic	https://github.com/adoptium/adoptium-support/issues/937,https://github.com/adoptium/aqa-tests/issues/5869	macosx-x64,windows-x86
+runtime/jni/nativeStack/TestNativeStack.java	https://bugs.openjdk.org/browse/JDK-8311092,https://github.com/adoptium/aqa-tests/issues/5384	aix-all,linux-arm
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
@@ -491,9 +471,7 @@ runtime/os/TestTracePageSizes.java#with-G1 https://bugs.openjdk.org/browse/JDK-8
 runtime/os/TestTracePageSizes.java#with-Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#with-Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-# runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://bugs.openjdk.org/browse/JDK-8313315 windows-aarch64
-# runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/6197 aix-ppc64
-runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://bugs.openjdk.org/browse/JDK-8347908 linux-arm,windows-aarch64,aix-ppc64
+runtime/ErrorHandling/MachCodeFramesInErrorFile.java	https://bugs.openjdk.org/browse/JDK-8313315,https://github.com/adoptium/aqa-tests/issues/6197,https://bugs.openjdk.org/browse/JDK-8347908	linux-arm,windows-aarch64,aix-ppc64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64
 
 ############################################################################
@@ -549,11 +527,11 @@ runtime/DefineClass/NullClassBytesTest.java https://github.com/adoptium/aqa-test
 # Uncomment duplicates above if any of these lines are removed.
 
 gc/z/TestUncommit.java https://github.com/adoptium/aqa-tests/issues/6424 linux-x64
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/infrastructure/issues/4243 linux-s390x,aix-all
-java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2810,https://github.com/adoptium/infrastructure/issues/4243	linux-s390x,aix-all
+java/net/DatagramSocket/DatagramSocketExample.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x
-sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
+sun/management/jdp/JdpDefaultsTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpSpecificAddressTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all

--- a/openjdk/excludes/ProblemList_openjdk18-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk18-openj9.txt
@@ -35,7 +35,7 @@ java/lang/ClassLoader/LibraryPathProperty.java	https://github.com/adoptium/aqa-t
 java/lang/ClassLoader/RecursiveSystemLoader.java	https://github.com/eclipse-openj9/openj9/issues/3178	generic-all
 java/lang/Enum/ConstantDirectoryOptimalCapacity.java	https://github.com/adoptium/aqa-tests/issues/1297	generic-all
 java/lang/ModuleLayer/BasicLayerTest.java	https://github.com/eclipse-openj9/openj9/issues/6462	generic-all
-java/lang/ProcessBuilder/Basic.java		https://github.com/eclipse-openj9/openj9/issues/10921	linux-ppc64le
+java/lang/ProcessBuilder/Basic.java	https://github.com/eclipse-openj9/openj9/issues/10921,https://github.com/adoptium/aqa-tests/issues/1920	aix-ppc64,linux-ppc64le
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
 java/lang/StackTraceElement/PublicConstructor.java	https://github.com/eclipse-openj9/openj9/issues/6659	generic-all
@@ -123,18 +123,16 @@ java/lang/reflect/Proxy/ProxyLayerTest.java	https://github.com/eclipse-openj9/op
 java/lang/reflect/PublicMethods/PublicMethodsTest.java	https://github.com/eclipse-openj9/openj9/issues/7897	generic-all
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/9018	generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/annotation/LoaderLeakTest.java https://github.com/eclipse-openj9/openj9/issues/13201 generic-all
 java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java	https://github.com/eclipse-openj9/openj9/issues/14441	aix-all
 java/lang/reflect/exeCallerAccessTest/CallerAccessTest.java https://github.com/eclipse-openj9/openj9/issues/14397 macosx-all
-java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
 
 ############################################################################
 
 # jdk_internal
-jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 
@@ -255,12 +253,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/eclipse-openj9/openj9/issues/6669
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk18.txt
+++ b/openjdk/excludes/ProblemList_openjdk18.txt
@@ -23,31 +23,25 @@ java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.java.net/
 java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
 java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
 java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-#java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-#java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all
 java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all
 java/beans/XMLEncoder/java_awt_CardLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all
 java/beans/XMLEncoder/javax_swing_Box.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java  https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-#java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810   aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java   https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 ############################################################################
@@ -86,9 +80,8 @@ jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-te
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/System/FileEncodingTest.java  https://github.com/adoptium/aqa-tests/issues/1267   aix-ppc64
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
-#java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
+java/lang/ProcessBuilder/Basic.java#id0	https://github.com/adoptium/aqa-tests/issues/1920,https://bugs.openjdk.org/browse/JDK-8245748	aix-ppc64,linux-all
 #java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
 java/lang/StringBuffer/HugeCapacity.java https://bugs.openjdk.org/browse/JDK-8279954 windows-all
 java/lang/StringBuilder/HugeCapacity.java https://bugs.openjdk.org/browse/JDK-8279954 windows-all
@@ -116,8 +109,7 @@ sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-t
 ############################################################################
 
 # jdk_other
-#com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 ############################################################################
 
 # jdk_net
@@ -158,7 +150,7 @@ java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tes
 java/net/DatagramSocket/PortUnreachable.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/Send12k.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088  aix-ppc64,linux-ppc64le 
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/aqa-tests/issues/3820	aix-all,linux-ppc64le
 java/net/DatagramSocket/SendSize.java.SendSize  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -178,22 +170,18 @@ java/net/Socks/SocksProxyVersion.java   https://github.com/adoptium/aqa-tests/is
 java/net/Socket/asyncClose/Race.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/httpclient/ManyRequests.java   https://github.com/adoptium/aqa-tests/issues/2828 aix-ppc64
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
-java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
+java/nio/channels/Channels/ReadXBytes.java	https://github.com/adoptium/aqa-tests/issues/3034	aix-ppc64,linux-aarch64,linux-ppc64le,linux-s390x,windows-x64
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 generic-all
 java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-java/nio/channels/DatagramChannel/AfterDisconnect.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
-#java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
 com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
@@ -203,8 +191,6 @@ java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.co
 com/sun/net/httpserver/simpleserver/CustomFileSystemTest.java https://bugs.openjdk.java.net/browse/JDK-8280965 windows-all
 com/sun/net/httpserver/simpleserver/MapToPathTest.java https://bugs.openjdk.java.net/browse/JDK-8281305 windows-x64
 com/sun/net/httpserver/simpleserver/SimpleFileServerTest.java https://bugs.openjdk.java.net/browse/JDK-8280965 windows-all
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
 com/sun/net/httpserver/simpleserver/StressDirListings.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
 ############################################################################
@@ -226,7 +212,6 @@ com/sun/jdi/JdwpListenTest.java https://bugs.openjdk.org/browse/JDK-8241624 gene
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593	linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
 java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
 java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
@@ -237,7 +222,6 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
-java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x
  
 
 ############################################################################ 
@@ -364,8 +348,8 @@ java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 g
 ############################################################################
 # jvm_compiler
 compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux-s390x
-compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/irTests/TestPostParseCallDevirtualization.java  https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/tiered/TieredLevelsTest.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
@@ -454,9 +438,7 @@ compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/is
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -480,13 +462,12 @@ jdk/jfr/jmx/streaming/TestDelegated.java	https://github.com/adoptium/aqa-tests/i
 jdk/jfr/jmx/streaming/TestEnableDisable.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jmx/streaming/TestRemoteDump.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jmx/streaming/TestRotate.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866,https://github.com/adoptium/aqa-tests/issues/2985	linux-arm,windows-x86
 
 jdk/jfr/api/consumer/TestRecordedFullStackTrace.java https://bugs.openjdk.java.net/browse/JDK-8284024 linux-s390x
 jdk/jfr/event/profiling/TestFullStackTrace.java https://bugs.openjdk.java.net/browse/JDK-8284024 linux-s390x
 jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/3492 generic-all
 jdk/jfr/jmx/streaming/TestMetadataEvent.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
-jdk/jfr/jmx/streaming/TestSetSettings.java  https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
 jdk/jfr/jmx/streaming/TestStart.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86
 jdk/jfr/jmx/TestGetRecordings.java  https://github.com/adoptium/aqa-tests/issues/2754 linux-ppc64le
 jdk/jfr/event/compiler/TestCodeCacheFull.java https://github.com/adoptium/aqa-tests/issues/3277 windows-x86

--- a/openjdk/excludes/ProblemList_openjdk19-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk19-openj9.txt
@@ -62,8 +62,7 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all
-java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
-java/lang/ProcessBuilder/Basic.java https://github.com/eclipse-openj9/openj9/issues/10921 linux-ppc64le
+java/lang/ProcessBuilder/Basic.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/10921	aix-ppc64,linux-ppc64le
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
@@ -117,7 +116,7 @@ java/lang/Thread/virtual/stress/TimedGet.java https://github.com/eclipse-openj9/
 java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-openj9/openj9/issues/15996 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
-jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/9018	generic-all
 jdk/internal/vm/Continuation/Basic.java#id0 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/Basic.java#id1 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/ClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
@@ -131,7 +130,6 @@ jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issu
 ############################################################################
 
 # jdk_internal
-jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 
@@ -266,12 +264,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk19.txt
+++ b/openjdk/excludes/ProblemList_openjdk19.txt
@@ -23,31 +23,25 @@ java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.java.net/
 java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
 java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
 java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-#java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-#java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all
 java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all
 java/beans/XMLEncoder/java_awt_CardLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all
 java/beans/XMLEncoder/javax_swing_Box.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-#java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java	https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java  https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-#java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810   aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java   https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 ############################################################################
@@ -60,8 +54,7 @@ java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java	https://git
 jdk/modules/etc/DefaultModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 jdk/modules/incubator/ImageModules.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/lang/Class/GetPackageBootLoaderChildLayer.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
-#java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java	https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/String/StringRepeat.java	https://bugs.openjdk.java.net/browse/JDK-8221400,https://github.com/adoptium/aqa-tests/issues/1272	windows-all,
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java	https://github.com/adoptium/infrastructure/issues/1118	linux-aarch64
@@ -85,9 +78,8 @@ java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java	https://g
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
-#java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
+java/lang/ProcessBuilder/Basic.java#id0	https://github.com/adoptium/aqa-tests/issues/1920,https://bugs.openjdk.org/browse/JDK-8245748	aix-ppc64,linux-all
 #java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
 java/lang/StringBuffer/HugeCapacity.java https://bugs.openjdk.org/browse/JDK-8279954 windows-all
 java/lang/StringBuilder/HugeCapacity.java https://bugs.openjdk.org/browse/JDK-8279954 windows-all
@@ -115,8 +107,7 @@ sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-t
 ############################################################################
 
 # jdk_other
-#com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 ############################################################################
 
@@ -158,7 +149,7 @@ java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tes
 java/net/DatagramSocket/PortUnreachable.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/Send12k.java    https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088  aix-ppc64,linux-ppc64le 
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/aqa-tests/issues/3820	aix-all,linux-ppc64le
 java/net/DatagramSocket/SendSize.java.SendSize  https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java   https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -179,35 +170,27 @@ java/net/Socket/asyncClose/Race.java    https://github.com/adoptium/aqa-tests/is
 java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/httpclient/ManyRequests.java   https://github.com/adoptium/aqa-tests/issues/2828 aix-ppc64
 
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue	https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all	
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/file/spi/SetDefaultProvider.java	https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
-java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-ppc64,linux-s390x,windows-x64
+java/nio/channels/Channels/ReadXBytes.java	https://github.com/adoptium/aqa-tests/issues/3034	aix-ppc64,linux-aarch64,linux-ppc64le,linux-s390x,windows-x64
 java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 generic-all
 java/nio/channels/FileChannel/Transfer2GPlus.java   https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-java/nio/channels/DatagramChannel/AfterDisconnect.java  https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java   https://github.com/adoptium/aqa-tests/issues/3086   aix-ppc64
-#java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java  https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
 com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
 java/net/InetAddress/HostsFileOrderingTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
 java/net/InetAddress/InternalNameServiceTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
 java/net/InetAddress/InternalNameServiceWithHostsFileTest.java https://github.com/adoptium/aqa-tests/issues/3637 linux-arm,linux-aarch64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
 com/sun/net/httpserver/simpleserver/StressDirListings.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
-java/net/vthread/HttpALot.java https://github.com/adoptium/aqa-tests/issues/4024 aix-all
-java/net/vthread/BlockingSocketOps.java https://github.com/adoptium/aqa-tests/issues/4024 aix-all
-java/net/vthread/HttpALot.java https://github.com/adoptium/aqa-tests/issues/4024 aix-all
-java/net/vthread/BlockingSocketOps.java https://github.com/adoptium/aqa-tests/issues/4024 aix-all
+java/net/vthread/HttpALot.java	https://github.com/adoptium/aqa-tests/issues/4024	aix-all
+java/net/vthread/BlockingSocketOps.java	https://github.com/adoptium/aqa-tests/issues/4024	aix-all
 java/net/vthread/InterruptHttp.java https://github.com/adoptium/aqa-tests/issues/4024 aix-all
 sun/net/www/http/KeepAliveCache/KeepAliveProperty.java https://bugs.openjdk.org/browse/JDK-8285836 linux-ppc64le
 ############################################################################
@@ -229,7 +212,6 @@ com/sun/jdi/JdwpListenTest.java https://bugs.openjdk.org/browse/JDK-8241624 gene
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593	linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java	https://github.com/adoptium/aqa-tests/issues/1597	linux-all,aix-all
 java/nio/charset/spi/CharsetProviderBasicTest.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ChangingAddress.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
 java/nio/channels/DatagramChannel/ConnectExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
 java/nio/channels/DatagramChannel/SendExceptions.java	https://github.com/adoptium/aqa-tests/issues/593	linux-all
@@ -240,7 +222,6 @@ jdk/nio/zipfs/ZipFSTester.java	https://github.com/adoptium/aqa-tests/issues/602 
 java/nio/file/Files/CopyAndMove.java	https://github.com/adoptium/aqa-tests/issues/1267	macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java	https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 
-java/nio/channels/Channels/ReadXBytes.java  https://github.com/adoptium/aqa-tests/issues/3034  linux-aarch64,linux-ppc64le,linux-s390x
 java/nio/channels/vthread/BlockingChannelOps.java#id0 https://github.com/adoptium/aqa-tests/issues/4024 aix-all
 
 
@@ -361,8 +342,8 @@ java/foreign/TestNative.java https://github.com/adoptium/aqa-tests/issues/1920 g
 # jvm_compiler
 
 compiler/unsafe/UnsafeCopyMemory.java   https://github.com/adoptium/aqa-tests/issues/2804   aix-ppc64,linux-s390x
-compiler/c2/cr6340864/TestIntVectRotate.java    https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/irTests/TestPostParseCallDevirtualization.java  https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
 compiler/tiered/TieredLevelsTest.java   https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
@@ -383,9 +364,7 @@ compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/is
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -412,11 +391,10 @@ jdk/jfr/jmx/streaming/TestDelegated.java	https://github.com/adoptium/aqa-tests/i
 jdk/jfr/jmx/streaming/TestEnableDisable.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jmx/streaming/TestRemoteDump.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jmx/streaming/TestRotate.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2866,https://github.com/adoptium/aqa-tests/issues/2985	linux-arm,windows-x86
 
 jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/3492 generic-all
 jdk/jfr/jmx/streaming/TestMetadataEvent.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
-jdk/jfr/jmx/streaming/TestSetSettings.java  https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
 jdk/jfr/jmx/streaming/TestStart.java    https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86
 jdk/jfr/jmx/TestGetRecordings.java  https://github.com/adoptium/aqa-tests/issues/2754 linux-ppc64le
 jdk/jfr/event/gc/detailed/TestZUncommitEvent.java https://bugs.openjdk.org/browse/JDK-8248078 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk20-openj9.txt
@@ -62,8 +62,7 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all
-java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
-java/lang/ProcessBuilder/Basic.java https://github.com/eclipse-openj9/openj9/issues/10921 linux-ppc64le
+java/lang/ProcessBuilder/Basic.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/10921	aix-ppc64,linux-ppc64le
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
@@ -116,7 +115,7 @@ java/lang/Thread/virtual/StackTraces.java https://github.com/eclipse-openj9/open
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
-jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/9018	generic-all
 jdk/internal/vm/Continuation/Basic.java#id0 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/Basic.java#id1 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/Fuzz.java https://github.com/eclipse-openj9/openj9/issues/15247 generic-all
@@ -128,7 +127,6 @@ jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issu
 ############################################################################
 
 # jdk_internal
-jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 
@@ -263,12 +261,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-java/nio/channels/DatagramChannel/Promiscuous.java              https://github.com/adoptium/infrastructure/issues/699    linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk20.txt
+++ b/openjdk/excludes/ProblemList_openjdk20.txt
@@ -24,31 +24,25 @@ java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/
 java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
 java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
 java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all
 java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
@@ -63,8 +57,7 @@ java/lang/System/LoggerFinder/modules/UnnamedLoggerForImageTest.java https://git
 jdk/modules/etc/DefaultModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 jdk/modules/incubator/ImageModules.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
 java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all
-# java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/String/StringRepeat.java	https://bugs.openjdk.java.net/browse/JDK-8221400,https://github.com/adoptium/aqa-tests/issues/1272	windows-all,
 java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessByte.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
 java/lang/invoke/VarHandles/VarHandleTestAccessChar.java https://github.com/adoptium/infrastructure/issues/1118 linux-aarch64
@@ -88,9 +81,8 @@ java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://g
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
-# java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
+java/lang/ProcessBuilder/Basic.java#id0	https://github.com/adoptium/aqa-tests/issues/1920,https://bugs.openjdk.org/browse/JDK-8245748	aix-ppc64,linux-all
 # java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
 
 ############################################################################
@@ -100,8 +92,7 @@ java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://bugs.openjdk.org/browse/JDK-8207908	macosx-all,linux-ppc64le
 sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
@@ -119,8 +110,7 @@ sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-t
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,linux-arm,aix-all
 
@@ -165,8 +155,7 @@ java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tes
 java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le 
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3820,https://github.com/adoptium/aqa-tests/issues/3088	aix-ppc64,linux-ppc64le
 java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -220,11 +209,8 @@ com/sun/jdi/JdwpListenTest.java https://bugs.openjdk.org/browse/JDK-8241624 gene
 
 # jdk_nio
 
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
@@ -232,12 +218,9 @@ java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/
 java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
@@ -275,8 +258,7 @@ sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/
 # jdk_security4
 
 # Cleaners.java issue is specific to alpine-linux, but there appears to be no way to exclude on alpine-linux platform specifically
-# sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
-sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all,linux-all
+sun/security/krb5/auto/Cleaners.java	https://github.com/adoptium/aqa-tests/issues/4366,https://github.com/adoptium/aqa-tests/issues/4432	aix-all,linux-all
 
 ###########################################################################
 
@@ -393,11 +375,9 @@ compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/is
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
@@ -443,8 +423,7 @@ jdk/jfr/jmx/streaming/TestDelegated.java https://github.com/adoptium/aqa-tests/i
 jdk/jfr/jmx/streaming/TestEnableDisable.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jmx/streaming/TestRemoteDump.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
 jdk/jfr/jmx/streaming/TestRotate.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
-# jdk/jfr/jmx/streaming/TestSetSettings.java https://github.com/adoptium/aqa-tests/issues/2985 linux-arm 
-jdk/jfr/jmx/streaming/TestSetSettings.java https://github.com/adoptium/aqa-tests/issues/2866 windows-x86,linux-arm
+jdk/jfr/jmx/streaming/TestSetSettings.java	https://github.com/adoptium/aqa-tests/issues/2985,https://github.com/adoptium/aqa-tests/issues/2866	windows-x86,linux-arm
 jdk/jfr/jcmd/TestJcmdDump.java https://github.com/adoptium/aqa-tests/issues/3492 generic-all
 jdk/jfr/jmx/streaming/TestMetadataEvent.java https://github.com/adoptium/aqa-tests/issues/2985 linux-arm
 jdk/jfr/jmx/streaming/TestStart.java https://github.com/adoptium/aqa-tests/issues/2985 linux-arm,windows-x86

--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -146,8 +146,7 @@ jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issu
 ############################################################################
 
 # jdk_internal
-# jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
-jdk/internal/loader/NativeLibraries/Main.java https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/9018	generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/vm/Continuation/MovingCompWindow.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -249,8 +248,7 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclip
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -290,14 +288,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699   generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk21.txt
+++ b/openjdk/excludes/ProblemList_openjdk21.txt
@@ -24,31 +24,25 @@ java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/
 java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
 java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
 java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
 java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
@@ -71,12 +65,8 @@ java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
-# sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jmxremote/startstop/JMXStatusTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://bugs.openjdk.org/browse/JDK-8207908	macosx-all,linux-ppc64le
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 
 ############################################################################
 
@@ -90,8 +80,7 @@ sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,linux-arm,aix-all
 
@@ -125,8 +114,6 @@ java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/iss
 java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
@@ -136,8 +123,7 @@ java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tes
 java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3820,https://github.com/adoptium/aqa-tests/issues/3088	aix-ppc64,linux-ppc64le
 java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -170,8 +156,7 @@ java/net/httpclient/ConnectTimeoutWithProxyAsync.java https://bugs.openjdk.org/b
 
 # jdk_io
 
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 ############################################################################
 
 # jdk_jdi
@@ -186,11 +171,8 @@ com/sun/jdi/FinalizerTest.java https://github.com/adoptium/aqa-tests/issues/5705
 
 # jdk_nio
 
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
@@ -198,12 +180,9 @@ java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/
 java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
@@ -226,8 +205,7 @@ java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adopti
 # jdk_security
 
 sun/security/ssl/SSLSocketImpl/SSLSocketLeak.java https://github.com/adoptium/aqa-tests/issues/3811 windows-x86
-# sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/infrastructure/issues/3855 windows-all
-sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/adoptium/aqa-tests/issues/5955 generic-all
+sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java	https://github.com/adoptium/infrastructure/issues/3855,https://github.com/adoptium/aqa-tests/issues/5955	generic-all
 sun/security/tools/jarsigner/TimestampCheck.java https://bugs.openjdk.org/browse/JDK-8352302 generic-all
 ############################################################################
 
@@ -270,8 +248,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java	https://github.com/adoptium/aqa-tests/issues/5871,https://github.com/adoptium/aqa-tests/issues/4155	windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
@@ -356,11 +333,9 @@ compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/is
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
@@ -457,16 +432,12 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 # hotspot_runtime
 
 runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
-#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
+runtime/cds/TestCDSVMCrash.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
-# runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5920 windows-aarch64
-runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
-# runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
-runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/aqa-tests/issues/7008 windows-aarch64,macosx-x64
+runtime/cds/appcds/TestDumpClassListSource.java	https://github.com/adoptium/aqa-tests/issues/5920,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
+runtime/cds/appcds/complexURI/ComplexURITest.java	https://github.com/adoptium/adoptium-support/issues/937,https://github.com/adoptium/aqa-tests/issues/7008	windows-aarch64,macosx-x64
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
@@ -493,15 +464,13 @@ serviceability/dtrace/DTraceOptionsTest.java#enabled https://github.com/adoptium
 serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfoWithEATest.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
-#serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
 serviceability/sa/CDSJMapClstats.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
-#serviceability/sa/ClhsdbJstackXcompStress.java https://bugs.openjdk.org/browse/JDK-8348864 windows-aarch64
-serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86,windows-aarch64
+serviceability/sa/ClhsdbJstackXcompStress.java	https://bugs.openjdk.org/browse/JDK-8348864,https://github.com/adoptium/aqa-tests/issues/5378	windows-x86,windows-aarch64
 serviceability/sa/ClhsdbJstack.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
@@ -549,9 +518,9 @@ vmTestbase/vm/mlvm/hiddenloader/stress/byteMutation/Test.java https://github.com
 # Unreliables - Tests that fail infrequently. These must not block releases.
 # Uncomment duplicates above if any of these lines are removed.
 
-java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
+java/net/DatagramSocket/DatagramSocketExample.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x
-sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
+sun/management/jdp/JdpDefaultsTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpSpecificAddressTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all

--- a/openjdk/excludes/ProblemList_openjdk22-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk22-openj9.txt
@@ -62,8 +62,7 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all
-java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
-java/lang/ProcessBuilder/Basic.java https://github.com/eclipse-openj9/openj9/issues/10921 linux-ppc64le
+java/lang/ProcessBuilder/Basic.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/10921	aix-ppc64,linux-ppc64le
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/ProcessHandle/TreeTest.java https://github.com/eclipse-openj9/openj9/issues/10569 windows-all,aix-all
@@ -124,7 +123,7 @@ java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-open
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
-jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/9018	generic-all
 jdk/internal/vm/Continuation/Basic.java#id0 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/Basic.java#id1 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/ClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
@@ -138,7 +137,6 @@ java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/
 ############################################################################
 
 # jdk_internal
-jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/vm/Continuation/MovingCompWindow.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -240,8 +238,7 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclip
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -282,14 +279,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699   generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk22.txt
+++ b/openjdk/excludes/ProblemList_openjdk22.txt
@@ -24,31 +24,25 @@ java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/
 java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
 java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
 java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all
 java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
@@ -56,15 +50,13 @@ java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-test
 
 # jdk_lang
 
-# java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/String/StringRepeat.java	https://bugs.openjdk.java.net/browse/JDK-8221400,https://github.com/adoptium/aqa-tests/issues/1272	windows-all,
 java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
-# java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
+java/lang/ProcessBuilder/Basic.java#id0	https://github.com/adoptium/aqa-tests/issues/1920,https://bugs.openjdk.org/browse/JDK-8245748	aix-ppc64,linux-all
 # java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
 
 ############################################################################
@@ -74,8 +66,7 @@ java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://bugs.openjdk.org/browse/JDK-8207908	macosx-all,linux-ppc64le
 sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
@@ -93,8 +84,7 @@ sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-t
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,linux-arm,aix-all
 
@@ -139,8 +129,7 @@ java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tes
 java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le 
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3820,https://github.com/adoptium/aqa-tests/issues/3088	aix-ppc64,linux-ppc64le
 java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -178,8 +167,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 # jdk_io
 
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 
 ############################################################################
 
@@ -195,11 +183,8 @@ com/sun/jdi/JdwpListenTest.java https://bugs.openjdk.org/browse/JDK-8241624 gene
 
 # jdk_nio
 
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
@@ -207,12 +192,9 @@ java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/
 java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
@@ -247,8 +229,7 @@ sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java https://github.com/
 # jdk_security4
 
 # Cleaners.java issue is specific to alpine-linux, but there appears to be no way to exclude on alpine-linux platform specifically
-# sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
-sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all,linux-all
+sun/security/krb5/auto/Cleaners.java	https://github.com/adoptium/aqa-tests/issues/4366,https://github.com/adoptium/aqa-tests/issues/4432	aix-all,linux-all
 
 ###########################################################################
 
@@ -351,11 +332,9 @@ compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/is
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestSkeletonPredicates.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/irTests/TestStripMiningDropsSafepoint.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86

--- a/openjdk/excludes/ProblemList_openjdk23-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk23-openj9.txt
@@ -74,8 +74,7 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all
-java/lang/ProcessBuilder/Basic.java https://github.com/adoptium/aqa-tests/issues/1920   aix-ppc64
-java/lang/ProcessBuilder/Basic.java https://github.com/eclipse-openj9/openj9/issues/10921 linux-ppc64le
+java/lang/ProcessBuilder/Basic.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/10921	aix-ppc64,linux-ppc64le
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/ProcessBuilder/SkipTest.java https://github.com/eclipse-openj9/openj9/issues/4124 windows-all
 java/lang/ProcessHandle/InfoTest.java https://github.com/eclipse-openj9/openj9/issues/19757 aix-ppc64
@@ -137,7 +136,7 @@ java/lang/Thread/virtual/TracePinnedThreads.java https://github.com/eclipse-open
 java/lang/ThreadGroup/SetMaxPriority.java https://github.com/eclipse-openj9/openj9/issues/6691 generic-all
 java/lang/Throwable/SuppressedExceptions.java https://github.com/eclipse-openj9/openj9/issues/6692 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java https://github.com/eclipse-openj9/openj9/issues/11135 generic-all
-jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/adoptium/aqa-tests/issues/1920,https://github.com/eclipse-openj9/openj9/issues/9018	generic-all
 jdk/internal/vm/Continuation/Basic.java#id0 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/Basic.java#id1 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/ClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
@@ -152,7 +151,6 @@ java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 https://github.com/
 ############################################################################
 
 # jdk_internal
-jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/vm/Continuation/MovingCompWindow.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -256,8 +254,7 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclip
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm, aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -298,14 +295,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699   generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk23.txt
+++ b/openjdk/excludes/ProblemList_openjdk23.txt
@@ -18,48 +18,32 @@
 
 # jdk_beans
 
-# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
@@ -67,15 +51,13 @@ java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-test
 
 # jdk_lang
 
-# java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/String/StringRepeat.java	https://bugs.openjdk.java.net/browse/JDK-8221400,https://github.com/adoptium/aqa-tests/issues/1272	windows-all,
 java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java https://bugs.openjdk.java.net/browse/JDK-8249079 generic-all
-# java/lang/ProcessBuilder/Basic.java#id0 https://github.com/adoptium/aqa-tests/issues/1920 aix-ppc64
+java/lang/ProcessBuilder/Basic.java#id0	https://github.com/adoptium/aqa-tests/issues/1920,https://bugs.openjdk.org/browse/JDK-8245748	aix-ppc64,linux-all
 # java/lang/ProcessBuilder/Basic.java is excluded for issue on alpine linux. As currently there is no way to exclude tests for alpine specifically, using linux-all instead
-java/lang/ProcessBuilder/Basic.java#id0 https://bugs.openjdk.org/browse/JDK-8245748 linux-all,aix-ppc64
 java/lang/ProcessBuilder/Basic.java#id1 https://bugs.openjdk.org/browse/JDK-8245748 linux-all
 java/lang/Thread/virtual/stress/PingPong.java#ltq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
 java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa-tests/issues/5677 generic-all
@@ -87,8 +69,7 @@ java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://bugs.openjdk.org/browse/JDK-8207908	macosx-all,linux-ppc64le
 sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
@@ -106,8 +87,7 @@ sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-t
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,linux-arm,aix-all
 
@@ -152,8 +132,7 @@ java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tes
 java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le 
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3820,https://github.com/adoptium/aqa-tests/issues/3088	aix-ppc64,linux-ppc64le
 java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -185,8 +164,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 # jdk_io
 
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 ############################################################################
 
 # jdk_jdi
@@ -201,11 +179,8 @@ com/sun/jdi/FinalizerTest.java https://github.com/adoptium/aqa-tests/issues/5705
 
 # jdk_nio
 
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
@@ -213,12 +188,9 @@ java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/
 java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
 java/nio/channels/AsyncCloseAndInterrupt.java https://github.com/adoptium/aqa-tests/issues/1597 linux-all,aix-all
@@ -255,8 +227,7 @@ sun/security/ssl/X509TrustManagerImpl/distrust/Symantec.java https://github.com/
 # jdk_security4
 
 # Cleaners.java issue is specific to alpine-linux, but there appears to be no way to exclude on alpine-linux platform specifically
-# sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4366 linux-all
-sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issues/4432 aix-all,linux-all
+sun/security/krb5/auto/Cleaners.java	https://github.com/adoptium/aqa-tests/issues/4366,https://github.com/adoptium/aqa-tests/issues/4432	aix-all,linux-all
 
 ###########################################################################
 
@@ -283,8 +254,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java	https://github.com/adoptium/aqa-tests/issues/5871,https://github.com/adoptium/aqa-tests/issues/4155	windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
@@ -364,11 +334,9 @@ compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/is
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
@@ -465,18 +433,14 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 runtime/memory/ReadFromNoaccessArea.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
-#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
+runtime/cds/TestCDSVMCrash.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
-#runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5920 macosx-all,windows-aarch64
+runtime/cds/appcds/TestDumpClassListSource.java	https://github.com/adoptium/aqa-tests/issues/5645,https://github.com/adoptium/aqa-tests/issues/5920	macosx-all,windows-aarch64
 runtime/cds/appcds/TransformInterfaceOfLambda.java https://github.com/adoptium/aqa-tests/issues/5920 macosx-all,windows-aarch64
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,windows-aarch64
+runtime/jni/nativeStack/TestNativeStack.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5384	aix-all,windows-aarch64
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
@@ -506,8 +470,7 @@ serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issue
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
-#serviceability/sa/ClhsdbJstackXcompStress.java https://bugs.openjdk.org/browse/JDK-8348864 windows-aarch64
-serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86,windows-aarch64
+serviceability/sa/ClhsdbJstackXcompStress.java	https://bugs.openjdk.org/browse/JDK-8348864,https://github.com/adoptium/aqa-tests/issues/5378	windows-x86,windows-aarch64
 serviceability/sa/ClhsdbJstack.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64

--- a/openjdk/excludes/ProblemList_openjdk24-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk24-openj9.txt
@@ -143,11 +143,10 @@ jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issu
 ############################################################################
 
 # jdk_internal
-jdk/internal/loader/NativeLibraries/Main.java  https://github.com/eclipse-openj9/openj9/issues/9018  generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/eclipse-openj9/openj9/issues/9018,https://github.com/adoptium/aqa-tests/issues/1920	generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/vm/Continuation/MovingCompWindow.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
-jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 jdk/internal/vm/Continuation/Basic.java#id0 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/Basic.java#id1 https://github.com/eclipse-openj9/openj9/issues/15163 generic-all
 jdk/internal/vm/Continuation/ClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/15152 generic-all
@@ -253,8 +252,7 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclip
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -294,14 +292,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699   generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk24.txt
+++ b/openjdk/excludes/ProblemList_openjdk24.txt
@@ -18,48 +18,32 @@
 
 # jdk_beans
 
-# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
@@ -67,8 +51,7 @@ java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-test
 
 # jdk_lang
 
-# java/lang/String/StringRepeat.java https://bugs.openjdk.java.net/browse/JDK-8221400
-java/lang/String/StringRepeat.java https://github.com/adoptium/aqa-tests/issues/1272 windows-all,
+java/lang/String/StringRepeat.java	https://bugs.openjdk.java.net/browse/JDK-8221400,https://github.com/adoptium/aqa-tests/issues/1272	windows-all,
 java/lang/String/concat/IntegerMinValue.java https://github.com/adoptium/aqa-tests/issues/4789 aix-all
 jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
 java/lang/ProcessBuilder/checkHandles/CheckHandles.java https://github.com/adoptium/aqa-tests/issues/1920 windows-all
@@ -84,8 +67,7 @@ java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
+sun/management/jmxremote/startstop/JMXStatusTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://bugs.openjdk.org/browse/JDK-8207908	macosx-all,linux-ppc64le
 sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
@@ -103,8 +85,7 @@ sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-t
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,linux-arm,aix-all
 
@@ -150,8 +131,7 @@ java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tes
 java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le 
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3820,https://github.com/adoptium/aqa-tests/issues/3088	aix-ppc64,linux-ppc64le
 java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -183,8 +163,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 # jdk_io
 
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm, aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 ############################################################################
 
 # jdk_jdi
@@ -200,11 +179,8 @@ com/sun/jdi/FinalizerTest.java https://github.com/adoptium/aqa-tests/issues/5705
 
 # jdk_nio
 
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
@@ -212,12 +188,9 @@ java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/
 java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java https://github.com/eclipse-openj9/openj9/issues/21959 windows-x64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
@@ -283,8 +256,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java	https://github.com/adoptium/aqa-tests/issues/5871,https://github.com/adoptium/aqa-tests/issues/4155	windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
@@ -295,7 +267,7 @@ sun/tools/jstatd/TestJstatdPort.java https://github.com/adoptium/aqa-tests/issue
 sun/tools/jstatd/TestJstatdPortAndServer.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/tools/jstatd/TestJstatdRmiPort.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/tools/jstatd/TestJstatdServer.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-tools/jpackage/share/AddLauncherTest.java#id1 https://github.com/adoptium/infrastructure/issues/2310 windows-all
+tools/jpackage/share/AddLauncherTest.java#id1	https://github.com/adoptium/infrastructure/issues/2310,https://bugs.openjdk.org/browse/JDK-8347124	generic-all
 tools/jpackage/share/AppImagePackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/EmptyFolderPackageTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/jpackage/share/FileAssociationsTest.java#id0 https://github.com/adoptium/infrastructure/issues/2310 windows-all
@@ -329,7 +301,6 @@ tools/jpackage/share/AddLShortcutTest.java https://github.com/adoptium/infrastru
 tools/jpackage/share/AppContentTest.java https://github.com/adoptium/infrastructure/issues/2310 windows-all
 tools/launcher/JliLaunchTest.java https://github.com/adoptium/aqa-tests/issues/5010 aix-all
 tools/jpackage/linux/LinuxWeirdOutputDirTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
-tools/jpackage/share/AddLauncherTest.java#id1 https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/AppLauncherEnvTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/AppVersionTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/ArgumentsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
@@ -338,8 +309,7 @@ tools/jpackage/share/DotInNameTest.java https://bugs.openjdk.org/browse/JDK-8347
 tools/jpackage/share/EmptyFolderTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/InOutPathTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/JLinkOptionsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
-tools/jpackage/share/JavaOptionsEqualsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
-tools/jpackage/share/JavaOptionsEqualsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
+tools/jpackage/share/JavaOptionsEqualsTest.java	https://bugs.openjdk.org/browse/JDK-8347124	generic-all
 tools/jpackage/share/JavaOptionsTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/MainClassTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
 tools/jpackage/share/MultipleJarAppTest.java https://bugs.openjdk.org/browse/JDK-8347124 generic-all
@@ -381,11 +351,9 @@ compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/is
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
 compiler/loopstripmining/TestPinnedUseInOuterLSMUnusedBySfpt.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
@@ -483,18 +451,15 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 runtime/memory/ReadFromNoaccessArea.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
 runtime/cds/TestDefaultArchiveLoading.java#coops_nocoh https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
 runtime/cds/TestDefaultArchiveLoading.java#nocoops_nocoh https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
-#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+runtime/cds/TestCDSVMCrash.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,windows-aarch64
+runtime/jni/nativeStack/TestNativeStack.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5384	aix-all,windows-aarch64
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
@@ -503,8 +468,7 @@ runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-833755
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/infrastructure/issues/3984 macosx-aarch64, linux-riscv64, linux-ppc64le
-runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-aarch64,linux-riscv64,linux-ppc64le
+runtime/ErrorHandling/CreateCoredumpOnCrash.java	https://github.com/adoptium/infrastructure/issues/3984,https://bugs.openjdk.org/browse/JDK-8348862	windows-aarch64,macosx-aarch64,linux-riscv64,linux-ppc64le
 runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/cds/appcds/complexURI/ComplexURITest.java https://github.com/adoptium/adoptium-support/issues/937 macosx-x64
@@ -524,8 +488,7 @@ serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issue
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
-#serviceability/sa/ClhsdbJstackXcompStress.java https://bugs.openjdk.org/browse/JDK-8348864 windows-aarch64
-serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86,windows-aarch64
+serviceability/sa/ClhsdbJstackXcompStress.java	https://bugs.openjdk.org/browse/JDK-8348864,https://github.com/adoptium/aqa-tests/issues/5378	windows-x86,windows-aarch64
 serviceability/sa/ClhsdbJstack.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64

--- a/openjdk/excludes/ProblemList_openjdk25-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk25-openj9.txt
@@ -143,8 +143,7 @@ jni/nullCaller/NullCallerTest.java https://github.com/eclipse-openj9/openj9/issu
 ############################################################################
 
 # jdk_internal
-# jdk/internal/loader/NativeLibraries/Main.java https://github.com/eclipse-openj9/openj9/issues/9018 generic-all
-jdk/internal/loader/NativeLibraries/Main.java https://github.com/adoptium/aqa-tests/issues/1920 generic-all
+jdk/internal/loader/NativeLibraries/Main.java	https://github.com/eclipse-openj9/openj9/issues/9018,https://github.com/adoptium/aqa-tests/issues/1920	generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id2 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/reflect/Reflection/GetCallerClassTest.java#id3 https://github.com/eclipse-openj9/openj9/issues/14097 generic-all
 jdk/internal/vm/Continuation/MovingCompWindow.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
@@ -254,8 +253,7 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclip
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -296,14 +294,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699   generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk25.txt
+++ b/openjdk/excludes/ProblemList_openjdk25.txt
@@ -18,48 +18,32 @@
 
 # jdk_beans
 
-# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
@@ -81,14 +65,9 @@ java/lang/Thread/virtual/stress/PingPong.java#sq https://github.com/adoptium/aqa
 
 com/sun/management/HotSpotDiagnosticMXBean/DumpThreadsWithEliminatedLock.java https://bugs.openjdk.org/browse/JDK-8380382 linux-s390x
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
-# sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
-# sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jmxremote/startstop/JMXStatusTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://bugs.openjdk.org/browse/JDK-8207908	macosx-all,linux-ppc64le
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 
 ############################################################################
 
@@ -102,8 +81,7 @@ sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,linux-arm,aix-all
 
@@ -138,33 +116,15 @@ java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/iss
 java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/CookieHandler/CookieManagerTest.java https://github.com/adoptium/infrastructure/issues/699 aix-ppc64,linux-ppc64le
-# java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le
-# java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le
 # java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/ProxyCons.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/ReadTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/SetSoLinger.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/SoTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/setReuseAddress/Basic.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socks/BadProxySelector.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socks/SocksProxyVersion.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/asyncClose/Race.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -183,8 +143,7 @@ java/net/httpclient/ConnectTimeoutWithProxyAsync.java https://bugs.openjdk.org/b
 
 # jdk_io
 
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 ############################################################################
 
 # jdk_jdi
@@ -200,24 +159,17 @@ com/sun/jdi/FinalizerTest.java https://github.com/adoptium/aqa-tests/issues/5705
 
 # jdk_nio
 
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/nio/file/spi/SetDefaultProvider.java https://github.com/adoptium/aqa-tests/issues/2871 linux-arm
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
-# java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 aix-all,linux-aarch64
 java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java https://github.com/eclipse-openj9/openj9/issues/21959 windows-x64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
@@ -283,8 +235,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java	https://github.com/adoptium/aqa-tests/issues/5871,https://github.com/adoptium/aqa-tests/issues/4155	windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-arm,linux-ppc64le
@@ -342,11 +293,9 @@ compiler/c2/cr6340864/TestByteVect.java https://github.com/adoptium/aqa-tests/is
 compiler/c2/cr6340864/TestDoubleVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestFloatVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/c2/cr6340864/TestIntVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestIntVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestIntVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestLongVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
-# compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/3004 windows-x86
-compiler/c2/cr6340864/TestLongVectRotate.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
+compiler/c2/cr6340864/TestLongVectRotate.java	https://github.com/adoptium/aqa-tests/issues/3004,https://github.com/adoptium/aqa-tests/issues/2382	windows-x86
 compiler/c2/cr6340864/TestShortVect.java https://github.com/adoptium/aqa-tests/issues/2382 windows-x86
 compiler/intrinsics/TestContinuationPinningAndEA.java https://bugs.openjdk.org/browse/JDK-8349193 linux-s390x
 compiler/unsafe/UnsafeCopyMemory.java https://github.com/adoptium/aqa-tests/issues/2804 aix-ppc64,linux-s390x
@@ -383,24 +332,18 @@ jdk/jfr/jvm/TestDumpOnCrash.java https://github.com/adoptium/aqa-tests/issues/41
 # jdk_vector
 
 jdk/incubator/vector/Byte512VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-# jdk/incubator/vector/Byte64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-# jdk/incubator/vector/ByteMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-# jdk/incubator/vector/Int64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-# jdk/incubator/vector/IntMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-# jdk/incubator/vector/Short64VectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
-# jdk/incubator/vector/ShortMaxVectorTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/Byte256VectorLoadStoreTests.java https://github.com/adoptium/aqa-tests/issues/2874 linux-arm
 jdk/incubator/vector/Int64VectorLoadStoreTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
 jdk/incubator/vector/Byte64VectorLoadStoreTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
-jdk/incubator/vector/Byte64VectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all,linux-arm
+jdk/incubator/vector/Byte64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874,https://bugs.openjdk.org/browse/JDK-8370244	aix-all,linux-arm
 jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
-jdk/incubator/vector/ByteMaxVectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all,linux-arm
+jdk/incubator/vector/ByteMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874,https://bugs.openjdk.org/browse/JDK-8370244	aix-all,linux-arm
 jdk/incubator/vector/Float64VectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
 jdk/incubator/vector/FloatMaxVectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all
-jdk/incubator/vector/Int64VectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all,linux-arm
-jdk/incubator/vector/IntMaxVectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all,linux-arm
-jdk/incubator/vector/Short64VectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all,linux-arm
-jdk/incubator/vector/ShortMaxVectorTests.java https://bugs.openjdk.org/browse/JDK-8370244 aix-all,linux-arm
+jdk/incubator/vector/Int64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874,https://bugs.openjdk.org/browse/JDK-8370244	aix-all,linux-arm
+jdk/incubator/vector/IntMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874,https://bugs.openjdk.org/browse/JDK-8370244	aix-all,linux-arm
+jdk/incubator/vector/Short64VectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874,https://bugs.openjdk.org/browse/JDK-8370244	aix-all,linux-arm
+jdk/incubator/vector/ShortMaxVectorTests.java	https://github.com/adoptium/aqa-tests/issues/2874,https://bugs.openjdk.org/browse/JDK-8370244	aix-all,linux-arm
 
 ############################################################################
 
@@ -425,14 +368,9 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://bugs.openjdk.org
 
 # sun_net
 
-# sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/http/KeepAliveCache/B5045306.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/http/ZoneId.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java https://bugs.openjdk.java.net/browse/JDK-8224204 generic-all
 sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
@@ -456,16 +394,13 @@ gc/shenandoah/jni/CriticalNativeStress.java https://github.com/adoptium/aqa-test
 runtime/memory/ReadFromNoaccessArea.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
-#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
+runtime/cds/TestCDSVMCrash.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/LambdaEagerInit.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,windows-aarch64
+runtime/jni/nativeStack/TestNativeStack.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5384	aix-all,windows-aarch64
 runtime/logging/loadLibraryTest/LoadLibraryTest.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java https://bugs.openjdk.java.net/browse/JDK-8269135 windows-x86
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
@@ -474,8 +409,6 @@ runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-833755
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/infrastructure/issues/3984 macosx-all,linux-riscv64,linux-ppc64le
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
 runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/jni/checked/TestLargeUTF8Length.java https://github.com/adoptium/aqa-tests/issues/6666 generic-all
@@ -495,8 +428,7 @@ serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issue
 serviceability/sa/ClhsdbFindPC.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#id1 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbJhisto.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
-#serviceability/sa/ClhsdbJstackXcompStress.java https://bugs.openjdk.org/browse/JDK-8348864 windows-aarch64
-serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-x86,windows-aarch64
+serviceability/sa/ClhsdbJstackXcompStress.java	https://bugs.openjdk.org/browse/JDK-8348864,https://github.com/adoptium/aqa-tests/issues/5378	windows-x86,windows-aarch64
 serviceability/sa/ClhsdbJstack.java#id0 https://github.com/adoptium/aqa-tests/issues/5378  windows-x86
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
@@ -542,53 +474,53 @@ vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adop
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/DatagramPacket/ReuseBuf.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/DatagramSocket/B6411513.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-all
-java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-all
-java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/Send12k.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-ppc64,linux-ppc64le
+java/net/DatagramSocket/DatagramSocketExample.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-all
+java/net/DatagramSocket/PortUnreachable.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/DatagramSocket/Send12k.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3820,https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-ppc64,linux-ppc64le
 java/net/DatagramSocket/SendSize.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PlainSocketImpl/BigBacklog.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PortUnreachableException/Concurrent.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PortUnreachableException/OneExceptionOnly.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/Socket/B6210227.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/GetLocalAddress.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/GetLocalAddress.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/Socket/HttpProxy.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/InheritTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/ProxyCons.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/ReadTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/SetSoLinger.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/SoTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/InheritTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/ProxyCons.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/ReadTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/SetSoLinger.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/SoTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/Socket/SocksConnectTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socks/BadProxySelector.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/setReuseAddress/Restart.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/SocketInputStream/SocketTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socks/BadProxySelector.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.com/adoptium/infrastructure/issues/4262 linux-s390x,linux-aarch64,aix-all
+java/nio/channels/FileChannel/LargeGatheringWrite.java	https://bugs.openjdk.org/browse/JDK-8278469,https://github.com/adoptium/infrastructure/issues/4262	linux-s390x,linux-aarch64,aix-all
 jdk/jfr/jvm/TestChunkIntegrity.java https://github.com/adoptium/aqa-tests/issues/6589 linux-s390x
 jdk/jfr/jvm/TestJFRIntrinsic.java https://github.com/adoptium/aqa-tests/issues/6589 linux-s390x
-runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/aqa-tests/issues/6596 linux-s390x,linux-x64,windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
-sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
+runtime/ErrorHandling/CreateCoredumpOnCrash.java	https://github.com/adoptium/infrastructure/issues/3984,https://bugs.openjdk.org/browse/JDK-8348862,https://github.com/adoptium/aqa-tests/issues/6596	linux-s390x,linux-x64,windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
+sun/management/jdp/JdpDefaultsTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpSpecificAddressTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/JvmstatCountersTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/LocalManagementTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/management/jmxremote/startstop/JMXStartStopTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/http/HttpClient/B8025710.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/B6299712.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/net/www/protocol/http/B6369510.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/HttpOnly.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/NoCache.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/B6216082.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/security/util/math/TestIntegerModuloP.java#Curve448OrderField https://github.com/adoptium/infrastructure/issues/3855 windows-x64
 sun/security/util/math/TestIntegerModuloP.java#IntegerPolynomial448 https://github.com/adoptium/infrastructure/issues/3855 windows-x64
 sun/security/util/math/TestIntegerModuloP.java#IntegerPolynomialP384 https://github.com/adoptium/infrastructure/issues/3855 windows-x64

--- a/openjdk/excludes/ProblemList_openjdk26-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk26-openj9.txt
@@ -261,8 +261,7 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclip
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -303,14 +302,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699   generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk26.txt
+++ b/openjdk/excludes/ProblemList_openjdk26.txt
@@ -18,48 +18,32 @@
 
 # jdk_beans
 
-# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
@@ -82,14 +66,9 @@ java/lang/instrument/RetransformRecordTypeAnn/TestRetransformRecord.java https:/
 
 com/sun/management/HotSpotDiagnosticMXBean/DumpThreadsWithEliminatedLock.java https://bugs.openjdk.org/browse/JDK-8380382 linux-s390x
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
-# sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
-# sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jmxremote/startstop/JMXStatusTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://bugs.openjdk.org/browse/JDK-8207908	macosx-all,linux-ppc64le
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 
 ############################################################################
 
@@ -103,8 +82,7 @@ sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,aix-all
 
@@ -141,33 +119,15 @@ java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/iss
 java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/CookieHandler/CookieManagerTest.java https://github.com/adoptium/infrastructure/issues/699 aix-ppc64,linux-ppc64le
-# java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le
-# java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le 
 # java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/ProxyCons.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/ReadTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/SetSoLinger.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/SoTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/setReuseAddress/Basic.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socks/BadProxySelector.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socks/SocksProxyVersion.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/asyncClose/Race.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -185,8 +145,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 # jdk_io
 
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,aix-all
 ############################################################################
 
 # jdk_jdi
@@ -202,24 +161,16 @@ com/sun/jdi/FinalizerTest.java https://github.com/adoptium/aqa-tests/issues/5705
 
 # jdk_nio
 
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
-# java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 aix-all,linux-aarch64
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
-# java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 aix-all
 java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java https://github.com/eclipse-openj9/openj9/issues/21959 windows-x64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
@@ -284,8 +235,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java	https://github.com/adoptium/aqa-tests/issues/5871,https://github.com/adoptium/aqa-tests/issues/4155	windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-ppc64le
@@ -395,14 +345,9 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://bugs.openjdk.org
 
 # sun_net
 
-# sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/http/KeepAliveCache/B5045306.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/http/ZoneId.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java https://bugs.openjdk.java.net/browse/JDK-8224204 generic-all
 sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
@@ -424,23 +369,18 @@ containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JD
 runtime/memory/ReadFromNoaccessArea.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
-#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
+runtime/cds/TestCDSVMCrash.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,windows-aarch64
+runtime/jni/nativeStack/TestNativeStack.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5384	aix-all,windows-aarch64
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all
 runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/infrastructure/issues/3984 macosx-all,linux-riscv64,linux-ppc64le
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
 runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/jni/checked/TestLargeUTF8Length.java https://github.com/adoptium/aqa-tests/issues/6666 generic-all
@@ -455,8 +395,7 @@ serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfo
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
-#serviceability/sa/ClhsdbJstackXcompStress.java https://bugs.openjdk.org/browse/JDK-8348864 windows-aarch64
-serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-aarch64
+serviceability/sa/ClhsdbJstackXcompStress.java	https://bugs.openjdk.org/browse/JDK-8348864,https://github.com/adoptium/aqa-tests/issues/5378	windows-aarch64
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-process https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
@@ -501,53 +440,53 @@ vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adop
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/DatagramPacket/ReuseBuf.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/DatagramSocket/B6411513.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-all
-java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-all
-java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/Send12k.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-ppc64,linux-ppc64le
+java/net/DatagramSocket/DatagramSocketExample.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-all
+java/net/DatagramSocket/PortUnreachable.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/DatagramSocket/Send12k.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3820,https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-ppc64,linux-ppc64le
 java/net/DatagramSocket/SendSize.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PlainSocketImpl/BigBacklog.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PortUnreachableException/Concurrent.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PortUnreachableException/OneExceptionOnly.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/Socket/B6210227.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/GetLocalAddress.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/GetLocalAddress.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/Socket/HttpProxy.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/InheritTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/ProxyCons.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/ReadTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/SetSoLinger.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/SoTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/InheritTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/ProxyCons.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/ReadTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/SetSoLinger.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/SoTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/Socket/SocksConnectTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socks/BadProxySelector.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/setReuseAddress/Restart.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/SocketInputStream/SocketTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socks/BadProxySelector.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.com/adoptium/infrastructure/issues/4262 linux-s390x,linux-aarch64,aix-all
+java/nio/channels/FileChannel/LargeGatheringWrite.java	https://bugs.openjdk.org/browse/JDK-8278469,https://github.com/adoptium/infrastructure/issues/4262	linux-s390x,linux-aarch64,aix-all
 jdk/jfr/jvm/TestChunkIntegrity.java https://github.com/adoptium/aqa-tests/issues/6589 linux-s390x
 jdk/jfr/jvm/TestJFRIntrinsic.java https://github.com/adoptium/aqa-tests/issues/6589 linux-s390x
-runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/aqa-tests/issues/6596 linux-s390x,linux-x64,windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
-sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
+runtime/ErrorHandling/CreateCoredumpOnCrash.java	https://github.com/adoptium/infrastructure/issues/3984,https://bugs.openjdk.org/browse/JDK-8348862,https://github.com/adoptium/aqa-tests/issues/6596	linux-s390x,linux-x64,windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
+sun/management/jdp/JdpDefaultsTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpSpecificAddressTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/JvmstatCountersTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/LocalManagementTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/management/jmxremote/startstop/JMXStartStopTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/http/HttpClient/B8025710.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/B6299712.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/net/www/protocol/http/B6369510.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/HttpOnly.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/NoCache.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/B6216082.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/security/util/math/TestIntegerModuloP.java#Curve448OrderField https://github.com/adoptium/infrastructure/issues/3855 windows-x64
 sun/security/util/math/TestIntegerModuloP.java#IntegerPolynomial448 https://github.com/adoptium/infrastructure/issues/3855 windows-x64
 sun/security/util/math/TestIntegerModuloP.java#IntegerPolynomialP384 https://github.com/adoptium/infrastructure/issues/3855 windows-x64

--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -263,8 +263,7 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclip
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -305,14 +304,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699   generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk27.txt
+++ b/openjdk/excludes/ProblemList_openjdk27.txt
@@ -18,48 +18,32 @@
 
 # jdk_beans
 
-# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
@@ -82,14 +66,9 @@ java/lang/instrument/RetransformRecordTypeAnn/TestRetransformRecord.java https:/
 
 com/sun/management/HotSpotDiagnosticMXBean/DumpThreadsWithEliminatedLock.java https://bugs.openjdk.org/browse/JDK-8380382 linux-s390x
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
-# sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
-# sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jmxremote/startstop/JMXStatusTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://bugs.openjdk.org/browse/JDK-8207908	macosx-all,linux-ppc64le
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 
 ############################################################################
 
@@ -103,8 +82,7 @@ sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,aix-all
 
@@ -141,33 +119,15 @@ java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/iss
 java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/CookieHandler/CookieManagerTest.java https://github.com/adoptium/infrastructure/issues/699 aix-ppc64,linux-ppc64le
-# java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le
-# java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le 
 # java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/ProxyCons.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/ReadTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/SetSoLinger.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/SoTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/setReuseAddress/Basic.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socks/BadProxySelector.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socks/SocksProxyVersion.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/asyncClose/Race.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -185,8 +145,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 # jdk_io
 
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,aix-all
 ############################################################################
 
 # jdk_jdi
@@ -202,24 +161,16 @@ com/sun/jdi/FinalizerTest.java https://github.com/adoptium/aqa-tests/issues/5705
 
 # jdk_nio
 
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
-# java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 aix-all,linux-aarch64
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
-# java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 aix-all
 java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java https://github.com/eclipse-openj9/openj9/issues/21959 windows-x64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
@@ -284,8 +235,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java	https://github.com/adoptium/aqa-tests/issues/5871,https://github.com/adoptium/aqa-tests/issues/4155	windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-ppc64le
@@ -395,14 +345,9 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://bugs.openjdk.org
 
 # sun_net
 
-# sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/http/KeepAliveCache/B5045306.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/http/ZoneId.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java https://bugs.openjdk.java.net/browse/JDK-8224204 generic-all
 sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
@@ -424,23 +369,18 @@ containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JD
 runtime/memory/ReadFromNoaccessArea.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
-#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
+runtime/cds/TestCDSVMCrash.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,windows-aarch64
+runtime/jni/nativeStack/TestNativeStack.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5384	aix-all,windows-aarch64
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all
 runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/infrastructure/issues/3984 macosx-all,linux-riscv64,linux-ppc64le
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
 runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/jni/checked/TestLargeUTF8Length.java https://github.com/adoptium/aqa-tests/issues/6666 generic-all
@@ -455,8 +395,7 @@ serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfo
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
-#serviceability/sa/ClhsdbJstackXcompStress.java https://bugs.openjdk.org/browse/JDK-8348864 windows-aarch64
-serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-aarch64
+serviceability/sa/ClhsdbJstackXcompStress.java	https://bugs.openjdk.org/browse/JDK-8348864,https://github.com/adoptium/aqa-tests/issues/5378	windows-aarch64
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-process https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
@@ -501,53 +440,53 @@ vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adop
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/DatagramPacket/ReuseBuf.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/DatagramSocket/B6411513.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-all
-java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-all
-java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/Send12k.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-ppc64,linux-ppc64le
+java/net/DatagramSocket/DatagramSocketExample.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-all
+java/net/DatagramSocket/PortUnreachable.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/DatagramSocket/Send12k.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3820,https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-ppc64,linux-ppc64le
 java/net/DatagramSocket/SendSize.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PlainSocketImpl/BigBacklog.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PortUnreachableException/Concurrent.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PortUnreachableException/OneExceptionOnly.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/Socket/B6210227.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/GetLocalAddress.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/GetLocalAddress.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/Socket/HttpProxy.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/InheritTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/ProxyCons.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/ReadTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/SetSoLinger.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/SoTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/InheritTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/ProxyCons.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/ReadTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/SetSoLinger.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/SoTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/Socket/SocksConnectTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socks/BadProxySelector.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/setReuseAddress/Restart.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/SocketInputStream/SocketTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socks/BadProxySelector.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.com/adoptium/infrastructure/issues/4262 linux-s390x,linux-aarch64,aix-all
+java/nio/channels/FileChannel/LargeGatheringWrite.java	https://bugs.openjdk.org/browse/JDK-8278469,https://github.com/adoptium/infrastructure/issues/4262	linux-s390x,linux-aarch64,aix-all
 jdk/jfr/jvm/TestChunkIntegrity.java https://github.com/adoptium/aqa-tests/issues/6589 linux-s390x
 jdk/jfr/jvm/TestJFRIntrinsic.java https://github.com/adoptium/aqa-tests/issues/6589 linux-s390x
-runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/aqa-tests/issues/6596 linux-s390x,linux-x64,windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
-sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
+runtime/ErrorHandling/CreateCoredumpOnCrash.java	https://github.com/adoptium/infrastructure/issues/3984,https://bugs.openjdk.org/browse/JDK-8348862,https://github.com/adoptium/aqa-tests/issues/6596	linux-s390x,linux-x64,windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
+sun/management/jdp/JdpDefaultsTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpSpecificAddressTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/JvmstatCountersTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/LocalManagementTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/management/jmxremote/startstop/JMXStartStopTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/http/HttpClient/B8025710.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/B6299712.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/net/www/protocol/http/B6369510.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/HttpOnly.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/NoCache.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/B6216082.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/security/util/math/TestIntegerModuloP.java#Curve448OrderField https://github.com/adoptium/infrastructure/issues/3855 windows-x64
 sun/security/util/math/TestIntegerModuloP.java#IntegerPolynomial448 https://github.com/adoptium/infrastructure/issues/3855 windows-x64
 sun/security/util/math/TestIntegerModuloP.java#IntegerPolynomialP384 https://github.com/adoptium/infrastructure/issues/3855 windows-x64

--- a/openjdk/excludes/ProblemList_openjdk28-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk28-openj9.txt
@@ -263,8 +263,7 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://github.com/eclip
 # jdk_io
 
 java/io/CharArrayReader/OverflowInRead.java https://github.com/adoptium/aqa-tests/issues/1500 generic-all
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 linux-arm,aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,linux-arm,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,linux-arm,aix-all
 java/io/FileInputStream/UnreferencedFISClosesFd.java  https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 java/io/FileOutputStream/UnreferencedFOSClosesFd.java https://github.com/eclipse-openj9/openj9/issues/3543 generic-all
 
@@ -305,14 +304,9 @@ java/nio/channels/DatagramChannel/EmptyBuffer.java https://github.ibm.com/runtim
 java/nio/channels/DatagramChannel/IsBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/IsConnected.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Loopback.java https://github.ibm.com/runtimes/backlog/issues/655 linux-s390x,windows-all
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-#java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 generic-all
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/aqa-tests/issues/1267	generic-all
 java/nio/channels/DatagramChannel/NotBound.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/eclipse-openj9/openj9/issues/6669
-#java/nio/channels/DatagramChannel/Promiscuous.java is excluded for all platforms and java levels due to issue https://github.ibm.com/runtimes/backlog/issues/783
-java/nio/channels/DatagramChannel/Promiscuous.java  https://github.com/adoptium/infrastructure/issues/699   generic-all
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/eclipse-openj9/openj9/issues/6669,https://github.ibm.com/runtimes/backlog/issues/783,https://github.com/adoptium/infrastructure/issues/699	generic-all
 java/nio/channels/DatagramChannel/PromiscuousIPv6.java https://github.com/adoptium/infrastructure/issues/699    linux-s390x
 java/nio/channels/DatagramChannel/ReceiveISA.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all
 java/nio/channels/DatagramChannel/Sender.java https://github.ibm.com/runtimes/backlog/issues/741 generic-all

--- a/openjdk/excludes/ProblemList_openjdk28.txt
+++ b/openjdk/excludes/ProblemList_openjdk28.txt
@@ -18,48 +18,32 @@
 
 # jdk_beans
 
-# java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://bugs.openjdk.org/browse/JDK-8336862 windows-all
 
-java/beans/PropertyEditor/6380849/TestPropertyEditor.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestColorClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClass.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-# java/beans/PropertyEditor/TestFontClassJava.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/PropertyEditor/TestFontClassValue.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/PropertyEditor/TestFontClassJava.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
-java/beans/PropertyEditor/TestFontClassNull.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,windows-all
-java/beans/PropertyEditor/TestFontClassValue.java https://bugs.openjdk.java.net/browse/JDK-8173082 macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/6380849/TestPropertyEditor.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestColorClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClass.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassJava.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
+java/beans/PropertyEditor/TestFontClassNull.java	https://bugs.openjdk.org/browse/JDK-8336862,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,windows-all
+java/beans/PropertyEditor/TestFontClassValue.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2138,https://bugs.openjdk.java.net/browse/JDK-8173082	macosx-all,linux-all,windows-all
 java/beans/XMLEncoder/java_awt_CardLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/java_awt_GridBagLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2848 macosx-all
-java/beans/XMLEncoder/java_awt_ScrollPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,macosx-all,windows-all
+java/beans/XMLEncoder/java_awt_ScrollPane.java	https://bugs.openjdk.org/browse/JDK-8336862,https://github.com/adoptium/aqa-tests/issues/2848,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,macosx-all,windows-all
 java/beans/XMLEncoder/javax_swing_Box.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_BoxLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_Box_Filler.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_DefaultCellEditor.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_JButton.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JLayeredPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_JSplitPane.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
-# java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/javax_swing_JTree.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all,linux-all
+java/beans/XMLEncoder/javax_swing_JTree.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-all,linux-all
 java/beans/XMLEncoder/javax_swing_OverlayLayout.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_border_TitledBorder.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/javax_swing_plaf_BorderUIResource_TitledBorderUIResource.java https://github.com/adoptium/aqa-tests/issues/2810 aix-all
 java/beans/XMLEncoder/Test4631471.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-# java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2138 linux-all
-java/beans/XMLEncoder/Test4903007.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64,linux-all
+java/beans/XMLEncoder/Test4903007.java	https://github.com/adoptium/aqa-tests/issues/2138,https://github.com/adoptium/aqa-tests/issues/2810	aix-ppc64,linux-all
 java/beans/PropertyChangeSupport/Test4682386.java https://github.com/adoptium/aqa-tests/issues/2810 aix-ppc64
 java/beans/Beans/TypoInBeanDescription.java https://github.com/adoptium/aqa-tests/issues/3841 aix-all
 
@@ -82,14 +66,9 @@ java/lang/instrument/RetransformRecordTypeAnn/TestRetransformRecord.java https:/
 
 com/sun/management/HotSpotDiagnosticMXBean/DumpThreadsWithEliminatedLock.java https://bugs.openjdk.org/browse/JDK-8380382 linux-s390x
 com/sun/management/OperatingSystemMXBean/TestTotalSwap.java https://bugs.openjdk.java.net/browse/JDK-8255263 linux-all
-# sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-# sun/management/jmxremote/startstop/JMXStatusTest.java https://github.com/adoptium/aqa-tests/issues/2808 linux-ppc64le
-sun/management/jmxremote/startstop/JMXStatusTest.java https://bugs.openjdk.org/browse/JDK-8207908 macosx-all,linux-ppc64le
-# sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
+sun/management/jmxremote/startstop/JMXStatusTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://bugs.openjdk.org/browse/JDK-8207908	macosx-all,linux-ppc64le
 sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
-# sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/aqa-tests/issues/2809 aix-all
 
 ############################################################################
 
@@ -103,8 +82,7 @@ sun/management/jdp/JdpOffTest.java https://github.com/adoptium/aqa-tests/issues/
 
 # jdk_other
 
-# com/sun/jndi/dns/ConfigTests/Timeout.java https://github.com/adoptium/aqa-tests/issues/2876 linux-s390x
-com/sun/jndi/dns/ConfigTests/Timeout.java https://bugs.openjdk.org/browse/JDK-8282993 generic-all
+com/sun/jndi/dns/ConfigTests/Timeout.java	https://github.com/adoptium/aqa-tests/issues/2876,https://bugs.openjdk.org/browse/JDK-8282993	generic-all
 com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.com/adoptium/aqa-tests/issues/3619 linux-ppc64le,windows-all
 jdk/incubator/concurrent/ScopedValue/StressStackOverflow.java https://bugs.openjdk.org/browse/JDK-8303498 linux-s390x,aix-all
 
@@ -141,33 +119,15 @@ java/net/MulticastSocket/B6427403.java https://github.com/adoptium/aqa-tests/iss
 java/net/MulticastSocket/NoLoopbackPackets.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all
 java/net/MulticastSocket/SetOutgoingIf.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
-# java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/JoinLeave.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/MulticastSocket/MulticastAddresses.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/adoptium/aqa-tests/issues/2246 aix-all
 java/net/CookieHandler/CookieManagerTest.java https://github.com/adoptium/infrastructure/issues/699 aix-ppc64,linux-ppc64le
-# java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le
-# java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/DatagramSocket/ReuseAddressTest.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/Send12k.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3088 aix-ppc64,linux-ppc64le 
 # java/net/DatagramSocket/SendSize.java.SendSize https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/CloseAvailable.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/GetLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/InheritTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/ProxyCons.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/ReadTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/SetSoLinger.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/SoTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/setReuseAddress/Basic.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# java/net/Socks/BadProxySelector.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socks/SocksProxyVersion.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/Socket/asyncClose/Race.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 java/net/ServerSocket/TestLocalAddress.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
@@ -185,8 +145,7 @@ java/nio/channels/vthread/BlockingChannelOps.java#direct-register https://github
 
 # jdk_io
 
-#java/io/File/GetXSpace.java https://bugs.openjdk.org/browse/JDK-8251017 aix-all
-java/io/File/GetXSpace.java https://bugs.openjdk.java.net/browse/JDK-8251466 windows-all,aix-all
+java/io/File/GetXSpace.java	https://bugs.openjdk.org/browse/JDK-8251017,https://bugs.openjdk.java.net/browse/JDK-8251466	windows-all,aix-all
 ############################################################################
 
 # jdk_jdi
@@ -202,24 +161,16 @@ com/sun/jdi/FinalizerTest.java https://github.com/adoptium/aqa-tests/issues/5705
 
 # jdk_nio
 
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java is excluded for two different reasons on different platforms https://github.com/adoptium/aqa-tests/issues/1016
-# java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
-java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java https://github.com/adoptium/aqa-tests/issues/1267 macosx-all,linux-s390x
-# java/nio/channels/DatagramChannel/Promiscuous.java is excluded on macosx due to different issue https://github.com/adoptium/aqa-tests/issues/602
-java/nio/channels/DatagramChannel/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,macosx-all 
-# java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 aix-all,linux-aarch64
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java	https://github.com/adoptium/aqa-tests/issues/1016,https://github.com/adoptium/infrastructure/issues/699,https://github.com/adoptium/aqa-tests/issues/1267	macosx-all,linux-s390x
+java/nio/channels/DatagramChannel/Promiscuous.java	https://github.com/adoptium/aqa-tests/issues/602,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,macosx-all
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
 java/nio/channels/Channels/ReadXBytes.java https://github.com/adoptium/aqa-tests/issues/3034 linux-aarch64,aix-all,linux-s390x,windows-x64,linux-ppc64le
-# java/nio/channels/FileChannel/LargeGatheringWrite.java https://bugs.openjdk.org/browse/JDK-8278469 aix-all
 java/nio/channels/FileChannel/Transfer2GPlus.java https://github.com/adoptium/aqa-tests/issues/3086 generic-all
 java/nio/channels/FileChannel/LoopingTruncate.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
 java/nio/channels/FileChannel/Transfer4GBFile.java https://github.com/adoptium/aqa-tests/issues/3686 windows-all
-# java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/AfterDisconnect.java https://github.com/adoptium/aqa-tests/issues/1650 aix-all
-# java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
-java/nio/channels/DatagramChannel/SendReceiveMaxSize.java https://github.com/adoptium/aqa-tests/issues/3820 aix-all
-# java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/infrastructure/issues/2645 windows-all
-java/nio/file/Files/probeContentType/Basic.java https://github.com/adoptium/aqa-tests/issues/2789 aix-ppc64,windows-all
+java/nio/channels/DatagramChannel/AfterDisconnect.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/1650	aix-all
+java/nio/channels/DatagramChannel/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3086,https://github.com/adoptium/aqa-tests/issues/3820	aix-all
+java/nio/file/Files/probeContentType/Basic.java	https://github.com/adoptium/infrastructure/issues/2645,https://github.com/adoptium/aqa-tests/issues/2789	aix-ppc64,windows-all
 java/nio/Buffer/DirectBufferAllocTest.java https://github.com/adoptium/aqa-tests/issues/3086 aix-ppc64
 java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java https://github.com/eclipse-openj9/openj9/issues/21959 windows-x64
 java/nio/file/attribute/BasicFileAttributeView/UnixSocketFile.java https://github.com/adoptium/aqa-tests/issues/593 linux-all
@@ -284,8 +235,7 @@ sun/security/krb5/auto/Cleaners.java https://github.com/adoptium/aqa-tests/issue
 # jdk_tools
 
 sun/tools/jhsdb/HeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-aarch64
-#sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/5871 windows-all
-sun/tools/jhsdb/JShellHeapDumpTest.java https://github.com/adoptium/aqa-tests/issues/4155 windows-all
+sun/tools/jhsdb/JShellHeapDumpTest.java	https://github.com/adoptium/aqa-tests/issues/5871,https://github.com/adoptium/aqa-tests/issues/4155	windows-all
 sun/tools/jstat/jstatLineCounts1.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-ppc64le
 sun/tools/jstat/jstatLineCounts2.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-ppc64le
 sun/tools/jstat/jstatLineCounts3.sh https://bugs.openjdk.java.net/browse/JDK-8248691 linux-ppc64le,aix-all,linux-ppc64le
@@ -395,14 +345,9 @@ javax/imageio/plugins/jpeg/JPEGsNotAcceleratedTest.java https://bugs.openjdk.org
 
 # sun_net
 
-# sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/http/KeepAliveCache/B5045306.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/http/ZoneId.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/B6226610.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
-# sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/PostThruProxyWithAuth.java https://bugs.openjdk.java.net/browse/JDK-8224204 generic-all
 sun/net/www/protocol/jar/MultiReleaseJarURLConnection.java https://github.com/adoptium/aqa-tests/issues/3088 linux-ppc64le
 
@@ -424,23 +369,18 @@ containers/docker/TestMemoryWithCgroupV1.java https://bugs.openjdk.org/browse/JD
 runtime/memory/ReadFromNoaccessArea.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
 runtime/ErrorHandling/UncaughtNativeExceptionTest.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-#runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/CheckDefaultArchiveFile.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
-#runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/cds/TestCDSVMCrash.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all,windows-aarch64
+runtime/cds/CheckDefaultArchiveFile.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
+runtime/cds/TestCDSVMCrash.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5645	macosx-all,windows-aarch64
 runtime/cds/appcds/CommandLineFlagCombo.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/TestDumpClassListSource.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveNoDefaultArchive.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
-#runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5671 windows-aarch64
-runtime/jni/nativeStack/TestNativeStack.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all,windows-aarch64
+runtime/jni/nativeStack/TestNativeStack.java	https://github.com/adoptium/aqa-tests/issues/5671,https://github.com/adoptium/aqa-tests/issues/5384	aix-all,windows-aarch64
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/aqa-tests/issues/5384 aix-all
 runtime/os/TestHugePageDecisionsAtVMStartup.java#THP_enabled https://bugs.openjdk.org/browse/JDK-8324580 linux-all
 runtime/os/TestTracePageSizes.java#G1 https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Parallel https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#Serial https://bugs.openjdk.org/browse/JDK-8337555 linux-all
 runtime/os/TestTracePageSizes.java#compiler-options https://bugs.openjdk.org/browse/JDK-8337555 linux-all
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/infrastructure/issues/3984 macosx-all,linux-riscv64,linux-ppc64le
-# runtime/ErrorHandling/CreateCoredumpOnCrash.java https://bugs.openjdk.org/browse/JDK-8348862 windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
 runtime/ReservedStack/ReservedStackTest.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/ReservedStack/ReservedStackTestCompiler.java https://github.com/adoptium/aqa-tests/issues/5886 windows-aarch64
 runtime/jni/checked/TestLargeUTF8Length.java https://github.com/adoptium/aqa-tests/issues/6666 generic-all
@@ -455,8 +395,7 @@ serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfo
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java https://github.com/adoptium/aqa-tests/issues/4469 aix-all
 serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java https://github.com/adoptium/aqa-tests/issues/5645 macosx-all
 serviceability/sa/ClhsdbCDSCore.java https://github.com/adoptium/aqa-tests/issues/5622 generic-all
-#serviceability/sa/ClhsdbJstackXcompStress.java https://bugs.openjdk.org/browse/JDK-8348864 windows-aarch64
-serviceability/sa/ClhsdbJstackXcompStress.java https://github.com/adoptium/aqa-tests/issues/5378  windows-aarch64
+serviceability/sa/ClhsdbJstackXcompStress.java	https://bugs.openjdk.org/browse/JDK-8348864,https://github.com/adoptium/aqa-tests/issues/5378	windows-aarch64
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-core https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbDumpheap.java https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
 serviceability/sa/ClhsdbFindPC.java#no-xcomp-process https://github.com/adoptium/aqa-tests/issues/5672 windows-aarch64
@@ -501,53 +440,53 @@ vmTestbase/gc/gctests/MTLinkedListGC/MTLinkedListGC.java https://github.com/adop
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanDoubleInvocationTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanInvocationTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/DatagramPacket/ReuseBuf.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/DatagramPacket/ReuseBuf.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/DatagramSocket/B6411513.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/DatagramSocket/DatagramSocketExample.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-all
-java/net/DatagramSocket/DatagramSocketMulticasting.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-all
-java/net/DatagramSocket/PortUnreachable.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/Send12k.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/SendReceiveMaxSize.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,aix-ppc64,linux-ppc64le
+java/net/DatagramSocket/DatagramSocketExample.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-all
+java/net/DatagramSocket/DatagramSocketMulticasting.java	https://github.com/adoptium/aqa-tests/issues/2246,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-all
+java/net/DatagramSocket/PortUnreachable.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/DatagramSocket/Send12k.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/DatagramSocket/SendReceiveMaxSize.java	https://github.com/adoptium/aqa-tests/issues/3820,https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,aix-ppc64,linux-ppc64le
 java/net/DatagramSocket/SendSize.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/MulticastSocket/SetLoopbackModeIPv4.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PlainSocketImpl/BigBacklog.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PortUnreachableException/Concurrent.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/PortUnreachableException/OneExceptionOnly.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 java/net/Socket/B6210227.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/GetLocalAddress.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/GetLocalAddress.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/Socket/HttpProxy.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/InheritTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/ProxyCons.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/ReadTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/SetSoLinger.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/SoTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/InheritTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/ProxyCons.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/ReadTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/SetSoLinger.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/SoTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/Socket/SocksConnectTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/net/Socket/asyncClose/BrokenPipe.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socket/setReuseAddress/Restart.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/SocketInputStream/SocketTimeout.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-java/net/Socks/BadProxySelector.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+java/net/Socket/asyncClose/BrokenPipe.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socket/setReuseAddress/Restart.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/SocketInputStream/SocketTimeout.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+java/net/Socks/BadProxySelector.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 java/net/ipv6tests/TcpTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-java/nio/channels/FileChannel/LargeGatheringWrite.java https://github.com/adoptium/infrastructure/issues/4262 linux-s390x,linux-aarch64,aix-all
+java/nio/channels/FileChannel/LargeGatheringWrite.java	https://bugs.openjdk.org/browse/JDK-8278469,https://github.com/adoptium/infrastructure/issues/4262	linux-s390x,linux-aarch64,aix-all
 jdk/jfr/jvm/TestChunkIntegrity.java https://github.com/adoptium/aqa-tests/issues/6589 linux-s390x
 jdk/jfr/jvm/TestJFRIntrinsic.java https://github.com/adoptium/aqa-tests/issues/6589 linux-s390x
-runtime/ErrorHandling/CreateCoredumpOnCrash.java https://github.com/adoptium/aqa-tests/issues/6596 linux-s390x,linux-x64,windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
-sun/management/jdp/JdpDefaultsTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
-sun/management/jdp/JdpSpecificAddressTest.java https://github.com/adoptium/infrastructure/issues/3189 linux-s390x,aix-all
+runtime/ErrorHandling/CreateCoredumpOnCrash.java	https://github.com/adoptium/infrastructure/issues/3984,https://bugs.openjdk.org/browse/JDK-8348862,https://github.com/adoptium/aqa-tests/issues/6596	linux-s390x,linux-x64,windows-aarch64,macosx-all,linux-riscv64,linux-ppc64le
+sun/management/jdp/JdpDefaultsTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
+sun/management/jdp/JdpSpecificAddressTest.java	https://github.com/adoptium/aqa-tests/issues/2809,https://github.com/adoptium/infrastructure/issues/3189	linux-s390x,aix-all
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/JvmstatCountersTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/LocalManagementTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
 sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/management/jmxremote/startstop/JMXStartStopTest.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/http/HttpClient/B8025710.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/protocol/http/B6299712.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/management/jmxremote/startstop/JMXStartStopTest.java	https://github.com/adoptium/aqa-tests/issues/2808,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/http/HttpClient/B8025710.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/B6299712.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/net/www/protocol/http/B6369510.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/net/www/protocol/http/HttpOnly.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
-sun/net/www/protocol/http/NoCache.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/HttpOnly.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
+sun/net/www/protocol/http/NoCache.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/net/www/protocol/https/HttpsURLConnection/B6216082.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x
-sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java https://github.com/adoptium/infrastructure/issues/2807 linux-s390x,linux-ppc64le
+sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java	https://github.com/adoptium/aqa-tests/issues/3088,https://github.com/adoptium/infrastructure/issues/2807	linux-s390x,linux-ppc64le
 sun/security/util/math/TestIntegerModuloP.java#Curve448OrderField https://github.com/adoptium/infrastructure/issues/3855 windows-x64
 sun/security/util/math/TestIntegerModuloP.java#IntegerPolynomial448 https://github.com/adoptium/infrastructure/issues/3855 windows-x64
 sun/security/util/math/TestIntegerModuloP.java#IntegerPolynomialP384 https://github.com/adoptium/infrastructure/issues/3855 windows-x64

--- a/openjdk/excludes/ProblemList_openjdk8-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk8-openj9.txt
@@ -125,13 +125,10 @@ sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java	  https://github
 sun/management/jmxremote/bootstrap/JvmstatCountersTest.java  https://github.com/adoptium/aqa-tests/issues/932 generic-all
 sun/management/jmxremote/bootstrap/LocalManagementTest.java  https://github.com/adoptium/aqa-tests/issues/932 generic-all
 sun/management/jmxremote/bootstrap/PasswordFilePermissionTest.java   https://github.com/adoptium/aqa-tests/issues/932 generic-all
-# sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
-sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh  https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh	https://github.com/adoptium/aqa-tests/issues/2294,https://github.com/adoptium/aqa-tests/issues/932	generic-all
 sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java   https://github.com/adoptium/aqa-tests/issues/932 generic-all
-# sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
-sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh  https://github.com/adoptium/aqa-tests/issues/932 generic-all
-# sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
-sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh  https://github.com/adoptium/aqa-tests/issues/932 generic-all
+sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh	https://github.com/adoptium/aqa-tests/issues/2294,https://github.com/adoptium/aqa-tests/issues/932	generic-all
+sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh	https://github.com/adoptium/aqa-tests/issues/2294,https://github.com/adoptium/aqa-tests/issues/932	generic-all
 sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.java   https://github.com/adoptium/aqa-tests/issues/932 generic-all
 sun/management/jmxremote/startstop/JMXStartStopTest.java  https://github.com/adoptium/aqa-tests/issues/932 generic-all
 sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java   https://github.com/adoptium/aqa-tests/issues/932 generic-all
@@ -161,24 +158,20 @@ java/net/DatagramSocket/Send12k.java https://github.ibm.com/runtimes/backlog/iss
 java/net/DatagramSocket/SendSize.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
 java/net/DatagramSocket/SetDatagramSocketImplFactory/ADatagramSocket.java https://github.ibm.com/runtimes/backlog/issues/684 macosx-all
 java/net/Inet4Address/PingThis.java	https://github.ibm.com/runtimes/backlog/issues/1595	aix-all
-# java/net/Inet6Address/B6206527.java on macosx-all issue https://github.com/adoptium/infrastructure/issues/1085
-java/net/Inet6Address/B6206527.java https://github.com/adoptium/infrastructure/issues/1105  linux-all,macosx-all
+java/net/Inet6Address/B6206527.java	https://github.com/adoptium/infrastructure/issues/1085,https://github.com/adoptium/infrastructure/issues/1105	linux-all,macosx-all
 java/net/MulticastSocket/B6427403.java https://github.ibm.com/runtimes/backlog/issues/715 macosx-all
 java/net/Inet6Address/B6558853.java	https://github.com/adoptium/aqa-tests/issues/827	macosx-all
 java/net/InetAddress/CheckJNI.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
 java/net/MulticastSocket/JoinLeave.java https://github.ibm.com/runtimes/backlog/issues/715 aix-all
 java/net/MulticastSocket/Promiscuous.java https://github.ibm.com/runtimes/backlog/issues/1605 macosx-all
 java/net/MulticastSocket/SetGetNetworkInterfaceTest.java	https://github.com/adoptium/aqa-tests/issues/1011	aix-all
-#java/net/MulticastSocket/SetLoopbackMode.java on aix issue	https://github.com/adoptium/aqa-tests/issues/1011
-java/net/MulticastSocket/SetLoopbackMode.java     https://github.ibm.com/runtimes/backlog/issues/1598  aix-all
+java/net/MulticastSocket/SetLoopbackMode.java	https://github.com/adoptium/aqa-tests/issues/1011,https://github.ibm.com/runtimes/backlog/issues/1598	aix-all
 java/net/MulticastSocket/SetOutgoingIf.java  https://github.com/adoptium/aqa-tests/issues/2246 macosx-all
-#java/net/MulticastSocket/Test.java	on aix issue https://github.com/adoptium/aqa-tests/issues/1011	aix-all
-java/net/MulticastSocket/Test.java  https://github.ibm.com/runtimes/backlog/issues/1606    macosx-all
+java/net/MulticastSocket/Test.java	https://github.com/adoptium/aqa-tests/issues/1011,https://github.ibm.com/runtimes/backlog/issues/1606	macosx-all
 java/net/NetworkInterface/UniqueMacAddressesTest.java https://github.ibm.com/runtimes/backlog/issues/719 macosx-all
 java/net/Socket/LinkLocal.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
 java/net/Socket/asyncClose/AsyncClose.java	https://github.com/eclipse-openj9/openj9/issues/4560    generic-all
-# java/net/ipv6tests/B6521014.java on macosx-all issue https://github.com/adoptium/infrastructure/issues/1085
-java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issues/1105 linux-all,macosx-all
+java/net/ipv6tests/B6521014.java	https://github.com/adoptium/infrastructure/issues/1085,https://github.com/adoptium/infrastructure/issues/1105	linux-all,macosx-all
 sun/net/www/http/ChunkedOutputStream/checkError.java	https://github.com/adoptium/aqa-tests/issues/1506	windows-all,linux-all
 
 ############################################################################
@@ -240,8 +233,7 @@ java/rmi/activation/Activatable/downloadParameterClass/DownloadParameterClass.ja
 java/rmi/activation/Activatable/extLoadedImpl/ext.sh	https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
 java/rmi/activation/Activatable/forceLogSnapshot/ForceLogSnapshot.java	https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
 java/rmi/activation/Activatable/inactiveGroup/InactiveGroup.java	https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
-#java/rmi/activation/Activatable/nestedActivate/NestedActivate.java on windows-all issue https://github.ibm.com/runtimes/backlog/issues/1004
-java/rmi/activation/Activatable/nestedActivate/NestedActivate.java	https://github.com/adoptium/aqa-tests/issues/830	macosx-all,windows-all
+java/rmi/activation/Activatable/nestedActivate/NestedActivate.java	https://github.ibm.com/runtimes/backlog/issues/1004,https://github.com/adoptium/aqa-tests/issues/830	macosx-all,windows-all
 java/rmi/activation/Activatable/restartCrashedService/RestartCrashedService.java	https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
 java/rmi/activation/Activatable/restartLatecomer/RestartLatecomer.java	https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
 java/rmi/activation/Activatable/restartService/RestartService.java	https://github.com/eclipse-openj9/openj9/issues/1144	generic-all
@@ -306,8 +298,7 @@ java/security/Signature/SignatureLength.java https://github.com/eclipse-openj9/o
 sun/security/ec/TestEC.java	https://github.ibm.com/runtimes/backlog/issues/795	aix-all,windows-all
 sun/security/lib/cacerts/VerifyCACerts.java	https://github.com/adoptium/aqa-tests/issues/2123	generic-all
 sun/security/pkcs11/fips/TestTLS12.java	https://github.ibm.com/runtimes/backlog/issues/795	linux-all
-sun/security/pkcs11/KeyStore/SecretKeysBasic.sh	https://github.com/eclipse-openj9/openj9/issues/15221	generic-all
-#sun/security/pkcs11/KeyStore/SecretKeysBasic.sh is also excluded for the issue https://bugs.openjdk.java.net/browse/JDK-8189603
+sun/security/pkcs11/KeyStore/SecretKeysBasic.sh	https://bugs.openjdk.java.net/browse/JDK-8189603,https://github.com/eclipse-openj9/openj9/issues/15221	generic-all
 sun/security/pkcs11/Secmod/GetPrivateKey.java	https://github.com/eclipse-openj9/openj9/issues/15221	generic-all
 sun/security/pkcs11/Secmod/JksSetPrivateKey.java	https://github.com/eclipse-openj9/openj9/issues/15221	generic-all
 sun/security/pkcs11/Secmod/TestNssDbSqlite.java	https://github.ibm.com/runtimes/backlog/issues/795	generic-all
@@ -433,8 +424,7 @@ javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github
 
 # jdk_docker
 
-# jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
-jdk/internal/platform/docker/TestDockerMemoryMetrics.java https://github.com/eclipse-openj9/openj9/issues/16460 generic-all
+jdk/internal/platform/docker/TestDockerMemoryMetrics.java	https://github.com/eclipse-openj9/openj9/issues/19176,https://github.com/eclipse-openj9/openj9/issues/16460	generic-all
 
 ############################################################################
 

--- a/openjdk/excludes/ProblemList_openjdk8.txt
+++ b/openjdk/excludes/ProblemList_openjdk8.txt
@@ -22,8 +22,7 @@ serviceability/jvmti/DynamicCodeGenerated/DynamicCodeGeneratedTest.sh https://bu
 # hotspot_all
 
 compiler/5091921/Test7005594.java https://bugs.openjdk.org/browse/JDK-8376338  macosx-all
-# compiler/7184394/TestAESMain.java https://github.com/adoptium/infrastructure/issues/2893
-compiler/7184394/TestAESMain.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,solaris-sparcv9
+compiler/7184394/TestAESMain.java	https://github.com/adoptium/infrastructure/issues/2893,https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x,solaris-sparcv9
 compiler/intrinsics/sha/TestSHA.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 
 ############################################################################
@@ -33,8 +32,7 @@ compiler/intrinsics/sha/TestSHA.java https://github.com/adoptium/aqa-tests/issue
 compiler/loopopts/TestUnrollLimitPreciseType.java#test1 https://bugs.openjdk.org/browse/JDK-8338125 linux-arm,windows-x86
 compiler/c2/Test8202414.java https://bugs.openjdk.java.net/browse/JDK-8251152 linux-arm
 compiler/tiered/Level2RecompilationTest.java https://github.com/adoptium/aqa-tests/issues/2671 linux-ppc64le,aix-all,linux-arm,windows-x86
-# compiler/6894807/IsInstanceTest.java https://github.com/adoptium/adoptium/issues/58 aix-all
-compiler/6894807/IsInstanceTest.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
+compiler/6894807/IsInstanceTest.java	https://github.com/adoptium/adoptium/issues/58,https://github.com/adoptium/aqa-tests/issues/2818	aix-all
 compiler/8004051/Test8004051.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all
 compiler/criticalnatives/argumentcorruption/Test8167409.sh https://github.com/adoptium/aqa-tests/issues/2984 linux-arm
 compiler/c2/cr6340864/TestByteVect.java https://bugs.openjdk.java.net/browse/JDK-8252473 linux-arm,windows-x86
@@ -54,7 +52,7 @@ compiler/gcbarriers/PreserveFPRegistersTest.java https://github.com/adoptium/aqa
 compiler/6891750/Test6891750.java https://bugs.openjdk.org/browse/JDK-8209023 linux-arm
 compiler/8009761/Test8009761.java https://bugs.openjdk.org/browse/JDK-8048003 linux-arm,windows-x86
 compiler/8209951/TestCipherBlockChainingEncrypt.java https://github.com/adoptium/aqa-tests/issues/4150 solaris-sparcv9
-gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/2818 aix-all,linux-arm
+gc/g1/TestHumongousCodeCacheRoots.java	https://github.com/adoptium/aqa-tests/issues/5247,https://github.com/adoptium/aqa-tests/issues/3297,https://github.com/adoptium/aqa-tests/issues/2818	aix-all,linux-arm
 gc/whitebox/TestConcMarkCycleWB.java https://bugs.openjdk.java.net/browse/JDK-8067368 linux-arm
 gc/metaspace/TestMetaspaceMemoryPool.java https://github.com/adoptium/aqa-tests/issues/2708 generic-all
 gc/ergonomics/TestDynamicNumberOfGCThreads.java https://github.com/adoptium/aqa-tests/issues/5019 linux-arm
@@ -92,8 +90,6 @@ gc/g1/TestSummarizeRSetStatsTools.java https://github.com/adoptium/aqa-tests/iss
 gc/g1/TestHumongousAllocInitialMark.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/g1/TestShrinkAuxiliaryData10.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/g1/TestStringDeduplicationPrintOptions.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
-# gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/5247 aix-all
-# gc/g1/TestHumongousCodeCacheRoots.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm,aix-all
 gc/g1/TestShrinkAuxiliaryData15.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/g1/TestStringDeduplicationTableRehash.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
 gc/g1/TestHumongousShrinkHeap.java https://github.com/adoptium/aqa-tests/issues/3297 linux-arm
@@ -109,8 +105,7 @@ runtime/SharedArchiveFile/LimitSharedSizes.java https://github.com/adoptium/aqa-
 runtime/SharedArchiveFile/PrintSharedArchiveAndExit.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/SharedArchiveFile/SharedArchiveFile.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
 runtime/SharedArchiveFile/SpaceUtilizationCheck.java https://github.com/adoptium/aqa-tests/issues/2659 linux-ppc64le,aix-all
-# runtime/7110720/Test7110720.sh https://github.com/adoptium/adoptium/issues/58 aix-all
-runtime/7110720/Test7110720.sh https://github.com/adoptium/aqa-tests/issues/2818 aix-all
+runtime/7110720/Test7110720.sh	https://github.com/adoptium/adoptium/issues/58,https://github.com/adoptium/aqa-tests/issues/2818	aix-all
 runtime/StackGap/testme.sh https://bugs.openjdk.java.net/browse/JDK-8201536 linux-arm
 runtime/CompressedOops/CompressedClassPointers.java https://bugs.openjdk.org/browse/JDK-8234058 linux-ppc64le,aix-all
 runtime/NMT/HugeArenaTracking.java https://github.com/adoptium/infrastructure/issues/2565 solaris-x64,aix-all
@@ -154,9 +149,8 @@ java/lang/management/MemoryMXBean/LowMemoryTest2.sh https://github.com/adoptium/
 com/sun/management/DiagnosticCommandMBean/DcmdMBeanPermissionsTest.java https://github.com/adoptium/aqa-tests/issues/55 generic-all
 com/sun/management/OperatingSystemMXBean/GetCommittedVirtualMemorySize.java https://github.com/adoptium/aqa-tests/issues/134 macosx-all
 sun/management/jmxremote/bootstrap/RmiBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
-# sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
 sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.sh https://github.com/adoptium/aqa-tests/issues/2294 windows-all
-sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh https://bugs.openjdk.org/browse/JDK-8205653 generic-all
+sun/management/jmxremote/bootstrap/RmiSslBootstrapTest.sh	https://github.com/adoptium/aqa-tests/issues/2294,https://bugs.openjdk.org/browse/JDK-8205653	generic-all
 sun/management/jmxremote/bootstrap/RmiRegistrySslTest.sh https://bugs.openjdk.org/browse/JDK-8205653 generic-all
 sun/management/jmxremote/bootstrap/CustomLauncherTest.java https://bugs.openjdk.java.net/browse/JDK-8031420 linux-all
 sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.sh https://github.com/adoptium/aqa-tests/issues/5917 solaris-x64
@@ -183,10 +177,8 @@ java/net/Inet6Address/B6206527.java https://github.com/adoptium/infrastructure/i
 java/net/InetAddress/CheckJNI.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
 java/net/MulticastSocket/Promiscuous.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x
 java/net/MulticastSocket/SetGetNetworkInterfaceTest.java https://github.com/adoptium/aqa-tests/issues/1011 aix-all
-# java/net/MulticastSocket/SetLoopbackMode.java on aix issue https://github.com/adoptium/aqa-tests/issues/1011
-java/net/MulticastSocket/SetLoopbackMode.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all,macosx-all
-# java/net/MulticastSocket/Test.java https://github.com/adoptium/aqa-tests/issues/1011 aix-all
-java/net/MulticastSocket/Test.java https://github.com/adoptium/infrastructure/issues/699 linux-s390x,aix-all,macosx-all
+java/net/MulticastSocket/SetLoopbackMode.java	https://github.com/adoptium/aqa-tests/issues/1011,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,aix-all,macosx-all
+java/net/MulticastSocket/Test.java	https://github.com/adoptium/aqa-tests/issues/1011,https://github.com/adoptium/infrastructure/issues/699	linux-s390x,aix-all,macosx-all
 java/net/Socket/LinkLocal.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
 java/net/ipv6tests/B6521014.java https://github.com/adoptium/infrastructure/issues/1085 macosx-all
 java/net/ipv6tests/UdpTest.java https://bugs.openjdk.java.net/browse/JDK-8198266 generic-all
@@ -343,8 +335,7 @@ sun/tools/jstatd/TestJstatdPortAndServer.java https://bugs.openjdk.java.net/brow
 sun/tools/jstatd/TestJstatdServer.java https://github.com/adoptium/aqa-tests/issues/115 linux-all,solaris-x64
 sun/tools/native2ascii/Native2AsciiTests.sh https://github.com/adoptium/aqa-tests/issues/2667 windows-all
 com/sun/tools/attach/StartManagementAgent.java https://github.com/adoptium/aqa-tests/issues/115 generic-all
-# tools/pack200/CommandLineTests.java https://github.com/adoptium/infrastructure/issues/2893 solaris-sparcv9
-tools/pack200/CommandLineTests.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,solaris-sparcv9
+tools/pack200/CommandLineTests.java	https://github.com/adoptium/infrastructure/issues/2893,https://github.com/adoptium/aqa-tests/issues/1051	linux-s390x,solaris-sparcv9
 tools/pack200/Pack200Test.java https://github.com/adoptium/aqa-tests/issues/2657 generic-all
 tools/launcher/RunpathTest.java https://bugs.openjdk.java.net/browse/JDK-8286118 linux-arm
 tools/launcher/VersionCheck.java https://github.com/adoptium/aqa-tests/issues/4243 linux-x64
@@ -381,11 +372,8 @@ java/util/stream/boottest/java/util/stream/SpinedBufferTest.java https://github.
 java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/ExplodeOpTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/FlatMapOpTest.java https://bugs.openjdk.java.net/browse/JDK-8173112 linux-s390x,linux-arm
-# java/util/stream/test/org/openjdk/tests/java/util/stream/InfiniteStreamWithLimitOpTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
-# java/util/stream/test/org/openjdk/tests/java/util/stream/SequentialOpTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/SliceOpTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,linux-arm
 java/util/stream/test/org/openjdk/tests/java/util/stream/StreamSpliteratorTest.java https://github.com/adoptium/aqa-tests/issues/1051 linux-s390x,linux-arm
-# java/util/stream/test/org/openjdk/tests/java/util/stream/StreamBuilderTest.java https://bugs.openjdk.java.net/browse/JDK-8173112 linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/TabulatorsTest.java https://bugs.openjdk.java.net/browse/JDK-8173112 linux-s390x,linux-arm
 java/util/stream/test/org/openjdk/tests/java/util/stream/TeeOpTest.java https://github.com/adoptium/aqa-tests/issues/2263 linux-arm
 java/util/stream/test/org/openjdk/tests/java/util/stream/ForEachOpTest.java https://github.com/adoptium/aqa-tests/issues/2263 linux-arm
@@ -414,17 +402,14 @@ com/sun/jndi/ldap/RemoveNamingListenerTest.java https://bugs.openjdk.java.net/br
 
 # jdk_imageio
 
-# javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github.com/adoptium/aqa-tests/issues/3242 solaris-all
-javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh https://github.com/adoptium/aqa-tests/issues/2321 aix-all,solaris-all
+javax/imageio/spi/AppletContextTest/BadPluginConfigurationTest.sh	https://github.com/adoptium/aqa-tests/issues/3242,https://github.com/adoptium/aqa-tests/issues/2321	aix-all,solaris-all
 
 ############################################################################
 
 # jdk_jfr
 
 jdk/jfr/api/flightrecorder/TestGetEventTypes.java https://bugs.openjdk.org/browse/JDK-8309729 solaris-sparcv9
-# jdk/jfr/event/sampling/TestNative.java https://github.com/adoptium/aqa-tests/issues/2754#issuecomment-1964356593 macosx-all
-# jdk/jfr/event/runtime/TestShutdownEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
-jdk/jfr/event/runtime/TestShutdownEvent.java https://bugs.openjdk.org/browse/JDK-8219686 generic-all
+jdk/jfr/event/runtime/TestShutdownEvent.java	https://github.com/adoptium/aqa-tests/issues/3301,https://bugs.openjdk.org/browse/JDK-8219686	generic-all
 jdk/jfr/event/compiler/TestCompilerPhase.java https://github.com/adoptium/aqa-tests/issues/3045#issuecomment-3960035561 generic-all
 jdk/jfr/event/compiler/TestCompile.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/collection/TestGCCauseWithG1ConcurrentMark.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
@@ -434,8 +419,7 @@ jdk/jfr/event/gc/detailed/TestEvacuationInfoEvent.java https://github.com/adopti
 jdk/jfr/event/gc/detailed/TestG1HeapRegionTypeChangeEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/detailed/TestG1MMUEvent.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/detailed/TestPromotionEventWithG1.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
-# jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventG1.java https://github.com/adoptium/aqa-tests/issues/3254 solaris-sparcv9
-jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventG1.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm,solaris-sparcv9
+jdk/jfr/event/gc/heapsummary/TestHeapSummaryEventG1.java	https://github.com/adoptium/aqa-tests/issues/3254,https://github.com/adoptium/aqa-tests/issues/3301	linux-arm,solaris-sparcv9
 jdk/jfr/event/gc/objectcount/TestObjectCountAfterGCEventWithG1ConcurrentMark.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/stacktrace/TestG1HumongousAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
 jdk/jfr/event/gc/stacktrace/TestG1OldAllocationPendingStackTrace.java https://github.com/adoptium/aqa-tests/issues/3301 linux-arm
@@ -483,15 +467,15 @@ java/util/stream/boottest/java/util/stream/DoubleNodeTest.java https://github.co
 java/util/stream/boottest/java/util/stream/FlagOpTest.java https://github.com/adoptium/aqa-tests/issues/5098 linux-arm
 java/util/stream/boottest/java/util/stream/NodeTest.java https://github.com/adoptium/aqa-tests/issues/5098 linux-arm
 java/util/stream/test/org/openjdk/tests/java/util/stream/FilterOpTest.java https://github.com/adoptium/aqa-tests/issues/5098 linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/InfiniteStreamWithLimitOpTest.java https://github.com/adoptium/aqa-tests/issues/5098 linux-arm,linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/InfiniteStreamWithLimitOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051,https://github.com/adoptium/aqa-tests/issues/5098	linux-arm,linux-s390x
 java/util/stream/test/org/openjdk/tests/java/util/stream/IntSliceOpTest.java https://github.com/adoptium/aqa-tests/issues/5098 linux-arm
 java/util/stream/test/org/openjdk/tests/java/util/stream/IntUniqOpTest.java https://github.com/adoptium/aqa-tests/issues/5098 linux-arm
 java/util/stream/test/org/openjdk/tests/java/util/stream/RangeTest.java https://github.com/adoptium/aqa-tests/issues/5098 linux-arm
-java/util/stream/test/org/openjdk/tests/java/util/stream/SequentialOpTest.java https://github.com/adoptium/aqa-tests/issues/5098 linux-arm,linux-s390x
-java/util/stream/test/org/openjdk/tests/java/util/stream/StreamBuilderTest.java https://github.com/adoptium/aqa-tests/issues/5098 linux-arm,linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/SequentialOpTest.java	https://github.com/adoptium/aqa-tests/issues/1051,https://github.com/adoptium/aqa-tests/issues/5098	linux-arm,linux-s390x
+java/util/stream/test/org/openjdk/tests/java/util/stream/StreamBuilderTest.java	https://bugs.openjdk.java.net/browse/JDK-8173112,https://github.com/adoptium/aqa-tests/issues/5098	linux-arm,linux-s390x
 jdk/jfr/event/gc/detailed/TestPromotionFailedEventWithParNew.java https://github.com/adoptium/aqa-tests/issues/3770 linux-aarch64
 jdk/jfr/event/runtime/TestThrowableInstrumentation.java https://github.com/adoptium/aqa-tests/issues/3760 linux-aarch64
-jdk/jfr/event/sampling/TestNative.java https://github.com/adoptium/aqa-tests/issues/6884 linux-x64,macosx-all
+jdk/jfr/event/sampling/TestNative.java	https://github.com/adoptium/aqa-tests/issues/2754#issuecomment-1964356593,https://github.com/adoptium/aqa-tests/issues/6884	linux-x64,macosx-all
 tools/javac/defaultMethods/super/TestDefaultSuperCall.java https://github.com/adoptium/aqa-tests/issues/6881 linux-arm
 tools/javac/lambda/TestInvokeDynamic.java https://github.com/adoptium/aqa-tests/issues/6882 linux-arm
 sun/security/ssl/X509KeyManager/PreferredKey.java https://bugs.openjdk.org/browse/JDK-8384815 generic-all


### PR DESCRIPTION
This pull request removes the legacy duplicate and commented-out testcase exclude entries across the `ProblemList_*.txt` files.

### Why?
Previously, to record different issue tickets or URLs for the same test case, duplicate entries or commented-out entries were added to the problemlists. This ended up cluttering the excludes files and created parsing issues for automated verification scripts. Automated tools were having a hard time parsing the problems correctly due to these duplicate entries in simple terms right.

Since the `jtreg` format natively supports a comma-separated list of issue urls and bug numbers (with no spaces) in the bug-list field of an active entry, what this PR does is that it merges those references into a single active exclusion line per testcase.

### Changes Made
- Scanned all `ProblemList_*.txt` files in `openjdk/excludes/` (including vendor-specific lists).
- Merged the issue URLs and JDK bug IDs (e.g. `JDK-xxxxxxx`) from commented-out entries into their corresponding active exclusion entries as a comma-separated list.
- Removed the redundant commented-out duplicate lines.
- **Impact:** Cleaned up 37 files, resulting in a net reduction of ~590 redundant lines from the exclude lists.

Fixes: #6574

Signed-off-by: Akshat Chaudhary <chaudharyakshat555@gmail.com>
