### PR TITLE
(v1.0.15) Re-enable TestCaptureCallState on OpenJ9 for JDK27+

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk27-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk27-openj9.txt
@@ -543,7 +543,6 @@ vm/verifier/VerifyProtectedConstructor.java https://github.com/eclipse-openj9/op
 
 # jdk_foreign
 
-java/foreign/capturecallstate/TestCaptureCallState.java https://github.com/eclipse-openj9/openj9/issues/24463 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all

--- a/openjdk/excludes/ProblemList_openjdk28-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk28-openj9.txt
@@ -543,7 +543,6 @@ vm/verifier/VerifyProtectedConstructor.java https://github.com/eclipse-openj9/op
 
 # jdk_foreign
 
-java/foreign/capturecallstate/TestCaptureCallState.java https://github.com/eclipse-openj9/openj9/issues/24463 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#default_gc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#shenandoah https://github.com/eclipse-openj9/openj9/issues/13993 generic-all
 java/foreign/stackwalk/TestAsyncStackWalk.java#zgc https://github.com/eclipse-openj9/openj9/issues/13993 generic-all


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/issues/24463 has been fixed by
- https://github.com/eclipse-openj9/openj9/pull/24585
- https://github.com/eclipse-openj9/openj9/pull/24602

Backport of https://github.com/adoptium/aqa-tests/pull/7618

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>