### PR TITLE
Exclude failing OpenJ9 Valhalla tests

### DIFF
--- a/openjdk/excludes/ProblemList_openjdk28-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdk28-openj9.txt
@@ -646,3 +646,5 @@ jdk/internal/platform/docker/TestPidsLimit.java https://github.com/eclipse-openj
 
 ############################################################################
 
+runtime/valhalla/inlinetypes/field_layout/ContendedValueClassInheritanceTest.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all
+runtime/valhalla/inlinetypes/TestValueObjectMethodsInit.java https://github.com/adoptium/aqa-tests/issues/1297 generic-all


### PR DESCRIPTION
- runtime/valhalla/inlinetypes/TestValueObjectMethodsInit.java
- runtime/valhalla/inlinetypes/field_layout/ContendedValueClassInheritanceTest.java
-
https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Test_JDKnext_valhalla_openjdk_x86-64_linux/220/