### PR TITLE
Enable dynamic nodes for Windows aarch64

### DIFF
--- a/buildenv/jenkins/config/temurin/default.json
+++ b/buildenv/jenkins/config/temurin/default.json
@@ -81,6 +81,9 @@
             },
             "x86-64_windows": {
                 "CLOUD_PROVIDER": "azure"
+            },
+            "aarch64_windows": {
+                "CLOUD_PROVIDER": "azure"
             }
         }
     }

--- a/buildenv/jenkins/openjdk_tests
+++ b/buildenv/jenkins/openjdk_tests
@@ -17,6 +17,8 @@ def PLATFORM_MAP = [
     'aarch64_windows' : [
         'SPEC' : 'windows_aarch64',
         'LABEL' : 'ci.role.test&&sw.os.windows&&hw.arch.aarch64',
+        'DynamicAgents' : ['azure'],
+        'azureTemplates' : ['sw.os.windows.11']
     ],
     'aarch64_alpine-linux' : [
         'SPEC' : 'alpine-linux_aarch64',


### PR DESCRIPTION
Part of https://github.com/adoptium/infrastructure/issues/4457

Aqa tests  changes required to allow Windows (aarch64) jobs to use dynamic nodes.

Also requires this PR : in ci-jenkins-pipelines https://github.com/adoptium/ci-jenkins-pipelines/pull/1485 