### PR TITLE
Enable JFR TestThreadExclusion test

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -889,7 +889,6 @@ jdk/jfr/jvm/TestLogImplementation.java https://github.com/eclipse-openj9/openj9/
 jdk/jfr/jvm/TestLogOutput.java https://github.com/eclipse-openj9/openj9/issues/24325 generic-all
 jdk/jfr/jvm/TestModularImage.java https://github.com/eclipse-openj9/openj9/issues/24325 generic-all
 jdk/jfr/jvm/TestPrimitiveClasses.java https://github.com/eclipse-openj9/openj9/issues/24311 generic-all
-jdk/jfr/jvm/TestThreadExclusion.java https://github.com/eclipse-openj9/openj9/issues/24335 generic-all
 jdk/jfr/jvm/TestUnloadEventClassCount.java https://github.com/eclipse-openj9/openj9/issues/24311 generic-all
 jdk/jfr/startupargs/TestBadOptionValues.java https://github.com/eclipse-openj9/openj9/issues/24313 generic-all
 jdk/jfr/startupargs/TestDumpOnExit.java https://github.com/eclipse-openj9/openj9/issues/24325 generic-all


### PR DESCRIPTION
Fixed by: https://github.com/eclipse-openj9/openj9/pull/24442