### PR TITLE
Enable passing JFR tests on J9

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk17-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk17-openj9.txt
@@ -874,13 +874,10 @@ jdk/jfr/jmx/TestFlightRecorderMXBeanLeak.java https://github.com/eclipse-openj9/
 jdk/jfr/jmx/TestStream.java https://github.com/eclipse-openj9/openj9/issues/24311 generic-all
 jdk/jfr/jmx/TestStreamMultiple.java https://github.com/eclipse-openj9/openj9/issues/24311 generic-all
 jdk/jfr/jvm/TestClearStaleConstants.java https://github.com/eclipse-openj9/openj9/issues/24316 generic-all
-jdk/jfr/jvm/TestCreateNative.java https://github.com/eclipse-openj9/openj9/issues/24325 generic-all
 jdk/jfr/jvm/TestDumpOnCrash.java https://github.com/eclipse-openj9/openj9/issues/24325 generic-all
 jdk/jfr/jvm/TestEventWriterLog.java https://github.com/eclipse-openj9/openj9/issues/24325 generic-all
 jdk/jfr/jvm/TestFatEvent.java https://github.com/eclipse-openj9/openj9/issues/24331 generic-all
-jdk/jfr/jvm/TestGetAllEventClasses.java https://github.com/eclipse-openj9/openj9/issues/24311 generic-all
 jdk/jfr/jvm/TestGetEventWriter.java https://github.com/eclipse-openj9/openj9/issues/24331 generic-all
-jdk/jfr/jvm/TestGetStackTraceId.java https://github.com/eclipse-openj9/openj9/issues/24317 generic-all
 jdk/jfr/jvm/TestJFRIntrinsic.java https://github.com/eclipse-openj9/openj9/issues/24325 generic-all
 jdk/jfr/jvm/TestLargeJavaEvent512k.java https://github.com/eclipse-openj9/openj9/issues/24318 generic-all
 jdk/jfr/jvm/TestLargeJavaEvent64k.java https://github.com/eclipse-openj9/openj9/issues/24318 generic-all


### PR DESCRIPTION
The following tests now pass regularly:
- TestCreateNative
- TestGetAllEventClasses
- TestGetStackTraceId