### PR TITLE
Use xlc_r for AIX native builds

### DIFF
--- a/jck/jtrunner/makefile
+++ b/jck/jtrunner/makefile
@@ -188,7 +188,7 @@ ifeq ($(OS),sunos)
 endif
 
 ifeq ($(OS),aix)
-	CC=/opt/IBM/xlC/16.1.0/bin/xlc
+	CC=/opt/IBM/xlC/16.1.0/bin/xlc_r
 	CFLAGS=-qstaticinline -q$(BitMode) -I$(UNIX_PATH) -I$(OSX_PATH) -I$(SRC_PATH)
 	LDFLAGS=-G -q$(BitMode)
 endif


### PR DESCRIPTION
Use `xlc_r` instead of `xlc` to enable thread-safe `errno` handling on AIX.