### PR TITLE
Enable Double128VectorTests on OpenJ9 AArch64 Linux

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk21-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk21-openj9.txt
@@ -503,7 +503,6 @@ java/util/zip/ZipFile/TestCleaner.java https://github.com/eclipse-openj9/openj9/
 
 jdk/incubator/vector/Byte128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/24071 aix-all
 jdk/incubator/vector/ByteMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/24072 linux-s390x
-jdk/incubator/vector/Double128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/20389 linux-aarch64
 jdk/incubator/vector/DoubleMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/24072 linux-s390x
 jdk/incubator/vector/FloatMaxVectorTests.java https://github.com/eclipse-openj9/openj9/issues/24072 linux-s390x
 jdk/incubator/vector/Int128VectorTests.java https://github.com/eclipse-openj9/openj9/issues/24071 aix-all

--- a/openjdk/playlist.xml
+++ b/openjdk/playlist.xml
@@ -3217,12 +3217,6 @@
 	</test>
 	<test>
 		<testCaseName>jdk_double128vector_j9</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/20389</comment>
-				<platform>aarch64_linux</platform>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xjit:{*Double128VectorTests*}(count=1,enforceVectorAPIExpansion),disableAsyncCompilation,dontApplyLogFileNameSuffix,verbose={vectorAPI}</variation>
 		</variations>


### PR DESCRIPTION
This commit enables Double128VectorTests on OpenJ9 AArch64 Linux back again.  The testcase was disabled by #7063 and #7106.