### PR TITLE
Separate generate/trigger child jobs with parameters defined by Configrations and Params

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -262,10 +262,10 @@ timestamps {
                             if (params.PLATFORMS) {
                                 if (params.PLATFORMS.contains(p)) {
                                     echo "Only triggering test builds specified in PLATFORMS: ${params.PLATFORMS}..."
-                                    generateJobs(JDK_VERSION, releaseTestFlag, p, t, globalBuildConfig, targetSpecificConfig, platformSpecificConfig, platformAdditionalTestLabels, platformAdditionalTestParams)
+                                    generateJobsWithConfig(JDK_VERSION, releaseTestFlag, p, t, globalBuildConfig, targetSpecificConfig, platformSpecificConfig, platformAdditionalTestLabels, platformAdditionalTestParams)
                                 }
                             } else {
-                                generateJobs(JDK_VERSION, releaseTestFlag, p, t, globalBuildConfig, targetSpecificConfig, platformSpecificConfig, platformAdditionalTestLabels, platformAdditionalTestParams)
+                                generateJobsWithConfig(JDK_VERSION, releaseTestFlag, p, t, globalBuildConfig, targetSpecificConfig, platformSpecificConfig, platformAdditionalTestLabels, platformAdditionalTestParams)
                             }
                         }
                     }
@@ -275,406 +275,374 @@ timestamps {
             if ( params.MODE == 'RELAY' && params.VARIANT == "temurin" ) {
                 remoteTriggerTemurinJCK(JDK_VERSION, PLATFORMS)
             } else {
-                generateJobs(JDK_VERSION, TEST_FLAG, PLATFORMS, TARGETS, [:], [:], [:], [:], [:])
+                generateJobsFromParams(JDK_VERSION, TEST_FLAG, PLATFORMS, TARGETS)
             }
         }
     }
     parallel JOBS
 }
 
-def generateJobs(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets, globalBuildConfig = [:], targetSpecificConfig = [:], platformSpecificConfig = [:], platformAdditionalTestLabels = [:], platformAdditionalTestParams = [:]) {
+// Build the job name suffix from a test flag string
+def buildTestFlagSuffix(jobTestFlag) {
+    if (!jobTestFlag) return ""
+    if (jobTestFlag.contains("FIPS")) {
+        if (jobTestFlag == "FIPS140_2")                                        return "_f2"
+        if (jobTestFlag == "FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced") return "_f3_strong"
+        if (jobTestFlag == "FIPS140_3_OpenJCEPlusFIPS.FIPS140-3")              return "_f3_strict"
+        if (jobTestFlag == "FIPS140_3_OpenJCEPlusFIPS")                        return "_f3_weak"
+        return "_" + jobTestFlag.toLowerCase().trim()
+    }
+    return "_" + jobTestFlag.toLowerCase().trim()
+}
+
+// Resolve platform/variant derived values from a PLATFORM string
+def resolvePlatformVars(PLATFORM) {
+    String[] tokens = PLATFORM.split('_')
+    def os   = tokens[1]
+    def arch = tokens[0]
+    if (arch.contains("x86-64"))  arch = "x64"
+    else if (arch.contains("x86-32")) arch = "x86-32"
+
+    def filter     = os.contains("windows") ? "*.zip" : "*.tar.gz"
+    def short_name = params.VARIANT
+    def jdk_impl   = "hotspot"
+    if (params.VARIANT == "openj9")  { short_name = "j9"; jdk_impl = params.VARIANT }
+    else if (params.VARIANT == "ibm")    { jdk_impl = params.VARIANT }
+    else if (params.VARIANT == "temurin"){ short_name = "hs" }
+
+    def download_url      = params.CUSTOMIZED_SDK_URL ?: ""
+    def sdk_resource_value = SDK_RESOURCE
+    if (SDK_RESOURCE == "customized" && params.TOP_LEVEL_SDK_URL) {
+        def url = params.TOP_LEVEL_SDK_URL.endsWith("/") ? params.TOP_LEVEL_SDK_URL : "${params.TOP_LEVEL_SDK_URL}/"
+        download_url = "${url}artifact/target/${os}/${arch}/${params.VARIANT}/${filter}/*zip*/${params.VARIANT}.zip"
+    }
+    echo "download_url: ${download_url}"
+    return [os: os, arch: arch, filter: filter, short_name: short_name, jdk_impl: jdk_impl,
+            download_url: download_url, sdk_resource_value: sdk_resource_value]
+}
+
+// Fire the downstream job and collect TAP artifacts
+def triggerChildJob(TEST_JOB_NAME, childParams) {
+    def JobHelper = library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+    if (JobHelper.jobIsRunnable(TEST_JOB_NAME as String)) {
+        int jobNum = JOBS.size() + 1
+        JOBS["${TEST_JOB_NAME}_${jobNum}"] = {
+            def downstreamJob = build job: TEST_JOB_NAME, parameters: childParams, propagate: false, wait: true
+            def downstreamJobResult = downstreamJob.getResult()
+            echo "${TEST_JOB_NAME} result is ${downstreamJobResult}"
+            def buildId      = downstreamJob.getNumber()
+            def childBuildUrl = "${env.JENKINS_URL}job/${TEST_JOB_NAME}/${buildId}"
+            def badgeUrl     = "${childBuildUrl}/badge/icon"
+            currentBuild.description += """
+                <p>${TEST_JOB_NAME}/${buildId}:
+                <a href="${childBuildUrl}">
+                    <img src="${badgeUrl}" />
+                </a>
+                </p>
+            """
+            if (downstreamJobResult == 'SUCCESS' || downstreamJobResult == 'UNSTABLE') {
+                echo "[NODE SHIFT] MOVING INTO CONTROLLER NODE..."
+                node("worker || (ci.role.test&&hw.arch.x86&&sw.os.linux)") {
+                    cleanWs disableDeferredWipeout: true, deleteDirs: true
+                    try {
+                        timeout(time: 2, unit: 'HOURS') {
+                            copyArtifacts(
+                                projectName: TEST_JOB_NAME,
+                                selector: specific("${downstreamJob.getNumber()}"),
+                                filter: "**/${TEST_JOB_NAME}*.tap",
+                                fingerprintArtifacts: true,
+                                flatten: true
+                            )
+                        }
+                    } catch (Exception e) {
+                        echo 'Exception: ' + e.toString()
+                        echo "Cannot run copyArtifacts from job ${TEST_JOB_NAME}. Skipping copyArtifacts..."
+                    }
+                    try {
+                        timeout(time: 1, unit: 'HOURS') {
+                            archiveArtifacts artifacts: "*.tap", fingerprint: true
+                        }
+                    } catch (Exception e) {
+                        echo 'Exception: ' + e.toString()
+                        echo "Cannot archiveArtifacts from job ${TEST_JOB_NAME}."
+                    }
+                }
+            }
+            updateBuildResult(downstreamJobResult)
+        }
+    } else {
+        println "Requested test job that does not exist or is disabled: ${TEST_JOB_NAME}. \n To generate the job, pelase set AUTO_AQA_GEN = true"
+        updateBuildResult("FAILURE")
+    }
+}
+
+// Scenario 3: params pass-through — used for manual/Grinder runs and private relay.
+// Pipeline params are authoritative. No JSON config is consulted.
+// All params are forwarded to the child job as-is; DEFAULTS are used only when a param is absent.
+def generateJobsFromParams(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets) {
+    def DEFAULTS = [
+        PARALLEL               : "Dynamic",
+        NUM_MACHINES           : "",
+        DYNAMIC_COMPILE        : false,
+        KEEP_REPORTDIR         : false,
+        RERUN_ITERATIONS       : "0",
+        USE_TESTENV_PROPERTIES : false,
+    ]
+
     if (jobTargets instanceof String) {
-        jobTargets = jobTargets.replace("defaultFipsTestTargets","${defaultFipsTestTargets}")
-        jobTargets = jobTargets.replace("defaultFips140_2TestTargets","${defaultFips140_2TestTargets}")
-        jobTargets = jobTargets.replace("defaultTestTargets","${defaultTestTargets}")
+        jobTargets = jobTargets.replace("defaultFipsTestTargets", "${defaultFipsTestTargets}")
+        jobTargets = jobTargets.replace("defaultFips140_2TestTargets", "${defaultFips140_2TestTargets}")
+        jobTargets = jobTargets.replace("defaultTestTargets", "${defaultTestTargets}")
         jobTargets = jobTargets.split("\\s*,\\s*")
     }
     if (jobPlatforms instanceof String) {
         jobPlatforms = jobPlatforms.split("\\s*,\\s*")
     }
-
     echo "jobJdkVersion: ${jobJdkVersion}, jobTestFlag: ${jobTestFlag}, jobPlatforms: ${jobPlatforms}, jobTargets: ${jobTargets}"
-    if (jobTestFlag == "NONE") {
-        jobTestFlag = ""
-    }
+    if (jobTestFlag == "NONE") jobTestFlag = ""
+
     jobPlatforms.each { PLATFORM ->
-        String[] tokens = PLATFORM.split('_')
-        def os = tokens[1];
-        def arch = tokens[0];
-        if (arch.contains("x86-64")){
-            arch = "x64"
-        } else if (arch.contains("x86-32")) {
-            arch ="x86-32"
-        }
-
-        def filter = "*.tar.gz"
-        if (os.contains("windows")) {
-            filter = "*.zip"
-        }
-        def short_name = params.VARIANT
-        def jdk_impl = "hotspot"
-        if (params.VARIANT == "openj9") {
-            short_name = "j9"
-            jdk_impl = params.VARIANT
-        } else if (params.VARIANT == "ibm") {
-            jdk_impl = params.VARIANT
-        } else if (params.VARIANT == "temurin") {
-            short_name = "hs"
-        } 
-        
-        def download_url = params.CUSTOMIZED_SDK_URL ? params.CUSTOMIZED_SDK_URL : ""
-        def sdk_resource_value = SDK_RESOURCE
-
-        if (SDK_RESOURCE == "customized" ) {
-            if (params.TOP_LEVEL_SDK_URL) {
-                def url = params.TOP_LEVEL_SDK_URL
-                if (!url.endsWith("/")) {
-                    url = "${params.TOP_LEVEL_SDK_URL}/"
-                }
-                // example: <jenkins_url>/job/build-scripts/job/openjdk11-pipeline/123/artifact/target/linux/aarch64/openj9/*_aarch64_linux_*.tar.gz/*zip*/openj9.zip
-                download_url = "${url}artifact/target/${os}/${arch}/${params.VARIANT}/${filter}/*zip*/${params.VARIANT}.zip"
-            }
-        }
-        echo "download_url: ${download_url}"
+        def pv = resolvePlatformVars(PLATFORM)
 
         jobTargets.each { TARGET ->
-            // Helper function to merge configs with special handling for LABEL_ADDITION
+            def TEST_JOB_NAME = TARGET.contains("Grinder") ? TARGET
+                : "Test_openjdk${jobJdkVersion}_${pv.short_name}_${TARGET}_${PLATFORM}${buildTestFlagSuffix(jobTestFlag)}"
+            echo "TEST_JOB_NAME: ${TEST_JOB_NAME}"
+
+            // Build childParams purely from pipeline params — params win, DEFAULTS are last resort
+            def childParams = []
+            params.each { param ->
+                if (param.key in ["PLATFORMS", "TARGETS", "TOP_LEVEL_SDK_URL", "AUTO_AQA_GEN",
+                                  "JDK_VERSIONS", "VARIANT", "PIPELINE_DISPLAY_NAME"]) {
+                    // do not pass to child jobs
+                } else if (param.key == "SDK_RESOURCE") {
+                    childParams << string(name: param.key, value: pv.sdk_resource_value)
+                } else if (param.key == "CUSTOMIZED_SDK_URL") {
+                    childParams << string(name: param.key, value: pv.download_url)
+                } else if (param.key == "PARALLEL") {
+                    childParams << string(name: param.key, value: params.PARALLEL ?: DEFAULTS.PARALLEL)
+                } else if (param.key == "NUM_MACHINES") {
+                    childParams << string(name: param.key, value: params.NUM_MACHINES ?: DEFAULTS.NUM_MACHINES)
+                } else if (param.key == "LIGHT_WEIGHT_CHECKOUT") {
+                    childParams << booleanParam(name: param.key, value: LIGHT_WEIGHT_CHECKOUT.toBoolean())
+                } else if (param.key == "TIME_LIMIT") {
+                    childParams << string(name: param.key, value: TIME_LIMIT.toString())
+                } else if (param.key == "USE_TESTENV_PROPERTIES") {
+                    childParams << booleanParam(name: param.key, value: params.USE_TESTENV_PROPERTIES ? params.USE_TESTENV_PROPERTIES.toBoolean() : DEFAULTS.USE_TESTENV_PROPERTIES)
+                } else {
+                    def value = param.value.toString()
+                    childParams << (value in ["true", "false"] ? booleanParam(name: param.key, value: value.toBoolean()) : string(name: param.key, value: value))
+                }
+            }
+            // Always-present params not covered by the params.each loop
+            childParams << booleanParam(name: "DYNAMIC_COMPILE",  value: (params.DYNAMIC_COMPILE  ?: DEFAULTS.DYNAMIC_COMPILE).toBoolean())
+            childParams << booleanParam(name: "KEEP_REPORTDIR",   value: (params.KEEP_REPORTDIR   ?: DEFAULTS.KEEP_REPORTDIR).toBoolean())
+            childParams << booleanParam(name: "GENERATE_JOBS",    value: AUTO_AQA_GEN.toBoolean())
+            childParams << string(name: "JDK_IMPL",               value: pv.jdk_impl)
+            childParams << string(name: "JDK_VERSION",            value: jobJdkVersion)
+            childParams << string(name: "PLATFORM",               value: PLATFORM)
+            childParams << string(name: "RERUN_ITERATIONS",       value: (params.RERUN_ITERATIONS ?: DEFAULTS.RERUN_ITERATIONS).toString())
+            childParams << string(name: "TEST_FLAG",              value: jobTestFlag)
+            childParams << string(name: "VENDOR_TEST_BRANCHES",   value: params.VENDOR_TEST_BRANCHES ?: '')
+            childParams << string(name: "VENDOR_TEST_DIRS",       value: params.VENDOR_TEST_DIRS     ?: '')
+            childParams << string(name: "VENDOR_TEST_REPOS",      value: params.VENDOR_TEST_REPOS    ?: '')
+
+            triggerChildJob(TEST_JOB_NAME, childParams)
+        }
+    }
+}
+
+// Scenario 1: config-driven — used for release/nightly/weekly builds.
+// JSON buildConfig is authoritative. Pipeline params are not consulted for config values.
+def generateJobsWithConfig(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets, globalBuildConfig = [:], targetSpecificConfig = [:], platformSpecificConfig = [:], platformAdditionalTestLabels = [:], platformAdditionalTestParams = [:]) {
+    if (jobTargets instanceof String) {
+        jobTargets = jobTargets.replace("defaultFipsTestTargets", "${defaultFipsTestTargets}")
+        jobTargets = jobTargets.replace("defaultFips140_2TestTargets", "${defaultFips140_2TestTargets}")
+        jobTargets = jobTargets.replace("defaultTestTargets", "${defaultTestTargets}")
+        jobTargets = jobTargets.split("\\s*,\\s*")
+    }
+    if (jobPlatforms instanceof String) {
+        jobPlatforms = jobPlatforms.split("\\s*,\\s*")
+    }
+    echo "jobJdkVersion: ${jobJdkVersion}, jobTestFlag: ${jobTestFlag}, jobPlatforms: ${jobPlatforms}, jobTargets: ${jobTargets}"
+    if (jobTestFlag == "NONE") jobTestFlag = ""
+
+    jobPlatforms.each { PLATFORM ->
+        def pv = resolvePlatformVars(PLATFORM)
+
+        jobTargets.each { TARGET ->
+            // Helper closure to merge configs with special handling for LABEL_ADDITION
             def mergeConfig = { target, source ->
                 source.each { key, value ->
                     if (key == "LABEL_ADDITION" && target.containsKey("LABEL_ADDITION") && target["LABEL_ADDITION"]) {
-                        // Append to existing LABEL_ADDITION instead of replacing
                         target["LABEL_ADDITION"] = "${target['LABEL_ADDITION']}&&${value}"
                     } else {
                         target[key] = value
                     }
                 }
             }
-            
-            // Apply configuration hierarchy: global -> target-specific -> platform-specific -> params
+
+            // Apply configuration hierarchy: global -> target-specific -> platform-specific
             def buildConfig = [:]
-            
-            // Start with global build config from JSON
-            if (globalBuildConfig) {
-                mergeConfig(buildConfig, globalBuildConfig)
-            }
-            
-            // Apply target-specific config (e.g., functional, openjdk, jck)
+            if (globalBuildConfig) mergeConfig(buildConfig, globalBuildConfig)
+
             if (targetSpecificConfig) {
-                // Check for exact match first (e.g., "dev.openjdk")
                 if (targetSpecificConfig.containsKey(TARGET)) {
                     mergeConfig(buildConfig, targetSpecificConfig[TARGET])
                 }
-                
-                // Apply test flag-only config (e.g., "FIPS", "OpenJCEPlus") - applies to any target
                 if (jobTestFlag && targetSpecificConfig.containsKey(jobTestFlag)) {
                     mergeConfig(buildConfig, targetSpecificConfig[jobTestFlag])
                 }
-                
-                // Check for target + test flag combination (e.g., "extended.functional.FIPS")
-                // Note: net.sf.json.JSONObject.containsKey() doesn't work with keys containing dots,
-                // so we use direct access instead
                 if (jobTestFlag) {
-                    // First try exact match (e.g., "extended.functional.FIPS140_3_OpenJCEPlusFIPS")
                     def exactKey = "${TARGET}.${jobTestFlag}"
                     if (targetSpecificConfig[exactKey]) {
                         mergeConfig(buildConfig, targetSpecificConfig[exactKey])
                     } else {
-                        // Then try with generic FIPS/OpenJCEPlus suffix for variants
-                        // Check for TARGET.FIPS when jobTestFlag contains FIPS (e.g., FIPS140_2, FIPS140_3_OpenJCEPlusFIPS)
                         if (jobTestFlag.contains("FIPS")) {
                             def targetFipsKey = "${TARGET}.FIPS"
-                            if (targetSpecificConfig[targetFipsKey]) {
-                                mergeConfig(buildConfig, targetSpecificConfig[targetFipsKey])
-                            }
+                            if (targetSpecificConfig[targetFipsKey]) mergeConfig(buildConfig, targetSpecificConfig[targetFipsKey])
                         }
-                        // Check for TARGET.OpenJCEPlus when jobTestFlag contains OpenJCEPlus
                         if (jobTestFlag.contains("OpenJCEPlus")) {
                             def targetOpenJCEPlusKey = "${TARGET}.OpenJCEPlus"
-                            if (targetSpecificConfig[targetOpenJCEPlusKey]) {
-                                mergeConfig(buildConfig, targetSpecificConfig[targetOpenJCEPlusKey])
-                            }
+                            if (targetSpecificConfig[targetOpenJCEPlusKey]) mergeConfig(buildConfig, targetSpecificConfig[targetOpenJCEPlusKey])
                         }
                     }
                 }
-                
-                // Apply configs in hierarchical order: base configs first, then specific overrides
-                // This allows "openjdk" to apply to all openjdk variants, but "sanity.openjdk" to override
-                
-                // First pass: Apply base configs (simple keys that match via substring)
+                // First pass: base configs via substring match
                 targetSpecificConfig.each { key, value ->
-                    if (!key.contains('.') && TARGET.contains(key)) {
-                        // Simple keys use substring match (e.g., "functional" matches "sanity.functional")
-                        // This allows base category configs to apply to all variants
-                        if (!['FIPS', 'OpenJCEPlus'].contains(key)) {
-                            mergeConfig(buildConfig, value)
-                        }
+                    if (!key.contains('.') && TARGET.contains(key) && !['FIPS', 'OpenJCEPlus'].contains(key)) {
+                        mergeConfig(buildConfig, value)
                     }
                 }
-                
-                // Second pass: Apply specific compound configs (exact match overrides)
+                // Second pass: compound exact-match overrides
                 targetSpecificConfig.each { key, value ->
                     if (key.contains('.')) {
                         def parts = key.split('\\.')
                         if (parts.size() == 2) {
-                            // Check if this is a test flag key (e.g., "functional.FIPS")
                             def isTestFlagKey = ['FIPS', 'OpenJCEPlus'].contains(parts[1])
-                            
-                            if (isTestFlagKey) {
-                                // Test flag keys are handled above, skip here
-                                return
-                            } else if (TARGET == key) {
-                                // Exact match for compound keys (e.g., "special.openjdk" matches "special.openjdk")
-                                // This overrides any base config applied in first pass
-                                // Only apply if jobTestFlag is empty
-                                if (!jobTestFlag || jobTestFlag == "") {
-                                    mergeConfig(buildConfig, value)
-                                }
+                            if (!isTestFlagKey && TARGET == key && (!jobTestFlag || jobTestFlag == "")) {
+                                mergeConfig(buildConfig, value)
                             }
                         }
                     }
                 }
             }
-            
-            // Apply platform-specific config for this target
+
             if (platformSpecificConfig && platformSpecificConfig.containsKey(TARGET)) {
                 def platformConfig = platformSpecificConfig[TARGET]
-                if (platformConfig.containsKey(PLATFORM)) {
-                    mergeConfig(buildConfig, platformConfig[PLATFORM])
-                }
+                if (platformConfig.containsKey(PLATFORM)) mergeConfig(buildConfig, platformConfig[PLATFORM])
             }
-            
-            // Apply platform-specific additional test labels
-            // This appends to any LABEL_ADDITION already set by target-specific config
+
             if (platformAdditionalTestLabels && platformAdditionalTestLabels.containsKey(PLATFORM)) {
                 def additionalLabel = platformAdditionalTestLabels[PLATFORM]
-                if (buildConfig.LABEL_ADDITION) {
-                    buildConfig.LABEL_ADDITION = "${buildConfig.LABEL_ADDITION}&&${additionalLabel}"
-                } else {
-                    buildConfig.LABEL_ADDITION = additionalLabel
-                }
+                buildConfig.LABEL_ADDITION = buildConfig.LABEL_ADDITION
+                    ? "${buildConfig.LABEL_ADDITION}&&${additionalLabel}"
+                    : additionalLabel
             }
-            
-            // Apply platform-specific additional test params
+
             if (platformAdditionalTestParams && platformAdditionalTestParams.containsKey(PLATFORM)) {
                 def additionalParams = platformAdditionalTestParams[PLATFORM]
-                if (!buildConfig.ADDITIONAL_TEST_PARAMS) {
-                    buildConfig.ADDITIONAL_TEST_PARAMS = [:]
-                }
+                if (!buildConfig.ADDITIONAL_TEST_PARAMS) buildConfig.ADDITIONAL_TEST_PARAMS = [:]
                 mergeConfig(buildConfig.ADDITIONAL_TEST_PARAMS, additionalParams)
             }
-            // Build config is now fully determined by JSON config files.
-            // Pipeline-level parameters (JDK_VERSIONS, PLATFORMS, TARGETS) are separate and not in JSON.
-            
-            
-            def TEST_JOB_NAME = "Grinder"
-            if (TARGET.contains("Grinder")) {
-                TEST_JOB_NAME = TARGET
-            } else {
-                def suffix = ""
-                if (jobTestFlag) {
-                    // Use abbreviated FIPS suffixes in job names to keep naming consistent
-                    // across platforms while still passing the original jobTestFlag unchanged
-                    // to the tests via the TEST_FLAG child parameter.
-                    if (jobTestFlag.contains("FIPS")) {
-                        if (jobTestFlag == "FIPS140_2") {
-                            suffix = "_f2"
-                        } else if (jobTestFlag == "FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced") {
-                            suffix = "_f3_strong"
-                        } else if (jobTestFlag == "FIPS140_3_OpenJCEPlusFIPS.FIPS140-3") {
-                            suffix = "_f3_strict"
-                        } else if (jobTestFlag == "FIPS140_3_OpenJCEPlusFIPS") {
-                            suffix = "_f3_weak"
-                        } else {
-                            // For any other FIPS variant, use lowercase
-                            suffix = "_" + jobTestFlag.toLowerCase().trim()
-                        }
-                    } else {
-                        // For non-FIPS test flags (e.g., OpenJCEPlus), use lowercase
-                        suffix = "_" + jobTestFlag.toLowerCase().trim()
-                    }
-                }
-                TEST_JOB_NAME = "Test_openjdk${jobJdkVersion}_${short_name}_${TARGET}_${PLATFORM}${suffix}"
-            }
+
+            def TEST_JOB_NAME = TARGET.contains("Grinder") ? TARGET
+                : "Test_openjdk${jobJdkVersion}_${pv.short_name}_${TARGET}_${PLATFORM}${buildTestFlagSuffix(jobTestFlag)}"
             echo "TEST_JOB_NAME: ${TEST_JOB_NAME}"
             echo "Applied buildConfig: ${buildConfig}"
 
-            // Extract values from buildConfig with fallbacks
-            def keep_reportdir = buildConfig.KEEP_REPORTDIR ? buildConfig.KEEP_REPORTDIR.toBoolean() : false
+            // Resolve all effective values from buildConfig; DEFAULTS are last resort
+            def keep_reportdir  = buildConfig.KEEP_REPORTDIR  ? buildConfig.KEEP_REPORTDIR.toBoolean()  : false
             def DYNAMIC_COMPILE = buildConfig.DYNAMIC_COMPILE ? buildConfig.DYNAMIC_COMPILE.toBoolean() : false
-            // Override config values with params if provided
-            def VENDOR_TEST_REPOS = params.VENDOR_TEST_REPOS ?: (buildConfig.VENDOR_TEST_REPOS ?: '')
+            def VENDOR_TEST_REPOS    = params.VENDOR_TEST_REPOS    ?: (buildConfig.VENDOR_TEST_REPOS    ?: '')
             def VENDOR_TEST_BRANCHES = params.VENDOR_TEST_BRANCHES ?: (buildConfig.VENDOR_TEST_BRANCHES ?: '')
-            def VENDOR_TEST_DIRS = params.VENDOR_TEST_DIRS ?: (buildConfig.VENDOR_TEST_DIRS ?: '')
+            def VENDOR_TEST_DIRS     = params.VENDOR_TEST_DIRS     ?: (buildConfig.VENDOR_TEST_DIRS     ?: '')
             int rerunIterations = (params.RERUN_ITERATIONS ?: (buildConfig.RERUN_ITERATIONS ?: '0')).toString().toInteger()
-            def buildList = buildConfig.BUILD_LIST ?: ""
-            def testLabel = buildConfig.LABEL ?: ""
-            def additionalTestLabel = buildConfig.LABEL_ADDITION ?: ""
-            
+            def buildList           = buildConfig.BUILD_LIST      ?: ""
+            def testLabel           = buildConfig.LABEL           ?: ""
+            def additionalTestLabel = buildConfig.LABEL_ADDITION  ?: ""
+
             // Apply variant-specific logic for special cases not covered by config
             if (params.VARIANT == "openj9" || params.VARIANT == "ibm") {
-                // Handle VENDOR_TEST_BRANCHES override for adoptium repo
                 if (TARGET.contains('functional') && !jobTestFlag.contains("FIPS")) {
                     if (params.ADOPTOPENJDK_REPO && params.ADOPTOPENJDK_REPO.contains("adoptium/aqa-tests")) {
                         VENDOR_TEST_BRANCHES = params.ADOPTOPENJDK_BRANCH ?: 'master'
                     }
                 }
             }
+
             // Grinder job has special settings and should be regenerated specifically, not via aqaTestPipeline
             if (AUTO_AQA_GEN.toBoolean() && !TEST_JOB_NAME.contains("Grinder")) {
                 String[] targetTokens = TARGET.split("\\.")
-                def level = targetTokens[0];
-                def group = targetTokens[1];
-                def parameters = [
-                    string(name: 'TEST_JOB_NAME', value: TEST_JOB_NAME),
-                    string(name: 'LEVELS', value: level),
-                    string(name: 'GROUPS', value: group),
-                    string(name: 'JDK_VERSIONS', value: jobJdkVersion),
-                    string(name: 'ARCH_OS_LIST', value: PLATFORM),
-                    string(name: 'JDK_IMPL', value: jdk_impl),
+                build job: 'Test_Job_Auto_Gen', parameters: [
+                    string(name: 'TEST_JOB_NAME',        value: TEST_JOB_NAME),
+                    string(name: 'LEVELS',               value: targetTokens[0]),
+                    string(name: 'GROUPS',               value: targetTokens[1]),
+                    string(name: 'JDK_VERSIONS',         value: jobJdkVersion),
+                    string(name: 'ARCH_OS_LIST',         value: PLATFORM),
+                    string(name: 'JDK_IMPL',             value: pv.jdk_impl),
                     booleanParam(name: 'LIGHT_WEIGHT_CHECKOUT', value: LIGHT_WEIGHT_CHECKOUT)
-                ]
-                build job: 'Test_Job_Auto_Gen', parameters: parameters, propagate: true
+                ], propagate: true
             }
 
-            def JobHelper = library(identifier: 'openjdk-jenkins-helper@master').JobHelper
-            if (JobHelper.jobIsRunnable(TEST_JOB_NAME as String)) {
-                def childParams = []
-                // loop through all the params and change the parameters if needed
-                params.each { param ->
-                    if ( param.key == "PLATFORMS" || param.key == "TARGETS" || param.key == "TOP_LEVEL_SDK_URL"
-                    || param.key == "AUTO_AQA_GEN" || param.key == "JDK_VERSIONS" || param.key == "VARIANT" || param.key == "PIPELINE_DISPLAY_NAME") {
-                        // do not need to pass the param to child jobs
-                    } else if (param.key == "SDK_RESOURCE") {
-                        childParams << string(name: param.key, value: sdk_resource_value)
-                    } else if (param.key == "CUSTOMIZED_SDK_URL") {
-                        childParams << string(name: param.key, value: download_url)
-                    } else if (param.key == "PARALLEL") {
-                        childParams << string(name: param.key, value: buildConfig.PARALLEL ?: "Dynamic")
-                    } else if (param.key == "NUM_MACHINES") {
-                        childParams << string(name: param.key, value: buildConfig.NUM_MACHINES ?: (params.NUM_MACHINES ?: ""))
-                    } else if (param.key == "LIGHT_WEIGHT_CHECKOUT") {
-                        childParams << booleanParam(name: param.key, value: LIGHT_WEIGHT_CHECKOUT.toBoolean())
-                    } else if (param.key == "TIME_LIMIT") {
-                        childParams << string(name: param.key, value: TIME_LIMIT.toString())
-                    } else if (param.key == "USE_TESTENV_PROPERTIES") {
-                        // Pipeline parameter true always wins; otherwise fall back to JSON config value.
-                        def useTestEnv = params.USE_TESTENV_PROPERTIES ? true : (buildConfig.USE_TESTENV_PROPERTIES != null ? buildConfig.USE_TESTENV_PROPERTIES.toBoolean() : false)
-                        childParams << booleanParam(name: param.key, value: useTestEnv)
-                    } else {
-                        def value = param.value.toString()
-                        if (value == "true" || value == "false") {
-                            childParams << booleanParam(name: param.key, value: value.toBoolean())
-                        } else {
-                            childParams << string(name: param.key, value: value)
-                        }
-                    }
+            // Assemble childParams — config is authoritative for all overridable values
+            def childParams = []
+            params.each { param ->
+                if (param.key in ["PLATFORMS", "TARGETS", "TOP_LEVEL_SDK_URL", "AUTO_AQA_GEN",
+                                  "JDK_VERSIONS", "VARIANT", "PIPELINE_DISPLAY_NAME"]) {
+                    // do not pass to child jobs
+                } else if (param.key == "SDK_RESOURCE") {
+                    childParams << string(name: param.key, value: pv.sdk_resource_value)
+                } else if (param.key == "CUSTOMIZED_SDK_URL") {
+                    childParams << string(name: param.key, value: pv.download_url)
+                } else if (param.key == "PARALLEL") {
+                    childParams << string(name: param.key, value: buildConfig.PARALLEL ?: "Dynamic")
+                } else if (param.key == "NUM_MACHINES") {
+                    childParams << string(name: param.key, value: buildConfig.NUM_MACHINES ?: "")
+                } else if (param.key == "LIGHT_WEIGHT_CHECKOUT") {
+                    childParams << booleanParam(name: param.key, value: LIGHT_WEIGHT_CHECKOUT.toBoolean())
+                } else if (param.key == "TIME_LIMIT") {
+                    childParams << string(name: param.key, value: TIME_LIMIT.toString())
+                } else if (param.key == "USE_TESTENV_PROPERTIES") {
+                    def useTestEnv = params.USE_TESTENV_PROPERTIES ? true : (buildConfig.USE_TESTENV_PROPERTIES != null ? buildConfig.USE_TESTENV_PROPERTIES.toBoolean() : false)
+                    childParams << booleanParam(name: param.key, value: useTestEnv)
+                } else {
+                    def value = param.value.toString()
+                    childParams << (value in ["true", "false"] ? booleanParam(name: param.key, value: value.toBoolean()) : string(name: param.key, value: value))
                 }
-                childParams << booleanParam(name: "DYNAMIC_COMPILE", value: DYNAMIC_COMPILE.toBoolean())
-                childParams << booleanParam(name: "GENERATE_JOBS", value: AUTO_AQA_GEN.toBoolean())
-                childParams << booleanParam(name: "KEEP_REPORTDIR", value: keep_reportdir.toBoolean())
-                childParams << string(name: "JDK_IMPL", value: jdk_impl)
-                childParams << string(name: "JDK_VERSION", value: jobJdkVersion)
-                childParams << string(name: "PLATFORM", value: PLATFORM)
-                childParams << string(name: "RERUN_ITERATIONS", value: rerunIterations.toString())
-                childParams << string(name: "TEST_FLAG", value: jobTestFlag)
-                childParams << string(name: "VENDOR_TEST_BRANCHES", value: VENDOR_TEST_BRANCHES)
-                childParams << string(name: "VENDOR_TEST_DIRS", value: VENDOR_TEST_DIRS)
-                childParams << string(name: "VENDOR_TEST_REPOS", value: VENDOR_TEST_REPOS)
-                
-                // Add build-specific parameters from config
-                // Support variable substitution for ${JDK_VERSION} in config values
-                if (buildConfig.JDK_REPO) {
-                    def jdkRepo = buildConfig.JDK_REPO.toString().replace('${JDK_VERSION}', jobJdkVersion)
-                    childParams << string(name: "JDK_REPO", value: jdkRepo)
-                }
-                if (buildConfig.JDK_BRANCH) {
-                    def jdkBranch = buildConfig.JDK_BRANCH.toString().replace('${JDK_VERSION}', jobJdkVersion)
-                    childParams << string(name: "JDK_BRANCH", value: jdkBranch)
-                }
-                if (buildConfig.OPENJ9_BRANCH) {
-                    childParams << string(name: "OPENJ9_BRANCH", value: buildConfig.OPENJ9_BRANCH)
-                }
-                if (testLabel) {
-                    childParams << string(name: "LABEL", value: testLabel)
-                }
-                if (additionalTestLabel) {
-                    childParams << string(name: "LABEL_ADDITION", value: additionalTestLabel)
-                }
-                if (buildConfig.ACTIVE_NODE_TIMEOUT) {
-                    childParams << string(name: "ACTIVE_NODE_TIMEOUT", value: buildConfig.ACTIVE_NODE_TIMEOUT.toString())
-                }
-                if (buildConfig.ADOPTOPENJDK_BRANCH) {
-                    childParams << string(name: "ADOPTOPENJDK_BRANCH", value: buildConfig.ADOPTOPENJDK_BRANCH)
-                }
-                if (buildConfig.RERUN_FAILURE != null) {
-                    childParams << booleanParam(name: "RERUN_FAILURE", value: buildConfig.RERUN_FAILURE.toBoolean())
-                }
-                if (buildList) {
-                    childParams << string(name: "BUILD_LIST", value: buildList)
-                }
-                
-                // Add any additional test params from config
-                if (buildConfig.ADDITIONAL_TEST_PARAMS && buildConfig.ADDITIONAL_TEST_PARAMS instanceof Map) {
-                    buildConfig.ADDITIONAL_TEST_PARAMS.each { key, value ->
-                        def valueStr = value.toString()
-                        if (valueStr == "true" || valueStr == "false") {
-                            childParams << booleanParam(name: key, value: valueStr.toBoolean())
-                        } else {
-                            childParams << string(name: key, value: valueStr)
-                        }
-                    }
-                }
-
-                int jobNum = JOBS.size() + 1
-                JOBS["${TEST_JOB_NAME}_${jobNum}"] = {
-                    def downstreamJob = build job: TEST_JOB_NAME, parameters: childParams, propagate: false, wait: true
-                    def downstreamJobResult = downstreamJob.getResult()
-                    echo "${TEST_JOB_NAME} result is ${downstreamJobResult}"
-                    def buildId = downstreamJob.getNumber()
-                    def childBuildUrl = "${env.JENKINS_URL}job/${TEST_JOB_NAME}/${buildId}"
-                    def badgeUrl = "${childBuildUrl}/badge/icon"
-                    currentBuild.description += """
-                        <p>${TEST_JOB_NAME}/${buildId}:
-                        <a href="${childBuildUrl}">
-                            <img src="${badgeUrl}" />
-                        </a>
-                        </p>
-                    """
-                    if (downstreamJobResult == 'SUCCESS' || downstreamJobResult == 'UNSTABLE') {
-                        echo "[NODE SHIFT] MOVING INTO CONTROLLER NODE..."
-                        node("worker || (ci.role.test&&hw.arch.x86&&sw.os.linux)") {
-                            cleanWs disableDeferredWipeout: true, deleteDirs: true
-                            try {
-                                timeout(time: 2, unit: 'HOURS') {
-                                    copyArtifacts(
-                                        projectName: TEST_JOB_NAME,
-                                        selector:specific("${downstreamJob.getNumber()}"),
-                                        filter: "**/${TEST_JOB_NAME}*.tap",
-                                        fingerprintArtifacts: true,
-                                        flatten: true
-                                    )
-                                }
-                            } catch (Exception e) {
-                                echo 'Exception: ' + e.toString()
-                                echo "Cannot run copyArtifacts from job ${TEST_JOB_NAME}. Skipping copyArtifacts..."
-                            }
-                            try {
-                                timeout(time: 1, unit: 'HOURS') {
-                                    archiveArtifacts artifacts: "*.tap", fingerprint: true
-                                }
-                            } catch (Exception e) {
-                                echo 'Exception: ' + e.toString()
-                                echo "Cannot archiveArtifacts from job ${TEST_JOB_NAME}. "
-                            }
-                        }
-                    }
-                    // Update build result to worst status
-                    updateBuildResult(downstreamJobResult)
-                }
-            } else {
-                println "Requested test job that does not exist or is disabled: ${TEST_JOB_NAME}. \n To generate the job, pelase set AUTO_AQA_GEN = true"
-                updateBuildResult("FAILURE")
             }
+            childParams << booleanParam(name: "DYNAMIC_COMPILE", value: DYNAMIC_COMPILE.toBoolean())
+            childParams << booleanParam(name: "GENERATE_JOBS",   value: AUTO_AQA_GEN.toBoolean())
+            childParams << booleanParam(name: "KEEP_REPORTDIR",  value: keep_reportdir.toBoolean())
+            childParams << string(name: "JDK_IMPL",              value: pv.jdk_impl)
+            childParams << string(name: "JDK_VERSION",           value: jobJdkVersion)
+            childParams << string(name: "PLATFORM",              value: PLATFORM)
+            childParams << string(name: "RERUN_ITERATIONS",      value: rerunIterations.toString())
+            childParams << string(name: "TEST_FLAG",             value: jobTestFlag)
+            childParams << string(name: "VENDOR_TEST_BRANCHES",  value: VENDOR_TEST_BRANCHES)
+            childParams << string(name: "VENDOR_TEST_DIRS",      value: VENDOR_TEST_DIRS)
+            childParams << string(name: "VENDOR_TEST_REPOS",     value: VENDOR_TEST_REPOS)
+            if (buildConfig.JDK_REPO) {
+                childParams << string(name: "JDK_REPO",   value: buildConfig.JDK_REPO.toString().replace('${JDK_VERSION}', jobJdkVersion))
+            }
+            if (buildConfig.JDK_BRANCH) {
+                childParams << string(name: "JDK_BRANCH", value: buildConfig.JDK_BRANCH.toString().replace('${JDK_VERSION}', jobJdkVersion))
+            }
+            if (buildConfig.OPENJ9_BRANCH)       childParams << string(name: "OPENJ9_BRANCH",       value: buildConfig.OPENJ9_BRANCH)
+            if (testLabel)                        childParams << string(name: "LABEL",               value: testLabel)
+            if (additionalTestLabel)              childParams << string(name: "LABEL_ADDITION",      value: additionalTestLabel)
+            if (buildConfig.ACTIVE_NODE_TIMEOUT)  childParams << string(name: "ACTIVE_NODE_TIMEOUT", value: buildConfig.ACTIVE_NODE_TIMEOUT.toString())
+            if (buildConfig.ADOPTOPENJDK_BRANCH)  childParams << string(name: "ADOPTOPENJDK_BRANCH", value: buildConfig.ADOPTOPENJDK_BRANCH)
+            if (buildConfig.RERUN_FAILURE != null) childParams << booleanParam(name: "RERUN_FAILURE", value: buildConfig.RERUN_FAILURE.toBoolean())
+            if (buildList)                        childParams << string(name: "BUILD_LIST",          value: buildList)
+            if (buildConfig.ADDITIONAL_TEST_PARAMS instanceof Map) {
+                buildConfig.ADDITIONAL_TEST_PARAMS.each { key, value ->
+                    def valueStr = value.toString()
+                    childParams << (valueStr in ["true", "false"] ? booleanParam(name: key, value: valueStr.toBoolean()) : string(name: key, value: valueStr))
+                }
+            }
+
+            triggerChildJob(TEST_JOB_NAME, childParams)
         }
     }
 }

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -20,7 +20,7 @@ def MODE = params.MODE ? params.MODE : "ENTRYPOINT"
 @Field Boolean LIGHT_WEIGHT_CHECKOUT
 
 SDK_RESOURCE = params.SDK_RESOURCE ? params.SDK_RESOURCE : "releases"
-TIME_LIMIT = params.TIME_LIMIT ? params.TIME_LIMIT : 10
+TIME_LIMIT = params.TIME_LIMIT ? params.TIME_LIMIT : 10 
 AUTO_AQA_GEN = params.AUTO_AQA_GEN ? params.AUTO_AQA_GEN.toBoolean() : false
 LIGHT_WEIGHT_CHECKOUT = params.LIGHT_WEIGHT_CHECKOUT != null ? params.LIGHT_WEIGHT_CHECKOUT.toBoolean() : true
 
@@ -375,7 +375,7 @@ def triggerChildJob(TEST_JOB_NAME, childParams) {
     }
 }
 
-// Scenario 3: params pass-through — used for manual/Grinder runs and private relay.
+// Params pass-through — used for manual/Grinder runs and private relay.
 // Pipeline params are authoritative. No JSON config is consulted.
 // All params are forwarded to the child job as-is; DEFAULTS are used only when a param is absent.
 def generateJobsFromParams(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets) {
@@ -417,6 +417,8 @@ def generateJobsFromParams(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets)
                     childParams << string(name: param.key, value: SDK_RESOURCE)
                 } else if (param.key == "CUSTOMIZED_SDK_URL") {
                     childParams << string(name: param.key, value: pv.download_url)
+                } else if (param.key == "TIME_LIMIT") {
+                    childParams << string(name: param.key, value: TIME_LIMIT.toString())
                 } else {
                     def value = param.value.toString()
                     childParams << (value in ["true", "false"] ? booleanParam(name: param.key, value: value.toBoolean()) : string(name: param.key, value: value))
@@ -443,7 +445,7 @@ def generateJobsFromParams(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets)
     }
 }
 
-// Scenario 1: config-driven — used for release/nightly/weekly builds.
+// Config-driven — used for release/nightly/weekly builds.
 // JSON buildConfig is authoritative. Pipeline params are not consulted for config values.
 def generateJobsWithConfig(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets, globalBuildConfig = [:], targetSpecificConfig = [:], platformSpecificConfig = [:], platformAdditionalTestLabels = [:], platformAdditionalTestParams = [:]) {
     if (jobTargets instanceof String) {
@@ -542,22 +544,11 @@ def generateJobsWithConfig(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets,
             echo "TEST_JOB_NAME: ${TEST_JOB_NAME}"
             echo "Applied buildConfig: ${buildConfig}"
 
-            // Resolve all effective values from buildConfig; DEFAULTS are last resort
-            def keep_reportdir  = buildConfig.KEEP_REPORTDIR  ? buildConfig.KEEP_REPORTDIR.toBoolean()  : false
-            def DYNAMIC_COMPILE = buildConfig.DYNAMIC_COMPILE ? buildConfig.DYNAMIC_COMPILE.toBoolean() : false
-            def VENDOR_TEST_REPOS    = params.VENDOR_TEST_REPOS    ?: (buildConfig.VENDOR_TEST_REPOS    ?: '')
-            def VENDOR_TEST_BRANCHES = params.VENDOR_TEST_BRANCHES ?: (buildConfig.VENDOR_TEST_BRANCHES ?: '')
-            def VENDOR_TEST_DIRS     = params.VENDOR_TEST_DIRS     ?: (buildConfig.VENDOR_TEST_DIRS     ?: '')
-            int rerunIterations = (params.RERUN_ITERATIONS ?: (buildConfig.RERUN_ITERATIONS ?: '0')).toString().toInteger()
-            def buildList           = buildConfig.BUILD_LIST      ?: ""
-            def testLabel           = buildConfig.LABEL           ?: ""
-            def additionalTestLabel = buildConfig.LABEL_ADDITION  ?: ""
-
             // Apply variant-specific logic for special cases not covered by config
             if (params.VARIANT == "openj9" || params.VARIANT == "ibm") {
                 if (TARGET.contains('functional') && !jobTestFlag.contains("FIPS")) {
                     if (params.ADOPTOPENJDK_REPO && params.ADOPTOPENJDK_REPO.contains("adoptium/aqa-tests")) {
-                        VENDOR_TEST_BRANCHES = params.ADOPTOPENJDK_BRANCH ?: 'master'
+                        buildConfig.VENDOR_TEST_BRANCHES = params.ADOPTOPENJDK_BRANCH ?: 'master'
                     }
                 }
             }
@@ -576,63 +567,42 @@ def generateJobsWithConfig(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets,
                 ], propagate: true
             }
 
-            // Assemble childParams — config is authoritative for all overridable values
+            // Build childParams by iterating buildConfig — skip non-param keys and nested maps,
+            // apply type coercion, then append computed/pipeline-sourced params that are not in config.
+            // Keys that need special handling are intercepted before the generic coercion.
+            def CONFIG_META_KEYS = ["ADDITIONAL_TEST_PARAMS"] as Set  // nested Maps handled separately below
             def childParams = []
-            params.each { param ->
-                if (param.key in ["PLATFORMS", "TARGETS", "TOP_LEVEL_SDK_URL", "AUTO_AQA_GEN",
-                                  "JDK_VERSIONS", "VARIANT", "PIPELINE_DISPLAY_NAME"]) {
-                    // do not pass to child jobs
-                } else if (param.key == "SDK_RESOURCE") {
-                    childParams << string(name: param.key, value: SDK_RESOURCE)
-                } else if (param.key == "CUSTOMIZED_SDK_URL") {
-                    childParams << string(name: param.key, value: pv.download_url)
-                } else if (param.key == "PARALLEL") {
-                    childParams << string(name: param.key, value: buildConfig.PARALLEL ?: PARALLEL)
-                } else if (param.key == "NUM_MACHINES") {
-                    childParams << string(name: param.key, value: buildConfig.NUM_MACHINES ?: params.NUM_MACHINES ?: "")
-                } else if (param.key == "LIGHT_WEIGHT_CHECKOUT") {
-                    childParams << booleanParam(name: param.key, value: LIGHT_WEIGHT_CHECKOUT.toBoolean())
-                } else if (param.key == "TIME_LIMIT") {
-                    childParams << string(name: param.key, value: TIME_LIMIT.toString())
+            buildConfig.each { key, value ->
+                if (value == null || value == "" || CONFIG_META_KEYS.contains(key)) return
+                if (key in ["JDK_REPO", "JDK_BRANCH"]) {
+                    // substitute ${JDK_VERSION} placeholder
+                    childParams << string(name: key, value: value.toString().replace('${JDK_VERSION}', jobJdkVersion))
+                } else if (value instanceof Boolean) {
+                    childParams << booleanParam(name: key, value: value)
                 } else {
-                    def value = param.value.toString()
-                    childParams << (value in ["true", "false"] ? booleanParam(name: param.key, value: value.toBoolean()) : string(name: param.key, value: value))
+                    childParams << string(name: key, value: value.toString())
                 }
             }
-            // buildConfig-driven values — always set explicitly (config is authoritative)
-            childParams << booleanParam(name: "DYNAMIC_COMPILE", value: DYNAMIC_COMPILE.toBoolean())
-            childParams << booleanParam(name: "KEEP_REPORTDIR",  value: keep_reportdir.toBoolean())
-            // Computed values — never pipeline params, always safe to set explicitly
-            childParams << booleanParam(name: "GENERATE_JOBS",   value: AUTO_AQA_GEN.toBoolean())
-            childParams << string(name: "JDK_IMPL",              value: pv.jdk_impl)
-            childParams << string(name: "JDK_VERSION",           value: jobJdkVersion)
-            childParams << string(name: "PLATFORM",              value: PLATFORM)
-            childParams << string(name: "TEST_FLAG",             value: jobTestFlag)
-            // only add if not already passed through the loop — avoids duplicates
-            if (!params.containsKey("USE_TESTENV_PROPERTIES")) childParams << booleanParam(name: "USE_TESTENV_PROPERTIES", value: buildConfig.USE_TESTENV_PROPERTIES != null ? buildConfig.USE_TESTENV_PROPERTIES.toBoolean() : false)
-            if (!params.containsKey("RERUN_ITERATIONS"))       childParams << string(name: "RERUN_ITERATIONS",             value: rerunIterations.toString())
-            if (!params.containsKey("VENDOR_TEST_BRANCHES"))   childParams << string(name: "VENDOR_TEST_BRANCHES",         value: VENDOR_TEST_BRANCHES)
-            if (!params.containsKey("VENDOR_TEST_DIRS"))       childParams << string(name: "VENDOR_TEST_DIRS",             value: VENDOR_TEST_DIRS)
-            if (!params.containsKey("VENDOR_TEST_REPOS"))      childParams << string(name: "VENDOR_TEST_REPOS",            value: VENDOR_TEST_REPOS)
-            if (buildConfig.JDK_REPO) {
-                childParams << string(name: "JDK_REPO",   value: buildConfig.JDK_REPO.toString().replace('${JDK_VERSION}', jobJdkVersion))
-            }
-            if (buildConfig.JDK_BRANCH) {
-                childParams << string(name: "JDK_BRANCH", value: buildConfig.JDK_BRANCH.toString().replace('${JDK_VERSION}', jobJdkVersion))
-            }
-            if (buildConfig.OPENJ9_BRANCH)       childParams << string(name: "OPENJ9_BRANCH",       value: buildConfig.OPENJ9_BRANCH)
-            if (testLabel)                        childParams << string(name: "LABEL",               value: testLabel)
-            if (additionalTestLabel)              childParams << string(name: "LABEL_ADDITION",      value: additionalTestLabel)
-            if (buildConfig.ACTIVE_NODE_TIMEOUT)  childParams << string(name: "ACTIVE_NODE_TIMEOUT", value: buildConfig.ACTIVE_NODE_TIMEOUT.toString())
-            if (buildConfig.ADOPTOPENJDK_BRANCH)  childParams << string(name: "ADOPTOPENJDK_BRANCH", value: buildConfig.ADOPTOPENJDK_BRANCH)
-            if (buildConfig.RERUN_FAILURE != null) childParams << booleanParam(name: "RERUN_FAILURE", value: buildConfig.RERUN_FAILURE.toBoolean())
-            if (buildList)                        childParams << string(name: "BUILD_LIST",          value: buildList)
+            // Flatten ADDITIONAL_TEST_PARAMS map entries as individual child params
             if (buildConfig.ADDITIONAL_TEST_PARAMS instanceof Map) {
                 buildConfig.ADDITIONAL_TEST_PARAMS.each { key, value ->
-                    def valueStr = value.toString()
-                    childParams << (valueStr in ["true", "false"] ? booleanParam(name: key, value: valueStr.toBoolean()) : string(name: key, value: valueStr))
+                    if (value != null && value != "") {
+                        def valueStr = value.toString()
+                        childParams << (valueStr in ["true", "false"] ? booleanParam(name: key, value: valueStr.toBoolean()) : string(name: key, value: valueStr))
+                    }
                 }
             }
+            // Params not present in buildConfig — computed or sourced from pipeline globals
+            childParams << string(name: "SDK_RESOURCE",                value: SDK_RESOURCE)
+            childParams << string(name: "CUSTOMIZED_SDK_URL",          value: pv.download_url)
+            childParams << booleanParam(name: "LIGHT_WEIGHT_CHECKOUT", value: LIGHT_WEIGHT_CHECKOUT.toBoolean())
+            childParams << string(name: "JDK_VERSION",                 value: jobJdkVersion)
+            childParams << string(name: "JDK_IMPL",                    value: pv.jdk_impl)
+            childParams << string(name: "PLATFORM",                    value: PLATFORM)
+            childParams << string(name: "TEST_FLAG",                   value: jobTestFlag)
+            childParams << booleanParam(name: "GENERATE_JOBS",         value: AUTO_AQA_GEN.toBoolean())
+            childParams << string(name: "ADOPTOPENJDK_REPO",   value: params.ADOPTOPENJDK_REPO   ?: "https://github.com/adoptium/aqa-tests.git")
+            childParams << string(name: "ADOPTOPENJDK_BRANCH", value: params.ADOPTOPENJDK_BRANCH ?: "master")
 
             triggerChildJob(TEST_JOB_NAME, childParams)
         }

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -310,15 +310,14 @@ def resolvePlatformVars(PLATFORM) {
     else if (params.VARIANT == "ibm")    { jdk_impl = params.VARIANT }
     else if (params.VARIANT == "temurin"){ short_name = "hs" }
 
-    def download_url      = params.CUSTOMIZED_SDK_URL ?: ""
-    def sdk_resource_value = SDK_RESOURCE
+    def download_url = params.CUSTOMIZED_SDK_URL ?: ""
     if (SDK_RESOURCE == "customized" && params.TOP_LEVEL_SDK_URL) {
         def url = params.TOP_LEVEL_SDK_URL.endsWith("/") ? params.TOP_LEVEL_SDK_URL : "${params.TOP_LEVEL_SDK_URL}/"
         download_url = "${url}artifact/target/${os}/${arch}/${params.VARIANT}/${filter}/*zip*/${params.VARIANT}.zip"
     }
     echo "download_url: ${download_url}"
     return [os: os, arch: arch, filter: filter, short_name: short_name, jdk_impl: jdk_impl,
-            download_url: download_url, sdk_resource_value: sdk_resource_value]
+            download_url: download_url]
 }
 
 // Fire the downstream job and collect TAP artifacts
@@ -371,7 +370,7 @@ def triggerChildJob(TEST_JOB_NAME, childParams) {
             updateBuildResult(downstreamJobResult)
         }
     } else {
-        println "Requested test job that does not exist or is disabled: ${TEST_JOB_NAME}. \n To generate the job, pelase set AUTO_AQA_GEN = true"
+        println "Requested test job that does not exist or is disabled: ${TEST_JOB_NAME}. \n To generate the job, please set AUTO_AQA_GEN = true"
         updateBuildResult("FAILURE")
     }
 }
@@ -381,10 +380,9 @@ def triggerChildJob(TEST_JOB_NAME, childParams) {
 // All params are forwarded to the child job as-is; DEFAULTS are used only when a param is absent.
 def generateJobsFromParams(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets) {
     def DEFAULTS = [
-        PARALLEL               : "Dynamic",
-        NUM_MACHINES           : "",
         DYNAMIC_COMPILE        : false,
         KEEP_REPORTDIR         : false,
+        RERUN_FAILURE          : false,
         RERUN_ITERATIONS       : "0",
         USE_TESTENV_PROPERTIES : false,
     ]
@@ -416,36 +414,29 @@ def generateJobsFromParams(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets)
                                   "JDK_VERSIONS", "VARIANT", "PIPELINE_DISPLAY_NAME"]) {
                     // do not pass to child jobs
                 } else if (param.key == "SDK_RESOURCE") {
-                    childParams << string(name: param.key, value: pv.sdk_resource_value)
+                    childParams << string(name: param.key, value: SDK_RESOURCE)
                 } else if (param.key == "CUSTOMIZED_SDK_URL") {
                     childParams << string(name: param.key, value: pv.download_url)
-                } else if (param.key == "PARALLEL") {
-                    childParams << string(name: param.key, value: params.PARALLEL ?: DEFAULTS.PARALLEL)
-                } else if (param.key == "NUM_MACHINES") {
-                    childParams << string(name: param.key, value: params.NUM_MACHINES ?: DEFAULTS.NUM_MACHINES)
-                } else if (param.key == "LIGHT_WEIGHT_CHECKOUT") {
-                    childParams << booleanParam(name: param.key, value: LIGHT_WEIGHT_CHECKOUT.toBoolean())
-                } else if (param.key == "TIME_LIMIT") {
-                    childParams << string(name: param.key, value: TIME_LIMIT.toString())
-                } else if (param.key == "USE_TESTENV_PROPERTIES") {
-                    childParams << booleanParam(name: param.key, value: params.USE_TESTENV_PROPERTIES ? params.USE_TESTENV_PROPERTIES.toBoolean() : DEFAULTS.USE_TESTENV_PROPERTIES)
                 } else {
                     def value = param.value.toString()
                     childParams << (value in ["true", "false"] ? booleanParam(name: param.key, value: value.toBoolean()) : string(name: param.key, value: value))
                 }
             }
-            // Always-present params not covered by the params.each loop
-            childParams << booleanParam(name: "DYNAMIC_COMPILE",  value: (params.DYNAMIC_COMPILE  ?: DEFAULTS.DYNAMIC_COMPILE).toBoolean())
-            childParams << booleanParam(name: "KEEP_REPORTDIR",   value: (params.KEEP_REPORTDIR   ?: DEFAULTS.KEEP_REPORTDIR).toBoolean())
-            childParams << booleanParam(name: "GENERATE_JOBS",    value: AUTO_AQA_GEN.toBoolean())
-            childParams << string(name: "JDK_IMPL",               value: pv.jdk_impl)
-            childParams << string(name: "JDK_VERSION",            value: jobJdkVersion)
-            childParams << string(name: "PLATFORM",               value: PLATFORM)
-            childParams << string(name: "RERUN_ITERATIONS",       value: (params.RERUN_ITERATIONS ?: DEFAULTS.RERUN_ITERATIONS).toString())
-            childParams << string(name: "TEST_FLAG",              value: jobTestFlag)
-            childParams << string(name: "VENDOR_TEST_BRANCHES",   value: params.VENDOR_TEST_BRANCHES ?: '')
-            childParams << string(name: "VENDOR_TEST_DIRS",       value: params.VENDOR_TEST_DIRS     ?: '')
-            childParams << string(name: "VENDOR_TEST_REPOS",      value: params.VENDOR_TEST_REPOS    ?: '')
+            // Add params that may not be defined on the private Jenkins job — ensure child always receives them
+            if (!params.containsKey("DYNAMIC_COMPILE"))        childParams << booleanParam(name: "DYNAMIC_COMPILE",        value: DEFAULTS.DYNAMIC_COMPILE)
+            if (!params.containsKey("KEEP_REPORTDIR"))         childParams << booleanParam(name: "KEEP_REPORTDIR",         value: DEFAULTS.KEEP_REPORTDIR)
+            if (!params.containsKey("RERUN_FAILURE"))          childParams << booleanParam(name: "RERUN_FAILURE",          value: DEFAULTS.RERUN_FAILURE)
+            if (!params.containsKey("USE_TESTENV_PROPERTIES")) childParams << booleanParam(name: "USE_TESTENV_PROPERTIES", value: DEFAULTS.USE_TESTENV_PROPERTIES)
+            if (!params.containsKey("RERUN_ITERATIONS"))       childParams << string(name: "RERUN_ITERATIONS",             value: DEFAULTS.RERUN_ITERATIONS)
+            if (!params.containsKey("VENDOR_TEST_BRANCHES"))   childParams << string(name: "VENDOR_TEST_BRANCHES",         value: '')
+            if (!params.containsKey("VENDOR_TEST_DIRS"))       childParams << string(name: "VENDOR_TEST_DIRS",             value: '')
+            if (!params.containsKey("VENDOR_TEST_REPOS"))      childParams << string(name: "VENDOR_TEST_REPOS",            value: '')
+            // Always override — computed values that are never pipeline params
+            childParams << booleanParam(name: "GENERATE_JOBS", value: AUTO_AQA_GEN.toBoolean())
+            childParams << string(name: "JDK_IMPL",            value: pv.jdk_impl)
+            childParams << string(name: "JDK_VERSION",         value: jobJdkVersion)
+            childParams << string(name: "PLATFORM",            value: PLATFORM)
+            childParams << string(name: "TEST_FLAG",           value: jobTestFlag)
 
             triggerChildJob(TEST_JOB_NAME, childParams)
         }
@@ -592,36 +583,37 @@ def generateJobsWithConfig(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets,
                                   "JDK_VERSIONS", "VARIANT", "PIPELINE_DISPLAY_NAME"]) {
                     // do not pass to child jobs
                 } else if (param.key == "SDK_RESOURCE") {
-                    childParams << string(name: param.key, value: pv.sdk_resource_value)
+                    childParams << string(name: param.key, value: SDK_RESOURCE)
                 } else if (param.key == "CUSTOMIZED_SDK_URL") {
                     childParams << string(name: param.key, value: pv.download_url)
                 } else if (param.key == "PARALLEL") {
-                    childParams << string(name: param.key, value: buildConfig.PARALLEL ?: "Dynamic")
+                    childParams << string(name: param.key, value: buildConfig.PARALLEL ?: PARALLEL)
                 } else if (param.key == "NUM_MACHINES") {
-                    childParams << string(name: param.key, value: buildConfig.NUM_MACHINES ?: "")
+                    childParams << string(name: param.key, value: buildConfig.NUM_MACHINES ?: params.NUM_MACHINES ?: "")
                 } else if (param.key == "LIGHT_WEIGHT_CHECKOUT") {
                     childParams << booleanParam(name: param.key, value: LIGHT_WEIGHT_CHECKOUT.toBoolean())
                 } else if (param.key == "TIME_LIMIT") {
                     childParams << string(name: param.key, value: TIME_LIMIT.toString())
-                } else if (param.key == "USE_TESTENV_PROPERTIES") {
-                    def useTestEnv = params.USE_TESTENV_PROPERTIES ? true : (buildConfig.USE_TESTENV_PROPERTIES != null ? buildConfig.USE_TESTENV_PROPERTIES.toBoolean() : false)
-                    childParams << booleanParam(name: param.key, value: useTestEnv)
                 } else {
                     def value = param.value.toString()
                     childParams << (value in ["true", "false"] ? booleanParam(name: param.key, value: value.toBoolean()) : string(name: param.key, value: value))
                 }
             }
+            // buildConfig-driven values — always set explicitly (config is authoritative)
             childParams << booleanParam(name: "DYNAMIC_COMPILE", value: DYNAMIC_COMPILE.toBoolean())
-            childParams << booleanParam(name: "GENERATE_JOBS",   value: AUTO_AQA_GEN.toBoolean())
             childParams << booleanParam(name: "KEEP_REPORTDIR",  value: keep_reportdir.toBoolean())
+            // Computed values — never pipeline params, always safe to set explicitly
+            childParams << booleanParam(name: "GENERATE_JOBS",   value: AUTO_AQA_GEN.toBoolean())
             childParams << string(name: "JDK_IMPL",              value: pv.jdk_impl)
             childParams << string(name: "JDK_VERSION",           value: jobJdkVersion)
             childParams << string(name: "PLATFORM",              value: PLATFORM)
-            childParams << string(name: "RERUN_ITERATIONS",      value: rerunIterations.toString())
             childParams << string(name: "TEST_FLAG",             value: jobTestFlag)
-            childParams << string(name: "VENDOR_TEST_BRANCHES",  value: VENDOR_TEST_BRANCHES)
-            childParams << string(name: "VENDOR_TEST_DIRS",      value: VENDOR_TEST_DIRS)
-            childParams << string(name: "VENDOR_TEST_REPOS",     value: VENDOR_TEST_REPOS)
+            // only add if not already passed through the loop — avoids duplicates
+            if (!params.containsKey("USE_TESTENV_PROPERTIES")) childParams << booleanParam(name: "USE_TESTENV_PROPERTIES", value: buildConfig.USE_TESTENV_PROPERTIES != null ? buildConfig.USE_TESTENV_PROPERTIES.toBoolean() : false)
+            if (!params.containsKey("RERUN_ITERATIONS"))       childParams << string(name: "RERUN_ITERATIONS",             value: rerunIterations.toString())
+            if (!params.containsKey("VENDOR_TEST_BRANCHES"))   childParams << string(name: "VENDOR_TEST_BRANCHES",         value: VENDOR_TEST_BRANCHES)
+            if (!params.containsKey("VENDOR_TEST_DIRS"))       childParams << string(name: "VENDOR_TEST_DIRS",             value: VENDOR_TEST_DIRS)
+            if (!params.containsKey("VENDOR_TEST_REPOS"))      childParams << string(name: "VENDOR_TEST_REPOS",            value: VENDOR_TEST_REPOS)
             if (buildConfig.JDK_REPO) {
                 childParams << string(name: "JDK_REPO",   value: buildConfig.JDK_REPO.toString().replace('${JDK_VERSION}', jobJdkVersion))
             }
@@ -759,7 +751,7 @@ def remoteTriggerTemurinJCK (jobJdkVersion, jobPlatforms) {
                 def rerunFailure = config.RERUN_FAILURE ? "true" : "false"
                 // SETUP_JCK_RUN is true for release builds
                 def setupJckRun = isReleaseBuild ? "true" : (config.SETUP_JCK_RUN ? "true" : "false")
-                def autoAqaGen = config.AUTO_AQA_GEN ? "true" : "false"
+                def autoAqaGen = AUTO_AQA_GEN ? "true" : "false"
                 
                 // Build display name
                 def displayName = params.PIPELINE_DISPLAY_NAME ?: "${params.BUILD_TYPE} : jdk${jobJdkVersion} : ${platform} : ${target}"

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -603,6 +603,11 @@ def generateJobsWithConfig(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets,
             childParams << booleanParam(name: "GENERATE_JOBS",         value: AUTO_AQA_GEN.toBoolean())
             childParams << string(name: "ADOPTOPENJDK_REPO",   value: params.ADOPTOPENJDK_REPO   ?: "https://github.com/adoptium/aqa-tests.git")
             childParams << string(name: "ADOPTOPENJDK_BRANCH", value: params.ADOPTOPENJDK_BRANCH ?: "master")
+            // Credential IDs — only present on some Jenkins instances; pass through only when non-empty
+            ["DOCKER_REGISTRY_URL_CREDENTIAL_ID", "BASE_DOCKER_REGISTRY_CREDENTIAL_ID",
+             "SSH_AGENT_CREDENTIAL", "USER_CREDENTIALS_ID", "CUSTOMIZED_SDK_URL_CREDENTIAL_ID", "DOCKER_REGISTRY_URL", "TRSS_URL"].each { credKey ->
+                if (params[credKey]) childParams << string(name: credKey, value: params[credKey])
+            }
 
             triggerChildJob(TEST_JOB_NAME, childParams)
         }

--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -377,16 +377,8 @@ def triggerChildJob(TEST_JOB_NAME, childParams) {
 
 // Params pass-through — used for manual/Grinder runs and private relay.
 // Pipeline params are authoritative. No JSON config is consulted.
-// All params are forwarded to the child job as-is; DEFAULTS are used only when a param is absent.
+// All params are forwarded to the child job as-is; empty params are skipped.
 def generateJobsFromParams(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets) {
-    def DEFAULTS = [
-        DYNAMIC_COMPILE        : false,
-        KEEP_REPORTDIR         : false,
-        RERUN_FAILURE          : false,
-        RERUN_ITERATIONS       : "0",
-        USE_TESTENV_PROPERTIES : false,
-    ]
-
     if (jobTargets instanceof String) {
         jobTargets = jobTargets.replace("defaultFipsTestTargets", "${defaultFipsTestTargets}")
         jobTargets = jobTargets.replace("defaultFips140_2TestTargets", "${defaultFips140_2TestTargets}")
@@ -407,7 +399,7 @@ def generateJobsFromParams(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets)
                 : "Test_openjdk${jobJdkVersion}_${pv.short_name}_${TARGET}_${PLATFORM}${buildTestFlagSuffix(jobTestFlag)}"
             echo "TEST_JOB_NAME: ${TEST_JOB_NAME}"
 
-            // Build childParams purely from pipeline params — params win, DEFAULTS are last resort
+            // Build childParams purely from pipeline params — empty params are skipped
             def childParams = []
             params.each { param ->
                 if (param.key in ["PLATFORMS", "TARGETS", "TOP_LEVEL_SDK_URL", "AUTO_AQA_GEN",
@@ -421,23 +413,16 @@ def generateJobsFromParams(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets)
                     childParams << string(name: param.key, value: TIME_LIMIT.toString())
                 } else {
                     def value = param.value.toString()
+                    if (value == "") return  // skip empty params — child job uses its own default
                     childParams << (value in ["true", "false"] ? booleanParam(name: param.key, value: value.toBoolean()) : string(name: param.key, value: value))
                 }
             }
-            // Add params that may not be defined on the private Jenkins job — ensure child always receives them
-            if (!params.containsKey("DYNAMIC_COMPILE"))        childParams << booleanParam(name: "DYNAMIC_COMPILE",        value: DEFAULTS.DYNAMIC_COMPILE)
-            if (!params.containsKey("KEEP_REPORTDIR"))         childParams << booleanParam(name: "KEEP_REPORTDIR",         value: DEFAULTS.KEEP_REPORTDIR)
-            if (!params.containsKey("RERUN_FAILURE"))          childParams << booleanParam(name: "RERUN_FAILURE",          value: DEFAULTS.RERUN_FAILURE)
-            if (!params.containsKey("USE_TESTENV_PROPERTIES")) childParams << booleanParam(name: "USE_TESTENV_PROPERTIES", value: DEFAULTS.USE_TESTENV_PROPERTIES)
-            if (!params.containsKey("RERUN_ITERATIONS"))       childParams << string(name: "RERUN_ITERATIONS",             value: DEFAULTS.RERUN_ITERATIONS)
-            if (!params.containsKey("VENDOR_TEST_BRANCHES"))   childParams << string(name: "VENDOR_TEST_BRANCHES",         value: '')
-            if (!params.containsKey("VENDOR_TEST_DIRS"))       childParams << string(name: "VENDOR_TEST_DIRS",             value: '')
-            if (!params.containsKey("VENDOR_TEST_REPOS"))      childParams << string(name: "VENDOR_TEST_REPOS",            value: '')
             // Always override — computed values that are never pipeline params
             childParams << booleanParam(name: "GENERATE_JOBS", value: AUTO_AQA_GEN.toBoolean())
             childParams << string(name: "JDK_IMPL",            value: pv.jdk_impl)
             childParams << string(name: "JDK_VERSION",         value: jobJdkVersion)
             childParams << string(name: "PLATFORM",            value: PLATFORM)
+            childParams << string(name: "TARGET",            value: TARGET)
             childParams << string(name: "TEST_FLAG",           value: jobTestFlag)
 
             triggerChildJob(TEST_JOB_NAME, childParams)
@@ -599,6 +584,7 @@ def generateJobsWithConfig(jobJdkVersion, jobTestFlag, jobPlatforms, jobTargets,
             childParams << string(name: "JDK_VERSION",                 value: jobJdkVersion)
             childParams << string(name: "JDK_IMPL",                    value: pv.jdk_impl)
             childParams << string(name: "PLATFORM",                    value: PLATFORM)
+            childParams << string(name: "TARGET",                      value: TARGET)
             childParams << string(name: "TEST_FLAG",                   value: jobTestFlag)
             childParams << booleanParam(name: "GENERATE_JOBS",         value: AUTO_AQA_GEN.toBoolean())
             childParams << string(name: "ADOPTOPENJDK_REPO",   value: params.ADOPTOPENJDK_REPO   ?: "https://github.com/adoptium/aqa-tests.git")

--- a/buildenv/jenkins/config/dragonwell/default.json
+++ b/buildenv/jenkins/config/dragonwell/default.json
@@ -21,7 +21,6 @@
             "RERUN_ITERATIONS": "1",
             "BUILD_LIST": "",
             "TIME_LIMIT": "10",
-            "GENERATE_JOBS": false,
             "ADDITIONAL_TEST_PARAMS": {}
         },
         "TARGET_SPECIFIC_CONFIG": {

--- a/buildenv/jenkins/config/temurin/default.json
+++ b/buildenv/jenkins/config/temurin/default.json
@@ -19,7 +19,6 @@
             "RERUN_ITERATIONS": "1",
             "BUILD_LIST": "",
             "TIME_LIMIT": "25",
-            "GENERATE_JOBS": false,
             "ADDITIONAL_TEST_PARAMS": {}
         },
         "TARGET_SPECIFIC_CONFIG": {

--- a/buildenv/jenkins/config/temurin/jck/default.json
+++ b/buildenv/jenkins/config/temurin/jck/default.json
@@ -7,7 +7,6 @@
             "RERUN_ITERATIONS": "1",
             "RERUN_FAILURE": true,
             "KEEP_REPORTDIR": true,
-            "AUTO_AQA_GEN": false,
             "SETUP_JCK_RUN": false
         },
         "PLATFORM_TARGETS": [

--- a/buildenv/jenkins/config/temurin/weekly/default.json
+++ b/buildenv/jenkins/config/temurin/weekly/default.json
@@ -3,9 +3,6 @@
         "TEST_FLAG": "NONE",
         "COMMENT": "Level 2: Weekly build configuration for JDK 25+ (including JDK 26, 27, etc.). Merged with Level 1 (config/temurin/default.json). For JDK 21 and earlier, see jdk21.json",
         "DEFAULT_TEST_TARGETS": "sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,special.openjdk,extended.perf,dev.functional",
-        "GLOBAL_BUILD_CONFIG": {
-            "GENERATE_JOBS": true
-        },
         "PLATFORM_ADDITIONAL_TEST_PARAMS": {
             "ppc64_aix": {
                 "TIME_LIMIT": "30"

--- a/buildenv/jenkins/config/temurin/weekly/jdk11.json
+++ b/buildenv/jenkins/config/temurin/weekly/jdk11.json
@@ -3,9 +3,6 @@
         "TEST_FLAG": "NONE",
         "COMMENT": "JDK 8-21 configuration - only differences from base. Uses sw.os.aix.7_2 (not 7_2TL5)",
         "DEFAULT_TEST_TARGETS": "sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,extended.perf,special.openjdk,dev.functional",
-        "GLOBAL_BUILD_CONFIG": {
-            "GENERATE_JOBS": true
-        },
         "PLATFORM_TARGETS": [
             { "aarch64_linux": "defaultTestTargets" },
             { "aarch64_mac": "defaultTestTargets" },

--- a/buildenv/jenkins/config/temurin/weekly/jdk17.json
+++ b/buildenv/jenkins/config/temurin/weekly/jdk17.json
@@ -3,9 +3,6 @@
         "TEST_FLAG": "NONE",
         "COMMENT": "JDK 8-21 configuration - only differences from base. Uses sw.os.aix.7_2 (not 7_2TL5)",
         "DEFAULT_TEST_TARGETS": "sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,extended.perf,special.openjdk,dev.functional",
-        "GLOBAL_BUILD_CONFIG": {
-            "GENERATE_JOBS": true
-        },
         "PLATFORM_TARGETS": [
             { "aarch64_linux": "defaultTestTargets" },
             { "aarch64_mac": "defaultTestTargets" },

--- a/buildenv/jenkins/config/temurin/weekly/jdk21.json
+++ b/buildenv/jenkins/config/temurin/weekly/jdk21.json
@@ -3,9 +3,6 @@
         "TEST_FLAG": "NONE",
         "COMMENT": "JDK 8-21 shared configuration - uses sw.os.aix.7_2 (not 7_2TL5) and has more platforms",
         "DEFAULT_TEST_TARGETS": "sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,extended.perf,special.openjdk,dev.functional",
-        "GLOBAL_BUILD_CONFIG": {
-            "GENERATE_JOBS": true
-        },
         "PLATFORM_TARGETS": [
             { "aarch64_linux": "defaultTestTargets,special.system" },
             { "aarch64_mac": "defaultTestTargets,dev.system,special.system" },

--- a/buildenv/jenkins/config/temurin/weekly/jdk8.json
+++ b/buildenv/jenkins/config/temurin/weekly/jdk8.json
@@ -3,9 +3,6 @@
         "TEST_FLAG": "NONE",
         "COMMENT": "JDK 8-21 configuration - only differences from base. Uses sw.os.aix.7_2 (not 7_2TL5). arm_linux uses custom aarch32-jdk8u repo.",
         "DEFAULT_TEST_TARGETS": "sanity.functional,extended.functional,special.functional,sanity.openjdk,extended.openjdk,sanity.system,extended.system,sanity.perf,extended.perf,special.openjdk,dev.functional",
-        "GLOBAL_BUILD_CONFIG": {
-            "GENERATE_JOBS": true
-        },
         "PLATFORM_TARGETS": [
             { "aarch64_linux": "defaultTestTargets" },
             { "arm_linux": "defaultTestTargets" },


### PR DESCRIPTION

Close #7535 

AqaTestPipeline triggers donwstream test jobs either by predefined configuration parameters or parameters forwarded from pipeline job itself. However several parameters (PARALLEL, NUM_MACHINES,KEEP_REPORTDIR, DYNAMIC_COMPILE) read from buildConfig only and silently discarded the incoming pipeline params, which arehardcoded as special cases. This is hard to reason about and error-prone.

Refactor generateJobs() into three focused functions:
- generateJobsWithConfig(): JSON buildConfig is authoritative for all config values  
- generateJobsFromParams():  manual/Grinder/noconfigurations,pipeline params are authoritative, hard-coded DEFAULTS as last resort  
- triggerChildJob(): shared lower half — fires the downstream job and  collects TAP artifacts
 
Extract two additional shared helpers:
- buildTestFlagSuffix(): computes job name suffix from test flag string
- resolvePlatformVars(): derives os, arch, jdk_impl, download_url from platform string
  
Each function now has a single clear source of truth for parameter values, eliminating the mixed buildConfig/?:/params fallback chains that made the previous code error-prone and hard to reason about.


Assisted by IBM Bob