### PR TITLE
fixed systemtest_prereqs folder creation for v1.0.14-release

### DIFF
--- a/system/common.xml
+++ b/system/common.xml
@@ -262,8 +262,8 @@
 				<isset property="env.SYSTEM_LIB_DIR"/>
 			</not>
 		</condition>
-		<mkdir dir="${SYSTEMTEST_DEST}/systemtest_prereqs" if:true="system_lib_dir_not_set"/>
-		<copy todir="${SYSTEMTEST_DEST}/systemtest_prereqs/" if:true="system_lib_dir_not_set">
+		<mkdir dir="${SYSTEMTEST_DEST}/systemtest_prereqs" if:true="${system_lib_dir_not_set}"/>
+		<copy todir="${SYSTEMTEST_DEST}/systemtest_prereqs/" if:true="${system_lib_dir_not_set}">
 			<fileset dir="${TEST_ROOT}/systemtest_prereqs/" includes="**"/>
 		</copy>
 		


### PR DESCRIPTION
The move away from ant-contrib had some side-effects caused by ant semantics. This fixes the issue where the dependencies for the `system` test suite were not copied to the correct location