### PR TITLE
Enable FlatArrayLargeIndicesTest

### DIFF
--- a/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
+++ b/openjdk/excludes/ProblemList_openjdkvalhalla-openj9.txt
@@ -43,9 +43,6 @@ com/sun/jdi/valhalla/ValueClassTypeTest.java https://github.com/adoptium/aqa-tes
 
 ############################################################################
 runtime/valhalla/inlinetypes/TestInheritedInlineTypeFields.java https://github.com/eclipse-openj9/openj9/issues/23952 generic-all
-runtime/valhalla/inlinetypes/FlatArrayLargeIndicesTest.java#interpreted https://github.com/eclipse-openj9/openj9/issues/24644 generic-all
-runtime/valhalla/inlinetypes/FlatArrayLargeIndicesTest.java#c1 https://github.com/eclipse-openj9/openj9/issues/24644 generic-all
-runtime/valhalla/inlinetypes/FlatArrayLargeIndicesTest.java#c2 https://github.com/eclipse-openj9/openj9/issues/24644 generic-all
 runtime/valhalla/inlinetypes/NPEInPreviewTest.java https://github.com/eclipse-openj9/openj9/issues/24618 generic-all
 
 ############################################################################


### PR DESCRIPTION
Fixed by: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1263

Passing Test: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/62748/testReport/runtime_valhalla_inlinetypes_FlatArrayLargeIndicesTest/