### PR TITLE
Exclude renaissance-db-shootout jdk17 arm linux

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -82,7 +82,7 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/6669</comment>
 				<vendor>eclipse</vendor>
 				<platform>arm_linux</platform>
-				<version>11</version>
+				<version>[11, 17]</version>
 			</disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(ADD_OPENS_CMD) $(JVM_OPTIONS) -jar $(Q)$(TEST_RESROOT)$(D)renaissance.jar$(Q) --json $(Q)$(REPORTDIR)$(D)db-shootout.json$(Q) db-shootout; \


### PR DESCRIPTION
renaissance-db-shootout needs excluding for known issue https://github.com/adoptium/aqa-tests/issues/6669 on jdk17 as well.