### PR TITLE
Exclude java/lang/IO/IO on OpenJ9 for jdk27+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -72,6 +72,7 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java https://github.com/
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/IO/IO.java https://github.com/eclipse-openj9/openj9/issues/23292 generic-all
 java/lang/LazyConstant/LazyConstantClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/LazyConstant/ThrowablesClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all

--- a/openjdk/excludes/ProblemList_openjdk28-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk28-openj9.txt
@@ -72,6 +72,7 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java https://github.com/
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
+java/lang/IO/IO.java https://github.com/eclipse-openj9/openj9/issues/23292 generic-all
 java/lang/LazyConstant/LazyConstantClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/LazyConstant/ThrowablesClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/23292