### PR TITLE
OpenJ9 Valhalla build should use openjdk28 exclude list

### DIFF
--- a/openjdk/build.xml
+++ b/openjdk/build.xml
@@ -318,7 +318,7 @@
 		<copy todir="${DEST}" if:set="is_openj9_valhalla">
 			<!-- When updating the problem list version also update
 			 PROBLEM_LIST_FILE for OpenJ9 in openjdk.mk -->
-			<fileset dir="${src}" includes="*.xml,**/ProblemList_openjdk26-openj9.txt,**/ProblemList_openjdkvalhalla-openj9.txt,*.mk"/>
+			<fileset dir="${src}" includes="*.xml,**/ProblemList_openjdk28-openj9.txt,**/ProblemList_openjdkvalhalla-openj9.txt,*.mk"/>
 		</copy>
 		<copy todir="${DEST}" unless:set="is_openj9_valhalla">
 			<fileset dir="${src}" includes="*.xml,**/ProblemList_openjdk${env.JDK_VERSION}*.txt,*.mk"/>

--- a/openjdk/excludes/ProblemList_openjdk28-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk28-openj9.txt
@@ -645,3 +645,10 @@ jdk/internal/platform/docker/TestLimitsUpdating.java https://github.com/eclipse-
 jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj9/openj9/issues/19176 linux-all
 
 ############################################################################
+
+# valhalla
+
+runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/24512 generic-all
+
+############################################################################
+

--- a/openjdk/openjdk.mk
+++ b/openjdk/openjdk.mk
@@ -218,7 +218,7 @@ TIMEOUT_HANDLER:=
 # in the build.xml dist target.
 ifneq ($(filter openj9 ibm, $(JDK_IMPL)),)
 	ifneq ($(filter Valhalla, $(JDK_VERSION)),)
-		PROBLEM_LIST_FILE:=excludes/ProblemList_openjdk26-openj9.txt
+		PROBLEM_LIST_FILE:=excludes/ProblemList_openjdk28-openj9.txt
 		PROBLEM_LIST_FILE_VALHALLA:=excludes/ProblemList_openjdkvalhalla-openj9.txt
 	else
 		PROBLEM_LIST_FILE:=excludes/ProblemList_openjdk$(JDK_VERSION)-openj9.txt


### PR DESCRIPTION
Update Valhalla build to use jdk28 exclude file
Exclude StrictInstanceFieldsTest