### PR TITLE
Exclude the jdk27+ jdk_doublevector128_j9 tests

### DIFF
--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -3270,6 +3270,10 @@
 				<comment>https://github.com/eclipse-openj9/openj9/issues/20389</comment>
 				<platform>aarch64_linux</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/24360</comment>
+				<version>27+</version>				
+			</disable>
 		</disables>
 		<variations>
 			<variation>-Xjit:{*DoubleVector128Tests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,dontApplyLogFileNameSuffix,verbose={vectorAPI}</variation>


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/24360

I missed one in https://github.com/adoptium/aqa-tests/pull/7509