### PR TITLE
 Modified jck/build.xml for vs22 fix on windows 32 bits runs

### DIFF
--- a/jck/build.xml
+++ b/jck/build.xml
@@ -86,7 +86,7 @@
 	<condition property="vcvarsall_bits_arg" value="arm64">
 		<equals arg1="${os.arch}" arg2="aarch64" trim="true"/>
 	</condition>
-	<condition property="vcvarsall_bits_arg" value="amd64" else="">
+	<condition property="vcvarsall_bits_arg" value="amd64" else="x86">
 		<and>
 			<equals arg1="${sun.arch.data.model}" arg2="64" trim="true"/>
 			<not>


### PR DESCRIPTION
This PR fixes the Windows (32-bit) JCK native build by passing the appropriate Visual Studio 2022 (VS2022) architecture argument to vcvarsall.bat.

**Reference links after applying the fixes to jck/build.xml:-**
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/62042/consoleText
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/62041/consoleText

**Problem Statement:-**
When running JCK tests on Windows 32-bit platforms with VS2022, the native build fails because vcvarsall.bat is invoked without the required architecture argument (for example, x86, amd64, x86_amd64, or amd64_x86). As a result, the Visual Studio build environment is not initialized correctly, leading to the following issues during native compilation:

vcvarsall.bat reports a usage error: **[ERROR:vcvarsall.bat] Error in script usage. The correct usage is:**
The required MSVC environment variables **(INCLUDE, LIB, LIBPATH, and PATH)** are not configured.
Native compilation subsequently fails with: **fatal error C1083: Cannot open include file: 'stdio.h': No such**

**Ref. Links:-**
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/62021/console
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder_CR/61920/console

```
16:04:45  setup-native-build-command:
16:04:45       [echo] Building jck natives
16:04:45  
16:04:45  build-natives-windows:
16:04:45       [exec] 
16:04:45       [exec] C:\Users\jenkins\workspace\Grinder_CR\aqa-tests\jck>call "c:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvarsall.bat"    && make build -f C:/Users/jenkins/workspace/Grinder_CR/aqa-tests//jck/jtrunner/makefile SRCDIR=C:\Users\jenkins\jck_root\JCK8-unzipped/JCK-runtime-8d JAVA_HOME=C:/Users/jenkins/workspace/Grinder_CR/jdkbinary/j2sdk-image OUTDIR=C:\Users\jenkins\jck_root\JCK8-unzipped/natives 
16:04:45       [exec] [ERROR:vcvarsall.bat] Error in script usage. The correct usage is:
16:04:45       [exec] Syntax:
16:04:45       [exec]     vcvarsall.bat [arch] [platform_type] [winsdk_version] [-vcvars_ver=vc_version] [-vcvars_spectre_libs=spectre_mode]
16:04:45       [exec] where :
16:04:45       [exec]     [arch]: x86 | amd64 | x86_amd64 | x86_arm | x86_arm64 | amd64_x86 | amd64_arm | amd64_arm64
16:04:45       [exec]     [platform_type]: {empty} | store | uwp
16:04:45       [exec]     [winsdk_version] : full Windows 10 SDK number (e.g. 10.0.10240.0) or "8.1" to use the Windows 8.1 SDK.
16:04:45       [exec]     [vc_version] : {none} for latest installed VC++ compiler toolset |
16:04:45       [exec]                    "14.0" for VC++ 2015 Compiler Toolset |
16:04:45       [exec]                    "14.xx" for the latest 14.xx.yyyyy toolset installed (e.g. "14.11") |
16:04:45       [exec]                    "14.xx.yyyyy" for a specific full version number (e.g. "14.11.25503")
16:04:45       [exec]     [spectre_mode] : {none} for libraries without spectre mitigations |
16:04:45       [exec]                      "spectre" for libraries with spectre mitigations
16:04:45       [exec] 
16:04:45       [exec] The store parameter sets environment variables to support Universal Windows Platform application
16:04:45       [exec] development and is an alias for 'uwp'.
16:04:45       [exec] 
16:04:45       [exec] For example:
16:04:45       [exec]     vcvarsall.bat x86_amd64
16:04:45       [exec]     vcvarsall.bat x86_amd64 10.0.10240.0
16:04:45       [exec]     vcvarsall.bat x86_arm uwp 10.0.10240.0
16:04:45       [exec]     vcvarsall.bat x86_arm onecore 10.0.10240.0 -vcvars_ver=14.0
16:04:45       [exec]     vcvarsall.bat x64 8.1
16:04:45       [exec]     vcvarsall.bat x64 store 8.1
16:04:45       [exec] 
16:04:45       [exec] Please make sure either Visual Studio or C++ Build SKU is installed.
16:04:46       [exec] make[2]: Entering directory '/cygdrive/c/Users/jenkins/workspace/Grinder_CR/aqa-tests/jck'
16:04:47       [exec] OS is win
16:04:47       [exec] ARCH is x86_64
16:04:47       [exec] C:/Users/jenkins/workspace/Grinder_CR/aqa-tests//jck/jtrunner/makefile:93: JAVA_HOME set to C:/Users/jenkins/workspace/Grinder_CR/jdkbinary/j2sdk-image. Using C:/Users/jenkins/workspace/Grinder_CR/jdkbinary/j2sdk-image/bin/jar to create jar files
16:04:47       [exec] rm -rf C:/Users/jenkins/jck_root/JCK8-unzipped/natives/win/
16:04:48       [exec] mkdir -p C:/Users/jenkins/jck_root/JCK8-unzipped/natives/win/
16:04:48       [exec] cd C:/Users/jenkins/jck_root/JCK8-unzipped/natives/win/ && cl /DWIN32 /D_AMD64_ /D_WINDOWS /LD /MD /I. /I"C:/Users/jenkins/workspace/Grinder_CR/jdkbinary/j2sdk-image/../include" /I"C:\Users\jenkins\jck_root\JCK8-unzipped/JCK-runtime-8d/src/share/lib/jni/include/win32" /I"C:\Users\jenkins\jck_root\JCK8-unzipped/JCK-runtime-8d/src/share/lib/jni/include/windows" /I"C:\Users\jenkins\jck_root\JCK8-unzipped/JCK-runtime-8d" /I"C:\Users\jenkins\jck_root\JCK8-unzipped/JCK-runtime-8d/src" /I"C:\Users\jenkins\jck_root\JCK8-unzipped/JCK-runtime-8d/src/share/lib/jni/include" /I"C:\Users\jenkins\jck_root\JCK8-unzipped/JCK-runtime-8d/src/share/lib/jvmti/include" -I"C:\Users\jenkins\jck_root\JCK8-unzipped/JCK-runtime-8d" -I"C:/Users/jenkins/jck_root/JCK8-unzipped/JCK-runtime-8d/src/share/lib/jni/include" -I"C:/Users/jenkins/jck_root/JCK8-unzipped/JCK-runtime-8d/src/share/lib/jvmti/include"  C:/Users/jenkins/jck_root/JCK8-unzipped/JCK-runtime-8d/src/share/lib/jni/jckjni.c /FeC:/Users/jenkins/jck_root/JCK8-unzipped/natives/win/jckjni.dll
16:04:48       [exec] Microsoft (R) C/C++ Optimizing Compiler Version 19.31.31106.2 for x86
16:04:48       [exec] Copyright (C) Microsoft Corporation.  All rights reserved.
16:04:48       [exec] 
16:04:48       [exec] jckjni.c
16:04:49       [exec] C:\Users\jenkins\jck_root\JCK8-unzipped/JCK-runtime-8d/src/share/lib/jni/include\jckjni.h(20): fatal error C1083: Cannot open include file: 'stdio.h': No such file or directory
16:04:50       [exec] make[2]: Leaving directory '/cygdrive/c/Users/jenkins/workspace/Grinder_CR/aqa-tests/jck'
16:04:50       [exec] make[2]: *** [C:/Users/jenkins/workspace/Grinder_CR/aqa-tests//jck/jtrunner/makefile:307: jckjni.dll] Error 2
16:04:50  
16:04:50  BUILD FAILED
16:04:50  C:\Users\jenkins\workspace\Grinder_CR\aqa-tests\TKG\scripts\build_test.xml:66: The following error occurred while executing this line:
16:04:50  C:\Users\jenkins\workspace\Grinder_CR\aqa-tests\jck\build.xml:397: The following error occurred while executing this line:
16:04:50  C:\Users\jenkins\workspace\Grinder_CR\aqa-tests\jck\build.xml:301: exec returned: 2
```

Thanks