### PR TITLE
Fix DateFormatTest DST mismatch: use calendar.getTime() instead of ne…

### DIFF
--- a/functional/MBCS_Tests/i18n/src/DateFormatTest.java
+++ b/functional/MBCS_Tests/i18n/src/DateFormatTest.java
@@ -262,9 +262,9 @@ public class DateFormatTest {
 		{
 			TimeZone tz = calendar.getTimeZone();
 			if (followingCount >= 3) {
-				buffer.append(tz.getDisplayName(tz.inDaylightTime(new Date()), TimeZone.LONG));
+				buffer.append(tz.getDisplayName(tz.inDaylightTime(calendar.getTime()), TimeZone.LONG));
 			}else{
-				buffer.append(tz.getDisplayName(tz.inDaylightTime(new Date()), TimeZone.SHORT));
+				buffer.append(tz.getDisplayName(tz.inDaylightTime(calendar.getTime()), TimeZone.SHORT));
 			}
 			break;
 		}


### PR DESCRIPTION
DateFormatTest.parse() was calling tz.inDaylightTime(new Date()) to determine whether to fetch the DST or standard timezone display name. This uses the current wall-clock instant rather than the instant being formatted (calendar.getTime()).

When the default JVM timezone observes DST and the current wall-clock time is in a different DST state than the calendar's time, the timezone display name diverges from what DateFormat.format() produces, causing checkParse() to fail.

Fix: pass calendar.getTime() so the DST flag matches the instant the formatter is formatting, consistent with DateFormat behaviour.

Fixes MBCS_Tests_i18n_zh_TW_linux_0 DateFormatTest failure on JDK27.