### PR TITLE
Re-enable StrictInstanceFieldsTest for OpenJ9 JDK28

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk28-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk28-openj9.txt
@@ -645,7 +645,5 @@ jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj
 
 # valhalla
 
-runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java https://github.com/eclipse-openj9/openj9/issues/24512 generic-all
-
 ############################################################################
 


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/issues/24520

fyi @hangshao0 