### PR TITLE
Set AQA_AUTO_GEN as passing in job parameter instead of configuration parameters for remote AQA_TEST_PIPELINE

### DIFF
--- a/buildenv/jenkins/aqaTestPipeline.groovy
+++ b/buildenv/jenkins/aqaTestPipeline.groovy
@@ -791,7 +791,7 @@ def remoteTriggerTemurinJCK (jobJdkVersion, jobPlatforms) {
                 def rerunFailure = config.RERUN_FAILURE ? "true" : "false"
                 // SETUP_JCK_RUN is true for release builds
                 def setupJckRun = isReleaseBuild ? "true" : (config.SETUP_JCK_RUN ? "true" : "false")
-                def autoAqaGen = config.AUTO_AQA_GEN ? "true" : "false"
+                def autoAqaGen = AUTO_AQA_GEN ? "true" : "false"
                 
                 // Build display name
                 def displayName = params.PIPELINE_DISPLAY_NAME ?: "${params.BUILD_TYPE} : jdk${jobJdkVersion} : ${platform} : ${target}"

--- a/buildenv/jenkins/config/temurin/jck/default.json
+++ b/buildenv/jenkins/config/temurin/jck/default.json
@@ -7,7 +7,6 @@
             "RERUN_ITERATIONS": "1",
             "RERUN_FAILURE": true,
             "KEEP_REPORTDIR": true,
-            "AUTO_AQA_GEN": false,
             "SETUP_JCK_RUN": false
         },
         "PLATFORM_TARGETS": [


### PR DESCRIPTION
Close #7629 

Set AQA_AUTO_GENS as passing in job parameter instead of configuration parameters for remote AQA_TEST_PIPELINE.

Depends on https://github.com/adoptium/ci-jenkins-pipelines/pull/1494