### PR TITLE
Aggregate JUnit results at parent test level (#6238)

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -1789,6 +1789,15 @@ def archiveChildJobTap(childJobs, originalStatus = 'SUCCESS') {
 						echo 'Exception: ' + e.toString()
 						echo "Cannot copy *.tap or AQACert.log from ${name} with buildid ${buildId} . Skipping copyArtifacts..."
 					}
+					// Aggregate JUnit XML results from child job to parent level (see #6238)
+					try {
+						timeout(time: 1, unit: 'HOURS') {
+							copyArtifacts (projectName: "${name}", selector: specific("${buildId}"), filter: "**/work/**/*.jtr.xml, **/result/**/*.jtr.xml, **/junitreports/**/*.xml, **/external_test_reports/**/*.xml", target:"${name}/${buildId}", optional: true)
+						}
+					} catch (Exception e) {
+						echo 'Exception: ' + e.toString()
+						echo "Cannot copy JUnit XML from ${name} with buildid ${buildId} . Skipping..."
+					}
 					def childBuildUrl = "${env.JENKINS_URL}job/${name}/${buildId}"
 					def badgeUrl = "${childBuildUrl}/badge/icon"
 					def duration = cjob.getDuration() ?: ""
@@ -1809,6 +1818,13 @@ def archiveChildJobTap(childJobs, originalStatus = 'SUCCESS') {
 			}
 			childJobStatus += "</table>"
 			currentBuild.description = (currentBuild.description) ? currentBuild.description + "<br>" + childJobStatus : childJobStatus
+
+			// Publish aggregated JUnit results from all child jobs at the parent level (see #6238)
+			try {
+				junit skipMarkingBuildUnstable: true, allowEmptyResults: true, keepLongStdio: true, testResults: '**/work/**/*.jtr.xml, **/result/**/*.jtr.xml, **/junitreports/**/*.xml, **/external_test_reports/**/*.xml'
+			} catch (Exception e) {
+				echo "Caught exception when aggregating JUnit results at parent level: ${e.message}"
+			}
 
 			// In case rerun job status be worse than original job status
 			if ( originalStatus != "SUCCESS" && isWorseThan( currentStatus, originalStatus)) {


### PR DESCRIPTION
## Aggregate JUnit results at parent test level

**Closes #6238**

### Background

Currently, child TAP files are already aggregated and surfaced at the parent build level. However, JUnit XML results (produced by openjdk/JCK tests) are only visible at the **child job level** — engineers have to click into each parallel `testList_N` job individually to see test reports.

This PR brings JUnit result aggregation to the parent build level, matching the existing TAP behaviour.

### Changes

**`buildenv/jenkins/JenkinsfileBase`**

Two additions inside `archiveChildJobTap()`:

1. **Per-child JUnit artifact copy** — alongside the existing `**/*.tap` copy, also fetches JUnit XML files from each parallel child job into the parent workspace:

```groovy
copyArtifacts(projectName: "${name}", selector: specific("${buildId}"),
    filter: "**/work/**/*.jtr.xml, **/result/**/*.jtr.xml, **/junitreports/**/*.xml, **/external_test_reports/**/*.xml",
    target: "${name}/${buildId}", optional: true)
```

`optional: true` ensures child jobs that produce no JUnit output (e.g. non-openjdk tests) are silently skipped without failing the step.

2. **Parent-level `junit` publish step** — after all child artifacts are gathered, publishes the aggregated report at the parent build:

```groovy
junit skipMarkingBuildUnstable: true, allowEmptyResults: true, keepLongStdio: true,
      testResults: '**/work/**/*.jtr.xml, **/result/**/*.jtr.xml, **/junitreports/**/*.xml, **/external_test_reports/**/*.xml'
```

### Safety / Status Interference

`skipMarkingBuildUnstable: true` is used intentionally to ensure the `junit` step **never overrides the pipeline's own build status logic** (`checkTestResults()`). This directly addresses the concern raised in #6244, where the TAP plugin was removed precisely because it forcibly set job status to `UNSTABLE` — this implementation avoids repeating that mistake.

`allowEmptyResults: true` ensures the parent build doesn't fail when no JUnit XML is present (e.g. platforms that only produce TAP).

### Testing

-  Verified JUnit report appears at parent build level after a parallel test run
-  Verified build status is not affected by the `junit` step (remains controlled by `checkTestResults()`)
-  Verified child jobs with no JUnit output are handled gracefully
