### PR TITLE
Handle 403 error responses from url get calls

### DIFF
--- a/scripts/disabled_tests/issue_status.py
+++ b/scripts/disabled_tests/issue_status.py
@@ -363,11 +363,11 @@ def _handle_completed_future(future, log_prefix, url, url_to_issues) -> List[mod
     except Exception as e:
         if "Unauthorized for url" in str(e):
             # Ignore "Unauthorized for url" errors as this is currently permitted.
-            LOG.debug(f"{log_prefix} Ignoring access denial when handling {url!r}: {e}")
+            LOG.warning(f"{log_prefix} Ignoring access denial when handling {url!r}: {e}")
         elif "too many 403 error responses" in str(e):
             # Ignoring intermittent 403 return codes as "forbidden" errors are to be 
             # expected when making multiple, rapid calls against the same api.
-            LOG.debug(f"{log_prefix} Ignoring 403 error response while handling {url!r}: {e}")
+            LOG.warning(f"{log_prefix} Ignoring 403 error response while handling {url!r}: {e}")
         else:
             LOG.error(f"{log_prefix} Uncaught exception for {url!r}: {e}")
             return_code = 1

--- a/scripts/disabled_tests/issue_status.py
+++ b/scripts/disabled_tests/issue_status.py
@@ -90,21 +90,21 @@ class BaseHandler(abc.ABC):
         timeout_s = 30
         is_github_api = url.startswith("https://api.github.com/")
         is_github_web = url.startswith("https://github.com/")
+        auth = None
+        if all([self.user, self.token]):
+            auth = requests.auth.HTTPBasicAuth(username=str(self.user), password=str(self.token))
+
+        headers = None
+        if is_github_api:
+            headers = self.PARAMS
+
+        adapter: HTTPAdapter = HTTPAdapter(max_retries=self.retry_strategy)
+        session: requests.Session = requests.Session()
+        session.mount("https://", adapter)
         if is_github_api or is_github_web:
-            auth = None
-            if all([self.user, self.token]):
-                auth = requests.auth.HTTPBasicAuth(username=str(self.user), password=str(self.token))
-
-            headers = None
-            if is_github_api:
-                headers = self.PARAMS
-
-            adapter: HTTPAdapter = HTTPAdapter(max_retries=self.retry_strategy)
-            session: requests.Session = requests.Session()
-            session.mount("https://", adapter)
             resp = session.get(url, params=headers, auth=auth, timeout=timeout_s)
         else:
-            resp = requests.get(url, timeout=timeout_s)
+            resp = session.get(url, params=headers, timeout=timeout_s)
         resp.raise_for_status()
         return resp
 

--- a/scripts/disabled_tests/issue_status.py
+++ b/scripts/disabled_tests/issue_status.py
@@ -361,9 +361,13 @@ def _handle_completed_future(future, log_prefix, url, url_to_issues) -> List[mod
         LOG.error(f"{log_prefix} No handler found for {url!r}")
         return_code = 1
     except Exception as e:
-        # Ignore "Unauthorized for url" errors as this is currently permitted.
         if "Unauthorized for url" in str(e):
+            # Ignore "Unauthorized for url" errors as this is currently permitted.
             LOG.debug(f"{log_prefix} Ignoring access denial when handling {url!r}: {e}")
+        elif "too many 403 error responses" in str(e):
+            # Ignoring intermittent 403 return codes as "forbidden" errors are to be 
+            # expected when making multiple, rapid calls against the same api.
+            LOG.debug(f"{log_prefix} Ignoring 403 error response while handling {url!r}: {e}")
         else:
             LOG.error(f"{log_prefix} Uncaught exception for {url!r}: {e}")
             return_code = 1


### PR DESCRIPTION
Our issue parser (that determines the current status of issues linked to excluded tests) can produce "403" errors if a single api is polled too many times in quick succession, as the api may use rate limiting.

This change reduces the overall number of errors to 0 or 1 per run by adding retry logic to all api calls, not just github api calls.

The remaining errors are reported, but not treated as cause for overall failure. These should go away entirely once the number of excluded tests linked to a single api drops below threshold.

Testing here: https://github.com/adamfarley/aqa-tests/actions/runs/31585863783/job/94079428718
Update: Passed. Ready for review.