### PR TITLE
Exclude jfr/event/oldobject/TestDFSWithSmallStack tests OpenJ9 jdk17

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -764,6 +764,8 @@ jdk/jfr/event/metadata/TestLookForUntestedEvents.java https://github.com/eclipse
 jdk/jfr/event/oldobject/TestAllocationTime.java https://github.com/eclipse-openj9/openj9/issues/24311 generic-all
 jdk/jfr/event/oldobject/TestArrayInformation.java https://github.com/eclipse-openj9/openj9/issues/24316 generic-all
 jdk/jfr/event/oldobject/TestClassLoaderLeak.java https://github.com/eclipse-openj9/openj9/issues/24316 generic-all
+jdk/jfr/event/oldobject/TestDFSWithSmallStack.java#bfsdfs https://github.com/eclipse-openj9/openj9/issues/24481 generic-all
+jdk/jfr/event/oldobject/TestDFSWithSmallStack.java#dfsonly https://github.com/eclipse-openj9/openj9/issues/24481 generic-all
 jdk/jfr/event/oldobject/TestFieldInformation.java https://github.com/eclipse-openj9/openj9/issues/24316 generic-all
 jdk/jfr/event/oldobject/TestHeapDeep.java https://github.com/eclipse-openj9/openj9/issues/24316 generic-all
 jdk/jfr/event/oldobject/TestHeapShallow.java https://github.com/eclipse-openj9/openj9/issues/24316 generic-all


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/24481