### PR TITLE
(v1.0.15) Re-enable java/lang/IO/IO on OpenJ9 for JDK27+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -72,7 +72,6 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java https://github.com/
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
-java/lang/IO/IO.java https://github.com/eclipse-openj9/openj9/issues/23292 generic-all
 java/lang/LazyConstant/LazyConstantClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/LazyConstant/ThrowablesClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all

--- a/openjdk/excludes/ProblemList_openjdk28-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk28-openj9.txt
@@ -72,7 +72,6 @@ java/lang/invoke/VarHandles/VarHandleTestByteArrayAsInt.java https://github.com/
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsLong.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestByteArrayAsShort.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
 java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java https://github.com/eclipse-openj9/openj9/issues/13368 generic-all
-java/lang/IO/IO.java https://github.com/eclipse-openj9/openj9/issues/23292 generic-all
 java/lang/LazyConstant/LazyConstantClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/LazyConstant/ThrowablesClassUnloading.java https://github.com/eclipse-openj9/openj9/issues/18049 generic-all
 java/lang/ModuleLayer/BasicLayerTest.java https://github.com/eclipse-openj9/openj9/issues/6462 generic-all


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/issues/23292 has been fixed by:
- https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1250
- https://github.com/ibmruntimes/openj9-openjdk-jdk27/pull/25

Backport of https://github.com/adoptium/aqa-tests/pull/7615