### PR TITLE
Enable ValueTagMapTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -50,7 +50,6 @@ runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.c
 
 ############################################################################
 serviceability/jvmti/valhalla/Heapwalking/ValueHeapwalkingTest.java https://github.com/eclipse-openj9/openj9/issues/24133 generic-all
-serviceability/jvmti/valhalla/SetTag/ValueTagMapTest.java https://github.com/eclipse-openj9/openj9/issues/24134 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Enable ValueTagMapTest.java
Fixed by: https://github.com/eclipse-openj9/openj9/pull/24354

Passing test Grinder link:https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/61858/