### PR TITLE
Update section to remove BigClassTreeClassLoader.java and PreLoadCircularityTest.java

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -81,9 +81,7 @@ valhalla/valuetypes/Reflection.java https://github.com/eclipse-openj9/openj9/iss
 # Tests to revisit after JEP 401 is finalized.
 
 ############################################################################
-runtime/valhalla/inlinetypes/classloading/BigClassTreeClassLoader.java https://github.com/eclipse-openj9/openj9/issues/24005 generic-all
 runtime/valhalla/inlinetypes/classloading/ConcurrentClassLoadingTest.java https://github.com/eclipse-openj9/openj9/issues/24005 generic-all
-runtime/valhalla/inlinetypes/classloading/PreLoadCircularityTest.java https://github.com/eclipse-openj9/openj9/issues/24005 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Fixed and removed BigClassTreeClassLoader.java and PreLoadCircularityTest.java from the problem list.