### PR TITLE
Archive compilation core dumps on compile failure

### DIFF
--- a/buildenv/jenkins/JenkinsfileBase
+++ b/buildenv/jenkins/JenkinsfileBase
@@ -687,14 +687,22 @@ def makeCompileTest(){
 	if (JDK_IMPL == 'hotspot' && PLATFORM.contains('alpine-linux')) {
 		makeTestCmd = "unset LD_LIBRARY_PATH; $makeTestCmd"
 	}
-	dir('aqa-tests') {
-		if (!env.SPEC.startsWith('zos')) {
-			sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"], ignoreMissing: true) {
+	try {
+		dir('aqa-tests') {
+			if (!env.SPEC.startsWith('zos')) {
+				sshagent (credentials: ["$params.SSH_AGENT_CREDENTIAL"], ignoreMissing: true) {
+					sh "$makeTestCmd";
+				}
+			} else {
 				sh "$makeTestCmd";
 			}
-		} else {
-			sh "$makeTestCmd";
 		}
+	} catch (e) {
+		// moveDmp.pl exits `false` after moving core/javacore/jitdump/Snap dumps to output_compilation/.
+		// At this point env.jobStatus is still SUCCESS so the FAILURE branch in post() is
+		// never reached, and cleanWs would wipe the dumps. Archive them here before re-throwing.
+		archiveArtifacts artifacts: "aqa-tests/TKG/output_compilation/**/*.dmp,aqa-tests/TKG/output_compilation/**/*.trc,aqa-tests/TKG/output_compilation/**/javacore*.txt", allowEmptyArchive: true
+		throw e
 	}
 }
 


### PR DESCRIPTION
When a JVM crash occurs during test compilation (e.g. an AOT relocation crash as seen in eclipse-openj9/openj9#24627), moveDmp.pl moves dump files to output_compilation/ then calls `false` to abort make. This causes the Jenkins shell step in makeCompileTest() to throw before env.jobStatus is updated from its initial SUCCESS value, so the FAILURE branch in post() is never reached and the dumps are wiped by cleanWs.

Wrap the compile sh step in a try/catch: archive *.dmp and *.trc from output_compilation/ in the catch block, then re-throw so the build still fails as expected.

Fixes: eclipse-openj9/openj9#24627

Signed-off-by: mahdi@ibm.com