### PR TITLE
Move portable container machine maps to JSON config files (#6188)

### DIFF
--- a/buildenv/jenkins/config/portable-container/README.md
+++ b/buildenv/jenkins/config/portable-container/README.md
@@ -1,0 +1,93 @@
+# Portable Container Config Files
+
+This directory holds the `imageUploadMap.json` and `imagePullMap.json` configuration files
+for each Portable Container Testing feature (e.g., CRIU, SCC).
+
+## Purpose
+
+Adding support for a new feature only requires:
+1. Implementing the relevant tests in `aqa-tests/external/<feature>/`
+2. Creating a new subdirectory here with `imageUploadMap.json` and `imagePullMap.json`
+
+No changes to `openjdk_tests` are needed.
+
+## Directory Structure
+
+```
+portable-container/
+├── README.md           (this file)
+├── criu/
+│   ├── imageUploadMap.json
+│   └── imagePullMap.json
+└── scc/
+    ├── imageUploadMap.json
+    └── imagePullMap.json
+```
+
+## imageUploadMap.json Schema
+
+```json
+{
+    "commonLabelBase": "<base Jenkins node label for this feature>",
+    "buildList":       "<comma-separated BUILD_LIST value for the upload test job>",
+    "target":          "<TARGET parameter value for the upload test job>",
+    "excludeTargetOnPlatform": {
+        "<platform>": "<substring to remove from 'target' when running on this platform>"
+    },
+    "platforms": {
+        "<platform>": ["<labelSuffix1>", "<labelSuffix2>", ...]
+    }
+}
+```
+
+Each `labelSuffix` is appended to `commonLabelBase` (and any user-supplied `LABEL_ADDITION`)
+with `&&` to form the full `LABEL_ADDITION` value for that machine.
+
+## imagePullMap.json Schema
+
+```json
+{
+    "commonLabelBase": "<base Jenkins node label for this feature>",
+    "platforms": {
+        "<platform>": ["<labelSuffix1>", "<labelSuffix2>", ...]
+    }
+}
+```
+
+The `imagePullMap.json` does not carry `target` or `buildList`; those are inherited
+from the `imageUploadMap.json` of the same feature.
+
+## Supported Platforms
+
+| Platform key   | Architecture  |
+|----------------|---------------|
+| `x86-64_linux` | x86-64        |
+| `aarch64_linux`| AArch64       |
+| `s390x_linux`  | IBM Z (s390x) |
+| `ppc64le_linux`| POWER (LE)    |
+
+## Example — Adding a New Feature
+
+Create `portable-container/myfeature/imageUploadMap.json`:
+```json
+{
+    "commonLabelBase": "sw.tool.podman&&sw.tool.myfeature",
+    "buildList": "external/myfeature",
+    "target": "testList TESTLIST=disabled.myfeature_test",
+    "platforms": {
+        "x86-64_linux": ["sw.os.ubuntu.22&&hw.arch.x86.broadwell"]
+    }
+}
+```
+
+Create `portable-container/myfeature/imagePullMap.json`:
+```json
+{
+    "commonLabelBase": "sw.tool.podman&&sw.tool.myfeature",
+    "platforms": {
+        "x86-64_linux": ["sw.os.ubuntu.22&&hw.arch.x86.broadwell"]
+    }
+}
+```
+
+The pipeline will automatically discover and run `myfeature` on the next execution.

--- a/buildenv/jenkins/config/portable-container/criu/imagePullMap.json
+++ b/buildenv/jenkins/config/portable-container/criu/imagePullMap.json
@@ -1,0 +1,27 @@
+{
+    "commonLabelBase": "sw.tool.podman&&sw.tool.container.criu",
+    "platforms": {
+        "x86-64_linux": [
+            "sw.os.ubuntu.22&&hw.arch.x86.broadwell",
+            "sw.os.ubuntu.22&&hw.arch.x86.amd",
+            "sw.os.rhel.8&&hw.arch.x86.broadwell",
+            "sw.os.rhel.8&&hw.arch.x86.amd",
+            "sw.os.rhel.8&&hw.arch.x86.skylake",
+            "sw.os.rhel.9&&hw.arch.x86.amd",
+            "sw.os.rhel.9&&hw.arch.x86.broadwell"
+        ],
+        "aarch64_linux": [
+            "sw.os.ubuntu.22",
+            "sw.os.rhel.8",
+            "sw.os.rhel.9"
+        ],
+        "s390x_linux": [
+            "hw.arch.s390x.z13",
+            "hw.arch.s390x.z14"
+        ],
+        "ppc64le_linux": [
+            "hw.arch.ppc64le.p10&&!sw.os.ubuntu.24",
+            "hw.arch.ppc64le.p9&&!sw.os.ubuntu.24"
+        ]
+    }
+}

--- a/buildenv/jenkins/config/portable-container/criu/imageUploadMap.json
+++ b/buildenv/jenkins/config/portable-container/criu/imageUploadMap.json
@@ -1,0 +1,33 @@
+{
+    "commonLabelBase": "sw.tool.podman&&sw.tool.container.criu",
+    "buildList": "external/criu,external/criu-portable-checkpoint,external/criu-portable-checkpoint,external/criu-portable-checkpoint,criu-ubi-portable-restore,external/criu-ubi-portable-checkpoint",
+    "target": "testList TESTLIST=disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi8,disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi9,disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi10,disabled.criu-portable-checkpoint_test,disabled.criu-ubi-portable-checkpoint_test",
+    "excludeTargetOnPlatform": {
+        "ppc64le_linux": "disabled.criu-portable-checkpoint_test,"
+    },
+    "platforms": {
+        "x86-64_linux": [
+            "sw.os.ubuntu.22&&hw.arch.x86.broadwell",
+            "sw.os.ubuntu.22&&hw.arch.x86.amd",
+            "sw.os.rhel.8&&hw.arch.x86.broadwell",
+            "sw.os.rhel.8&&hw.arch.x86.amd",
+            "sw.os.rhel.8&&hw.arch.x86.skylake",
+            "sw.os.rhel.9&&hw.arch.x86.amd",
+            "sw.os.rhel.9&&hw.arch.x86.broadwell"
+        ],
+        "aarch64_linux": [
+            "sw.os.ubuntu.22&&hw.arch.aarch64.armv8",
+            "sw.os.rhel.8&&hw.arch.aarch64.armv8",
+            "sw.os.rhel.9&&hw.arch.aarch64.armv8"
+        ],
+        "s390x_linux": [
+            "sw.os.ubuntu.22&&hw.arch.s390x.z13",
+            "sw.os.ubuntu.22&&hw.arch.s390x.z14",
+            "sw.os.rhel.8&&hw.arch.s390x.z14"
+        ],
+        "ppc64le_linux": [
+            "sw.os.rhel.8&&hw.arch.ppc64le.p10",
+            "sw.os.rhel.9&&hw.arch.ppc64le.p9"
+        ]
+    }
+}

--- a/buildenv/jenkins/config/portable-container/scc/imagePullMap.json
+++ b/buildenv/jenkins/config/portable-container/scc/imagePullMap.json
@@ -1,0 +1,13 @@
+{
+    "commonLabelBase": "sw.tool.podman",
+    "platforms": {
+        "s390x_linux": [
+            "sw.os.rhel.9&&hw.arch.s390x.z14",
+            "sw.os.rhel.9&&hw.arch.s390x.z17"
+        ],
+        "ppc64le_linux": [
+            "sw.os.rhel.9&&hw.arch.ppc64le.p9",
+            "sw.os.rhel.9&&hw.arch.ppc64le.p11"
+        ]
+    }
+}

--- a/buildenv/jenkins/config/portable-container/scc/imageUploadMap.json
+++ b/buildenv/jenkins/config/portable-container/scc/imageUploadMap.json
@@ -1,0 +1,15 @@
+{
+    "commonLabelBase": "sw.tool.podman",
+    "buildList": "external/scc",
+    "target": "testList TESTLIST=disabled.portable_scc_CreateImageAndPushToRegistry_ubi9",
+    "platforms": {
+        "s390x_linux": [
+            "sw.os.rhel.9&&hw.arch.s390x.z14",
+            "sw.os.rhel.9&&hw.arch.s390x.z17"
+        ],
+        "ppc64le_linux": [
+            "sw.os.rhel.9&&hw.arch.ppc64le.p9",
+            "sw.os.rhel.9&&hw.arch.ppc64le.p11"
+        ]
+    }
+}

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -169,120 +169,79 @@ timestamps{
             parallel testJobs
         }
     } else if (!JOB_NAME.contains("_imagePull") && !JOB_NAME.contains("_imageUpload") && params.TARGET == "dev.external" ) {
-        def types = ["criu", "scc"]
+        // Load portable container feature configurations from JSON config files.
+        // Config files live in buildenv/jenkins/config/portable-container/<type>/.
+        // To add a new feature, create a new subdirectory with imageUploadMap.json
+        // and imagePullMap.json — no changes to this file are needed.
+        def portableContainerConfigs = [:]
+        def configBasePath = "./aqa-tests/buildenv/jenkins/config/portable-container"
+        node("worker || (ci.role.test&&hw.arch.x86&&sw.os.linux)") {
+            checkout scm
+            dir(env.WORKSPACE) {
+                // Auto-discover feature types from the config directory.
+                // Any subdirectory containing imageUploadMap.json is treated as a feature.
+                // Adding a new feature requires only adding JSON files here — no Groovy changes needed.
+                def configFiles = findFiles(glob: "${configBasePath}/*/imageUploadMap.json")
+                for (def configFile : configFiles) {
+                    def featureType = configFile.path.tokenize('/')[-2]
+                    portableContainerConfigs[featureType] = [
+                        upload: readJSON(file: "${configBasePath}/${featureType}/imageUploadMap.json"),
+                        pull:   readJSON(file: "${configBasePath}/${featureType}/imagePullMap.json")
+                    ]
+                }
+            }
+        }
+
         def imageUploadJobs = [:]
         def imagePullJobs = [:]
-        for (String type : types) {
-            def imageUploadMap = []
-            def imagePullMap = []
+        for (String type : portableContainerConfigs.keySet().toList()) {
+            def imageUploadMap = [:]
+            def imagePullMap = [:]
             def target = "dev.external"
             def buildList = ""
+
+            def uploadConfig = portableContainerConfigs[type].upload
+            def pullConfig   = portableContainerConfigs[type].pull
+
             if (type == "criu") {
                 // Temporarily exclude JDK26+ due to lack of dockerfile
-                if (!(params.JDK_VERSION.isInteger() && params.JDK_VERSION.toInteger() >= 26)) {
-                    def commonLabel = "sw.tool.podman&&sw.tool.container.criu"
-                    if (params.LABEL_ADDITION) {
-                        commonLabel += "&&${params.LABEL_ADDITION}"
-                    }
-                    buildList="external/criu,external/criu-portable-checkpoint,external/criu-portable-checkpoint,external/criu-portable-checkpoint,criu-ubi-portable-restore,external/criu-ubi-portable-checkpoint"
-                    imageUploadMap = [
-                        'x86-64_linux' : [
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.x86.broadwell"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.x86.amd"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.broadwell"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.amd"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.skylake"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.amd"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.broadwell"]
-                                ],
-                        'aarch64_linux' : [
-                                    // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.20"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.aarch64.armv8"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.aarch64.armv8"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.aarch64.armv8"]
-                                ],
-                        's390x_linux' : [
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z13"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z14"],
-                                    // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.s390x.z15"],
-                                    // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z13"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z14"],
-                                    // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.s390x.z15"],
-                                    // rhel.9 s390x excluded from upload: sudo requires password on all available nodes (runtimes_backlog_issues_879)
-                                    // ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"]
-                                    // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z15"]
-                                ],
-                        'ppc64le_linux' : [
-                                    // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p9"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.ppc64le.p10"],
-                                    // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p8"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p9"],
-                                    // no machine available ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.98&&hw.arch.ppc64le.p10"],
-                        ]
-                    ]
-                    imagePullMap = [
-                        'x86-64_linux' : [
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.x86.broadwell"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22&&hw.arch.x86.amd"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.broadwell"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.amd"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8&&hw.arch.x86.skylake"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.amd"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.x86.broadwell"]
-                                ],
-                        'aarch64_linux' : [
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.ubuntu.22"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.8"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9"]
-                                ],
-                        's390x_linux' : [
-                                    ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z13"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z14"]
-                                    // no machine available ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.s390x.z15"]
-                                ],
-                        'ppc64le_linux' : [
-                                    // Temporarily exclude ubuntu 24 machines due to issue runtimes_backlog 1506
-                                    ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.ppc64le.p10&&!sw.os.ubuntu.24"],
-                                    ['LABEL_ADDITION' : "${commonLabel}&&hw.arch.ppc64le.p9&&!sw.os.ubuntu.24"]
-                                ]
-                    ]
-                    target = "testList TESTLIST=disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi8,disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi9,disabled.criu_pingPerf_testCreateRestoreImageAndPushToRegistry_ubi10,disabled.criu-portable-checkpoint_test,disabled.criu-ubi-portable-checkpoint_test"
-
-                    if (params.PLATFORM == "ppc64le_linux") {
-                        // exclude criu-portable-checkpoint_test on plinux due to github_ibm/runtimes/backlog/issues/1099
-                        target = target.minus("disabled.criu-portable-checkpoint_test,")
-                    }
+                if (params.JDK_VERSION.isInteger() && params.JDK_VERSION.toInteger() >= 26) {
+                    echo "Skipping CRIU for JDK ${params.JDK_VERSION}: JDK26+ not yet supported (no dockerfile)"
+                    continue
                 }
-            } else if (type == "scc") {
-                def commonLabel = "sw.tool.podman"
-                if (params.LABEL_ADDITION) {
-                    commonLabel += "&&${params.LABEL_ADDITION}"
-                }
-                buildList="external/scc"
-                imageUploadMap = [
-                    's390x_linux' : [
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z17"],
-                            ],
-                    'ppc64le_linux' : [
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p9"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p11"],
-                    ]
-                ]
-                imagePullMap = [
-                    's390x_linux' : [
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z14"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.s390x.z17"],
-                            ],
-                    'ppc64le_linux' : [
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p9"],
-                                ['LABEL_ADDITION' : "${commonLabel}&&sw.os.rhel.9&&hw.arch.ppc64le.p11"]
-                            ]
-                ]
-
-                target = "testList TESTLIST=disabled.portable_scc_CreateImageAndPushToRegistry_ubi9"
-
             }
+
+            // Build commonLabel from config base + any user-supplied LABEL_ADDITION
+            def commonLabel = uploadConfig.commonLabelBase as String
+            if (params.LABEL_ADDITION) {
+                commonLabel += "&&${params.LABEL_ADDITION}"
+            }
+            buildList = uploadConfig.buildList as String
+            target    = uploadConfig.target    as String
+
+            // Apply platform-specific target exclusions (e.g., plinux CRIU backlog/1099)
+            if (uploadConfig.excludeTargetOnPlatform && uploadConfig.excludeTargetOnPlatform[params.PLATFORM]) {
+                target = target.minus(uploadConfig.excludeTargetOnPlatform[params.PLATFORM] as String)
+            }
+
+            // Build imageUploadMap: { platform -> [ ['LABEL_ADDITION': fullLabel], ... ] }
+            uploadConfig.platforms.each { platform, labelSuffixes ->
+                imageUploadMap[platform as String] = labelSuffixes.collect { suffix ->
+                    ['LABEL_ADDITION': "${commonLabel}&&${suffix}"]
+                }
+            }
+
+            // Build imagePullMap with its own commonLabel (may differ from upload's)
+            def pullCommonLabel = pullConfig.commonLabelBase as String
+            if (params.LABEL_ADDITION) {
+                pullCommonLabel += "&&${params.LABEL_ADDITION}"
+            }
+            pullConfig.platforms.each { platform, labelSuffixes ->
+                imagePullMap[platform as String] = labelSuffixes.collect { suffix ->
+                    ['LABEL_ADDITION': "${pullCommonLabel}&&${suffix}"]
+                }
+            }
+
             // trigger xxx_imageUpload test job, then xxx_imagePull test job
             if (params.PLATFORM && imageUploadMap[params.PLATFORM] != null && imagePullMap[params.PLATFORM] != null) {
                 def imageUploadJobName = "${JOB_NAME}_${type}_imageUpload"


### PR DESCRIPTION
# Summary

Moves the hardcoded `imageUploadMap` and `imagePullMap` Groovy maps out of `openjdk_tests`
and into external JSON config files, completing the second phase of the Portable Container
Testing setup described in #6188.
Closes #6188  
Related: automation/issues/294


## Background

PR #6195 ("Set up pipeline for criu and portable SCC") added inline Groovy maps for both
CRIU and portable SCC directly into `openjdk_tests`. During review, it was acknowledged
that this mapping would **eventually move to a separate config file** to make the pipeline
extensible without requiring code changes.
This PR implements that config-folder approach.


## Changes

### New: `buildenv/jenkins/config/portable-container/`

```
config/portable-container/
├── README.md
├── criu/
│   ├── imageUploadMap.json   # machine combinations for CRIU image upload
│   └── imagePullMap.json     # machine combinations for CRIU image pull/restore
└── scc/
    ├── imageUploadMap.json   # machine combinations for SCC image upload
    └── imagePullMap.json     # machine combinations for SCC image pull/restore
```

Each `imageUploadMap.json` carries:
- `commonLabelBase` — base Jenkins node label for the feature
- `buildList` — `BUILD_LIST` value for child jobs
- `target` — `TARGET` value for upload child jobs
- `excludeTargetOnPlatform` — platform-specific test exclusions (e.g. CRIU ppc64le backlog/1099)
- `platforms` — map of platform → list of label suffixes

Each `imagePullMap.json` carries:
- `commonLabelBase`
- `platforms`

### Modified: `buildenv/jenkins/openjdk_tests`

- Replaces all hardcoded Groovy `imageUploadMap`/`imagePullMap` blocks with a
  `node { checkout scm; readJSON(...) }` config-loading block (same pattern as
  `aqaTestPipeline.groovy`).
- Uses `findFiles(glob: ".../portable-container/*/imageUploadMap.json")` for
  **auto-discovery** — the pipeline detects supported features from the directory
  structure at runtime.
- All orchestration logic (`generateJobViaAutoGen`, `parallel`, `build job:`,
  `changeParam`) is **unchanged**.
- CRIU JDK26+ skip and ppc64le target exclusion are fully preserved.

Net result: **−104 / +63 lines** in `openjdk_tests`.


## How to Add a New Feature (after this PR)

1. Implement tests in `aqa-tests/external/<feature>/`
2. Create `buildenv/jenkins/config/portable-container/<feature>/imageUploadMap.json`
3. Create `buildenv/jenkins/config/portable-container/<feature>/imagePullMap.json`

No changes to `openjdk_tests` required.

## Testing

- All 4 JSON files validated as syntactically correct JSON.
- Logic simulation confirms the Groovy maps constructed from JSON are
  **identical** to the previous hardcoded maps for all platforms (CRIU: 15 upload
  + 14 pull entries; SCC: 4 upload + 4 pull entries).
- CRIU `target` string, ppc64le exclusion substring, and resulting target-after-exclusion
  all verified to match the original values exactly.
