### PR TITLE
Enable TestUpcallStress

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -559,7 +559,6 @@ java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/open
 java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all
 java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all
 java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all
-java/foreign/TestUpcallStress.java https://github.com/eclipse-openj9/openj9/issues/24464 generic-all
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 

--- a/openjdk/excludes/ProblemList_openjdk28-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk28-openj9.txt
@@ -559,7 +559,6 @@ java/foreign/TestUnsupportedPlatform.java https://github.com/eclipse-openj9/open
 java/foreign/TestUpcallAsync.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all
 java/foreign/TestUpcallScope.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all
 java/foreign/TestUpcallStack.java https://github.com/eclipse-openj9/openj9/issues/22403 aix-all
-java/foreign/TestUpcallStress.java https://github.com/eclipse-openj9/openj9/issues/24464 generic-all
 java/foreign/upcalldeopt/TestUpcallDeopt.java https://github.com/eclipse-openj9/openj9/issues/13157 generic-all
 java/foreign/valist/VaListTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
 


### PR DESCRIPTION
Fixed by: https://github.com/eclipse-openj9/openj9/pull/24511

Passing Test: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/61889/testReport/