### PR TITLE
New implementation of TAP collection

### DIFF
--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -140,7 +140,12 @@ pipeline {
                         return
                     }
 
-                    echo "Found ${matchedBuilds.size()} matching build(s). Downloading artifacts..."
+                    echo "=== Found ${matchedBuilds.size()} matching build(s) ==="
+                    matchedBuilds.each { entry ->
+                        def buildUrl = "${env.JENKINS_URL}job/${jobPath}/${entry.number}/"
+                        echo "  #${entry.number} — platform: '${entry.platform}' — ${buildUrl}"
+                    }
+                    echo "Downloading artifacts..."
 
                     matchedBuilds.each { entry ->
                         def bNum     = entry.number

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -216,18 +216,24 @@ pipeline {
                         }
 
                         // Helper: download all .tap.txt attachments from a Markdown body.
-                        // Matches any github.com URL ending in .tap.txt (covers both
-                        // repo-files and user-attachments domains).
+                        // Mirrors the logic in TapCollection.groovy: only processes lines
+                        // that are Markdown attachment links ending with ')' and contain
+                        // a github.com files URL. Filters to .tap.txt files only.
                         def downloadTapTxt = { body ->
                             if (!body) return
                             body.split(/\r?\n/).each { line ->
-                                def urlMatcher = (line =~ /https:\/\/github\.com\/[^\s\)\]>'"]+\.tap\.txt/)
-                                urlMatcher.each {
-                                    def url      = it[0].replaceAll(/[\)\]>'"]+$/, '')
-                                    def filename = url.tokenize('/').last()
-                                    echo "    Downloading ${filename} ..."
-                                    sh "curl -Lsf -o '${tapsDir}/${filename}' '${url}'"
-                                }
+                                if (!line.endsWith(')')) return
+                                if (!line.contains('https://github.com/user-attachments/files/') &&
+                                    !line.contains("https://github.com/${repoSlug}/files/")) return
+                                // Extract URL from Markdown [name](url) — take whichever domain matches
+                                def urlStart = line.indexOf('(https://github.com/user-attachments/files/')
+                                if (urlStart < 0) urlStart = line.indexOf("(https://github.com/${repoSlug}/files/")
+                                if (urlStart < 0) return
+                                def url      = line.substring(urlStart + 1, line.lastIndexOf(')'))
+                                if (!url.endsWith('.tap.txt')) return
+                                def filename = url.split('/').last()
+                                echo "    Downloading ${filename} ..."
+                                sh "curl -Lsf -o '${tapsDir}/${filename}' '${url}'"
                             }
                         }
 

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -68,6 +68,11 @@ pipeline {
             description: 'GitHub issue URL (e.g. https://github.com/adoptium/aqa-tests/issues/7612)'
         )
         string(
+            name: 'JENKINS_CREDENTIAL',
+            defaultValue: 'jenkins-bot-token',
+            description: 'Jenkins credential ID (username:token) for internal Jenkins REST API calls'
+        )
+        string(
             name: 'GITHUB_CREDENTIAL',
             defaultValue: 'github-bot-token',
             description: 'Jenkins credential ID for the GitHub API token'
@@ -90,6 +95,7 @@ pipeline {
                     def pipelineName  = params.PIPELINE_NAME?.trim()
                     def buildNumbers  = params.BUILD_NUMBERS?.trim()
                     def testJob       = params.TEST_PIPELINE_JOB?.trim() ?: 'AQA_Test_Pipeline_RELEASE'
+                    def jenkinsCred   = params.JENKINS_CREDENTIAL?.trim() ?: 'jenkins-bot-token'
 
                     if (!pipelineName) { error "PIPELINE_NAME parameter must be set." }
                     if (!buildNumbers) { error "BUILD_NUMBERS parameter must be set." }
@@ -114,15 +120,18 @@ pipeline {
                     // builds, one per platform. Each zip is named <platform>.zip.
                     def matchedBuilds = []
 
+                    withCredentials([usernameColonPassword(credentialsId: jenkinsCred, variable: 'JENKINS_AUTH')]) {
                     allBuildsJson.builds.each { b ->
                         def num = b.number as int
                         def buildApiUrl = "${env.JENKINS_URL}job/${jobPath}/${num}/api/json" +
                             "?tree=number,displayName,description,actions%5Bcauses%5BupstreamProject,upstreamBuild,shortDescription%5D%5D"
-                        def info = fetchJson(buildApiUrl, "'${testJob}' #${num}")
+                        def info = fetchJson(buildApiUrl, "'${testJob}' #${num}", env.JENKINS_AUTH)
                         if (!info) return
 
                         // Gate: cause chain must match PIPELINE_NAME + one of BUILD_NUMBERS.
-                        if (!isBuildTriggeredBy(info, pipelineName, targetBuildNums)) return
+                        // The intermediate build-scripts job requires auth to fetch, so pass
+                        // credentials through to the recursive cause-chain walker.
+                        if (!isBuildTriggeredBy(info, pipelineName, targetBuildNums, 3, env.JENKINS_AUTH)) return
 
                         // Platform always comes from the build's own display name / description,
                         // since each build is for exactly one platform regardless of which
@@ -134,6 +143,7 @@ pipeline {
                         echo "  Matched build #${num} — platform: '${platform}'"
                         matchedBuilds << [number: num, platform: platform]
                     }
+                    } // end withCredentials
 
                     if (matchedBuilds.isEmpty()) {
                         echo "No matching builds found in '${testJob}'."
@@ -261,11 +271,13 @@ pipeline {
 
 /**
  * Fetch a URL with curl and return a parsed JSON map.
+ * @param auth  Optional "user:token" string for Basic auth (-u flag).  Pass null to skip.
  * Returns null on failure.
  */
-def fetchJson(String url, String label) {
+def fetchJson(String url, String label, String auth = null) {
     try {
-        def json = sh(script: "curl -sf --connect-timeout 10 '${url}'", returnStdout: true).trim()
+        def authFlag = auth ? "-u '${auth}'" : ''
+        def json = sh(script: "curl -sf --connect-timeout 10 ${authFlag} '${url}'", returnStdout: true).trim()
         if (!json) { echo "Empty response for ${label}"; return null }
         return readJSON(text: json)
     } catch (Exception e) {
@@ -275,35 +287,61 @@ def fetchJson(String url, String label) {
 }
 
 /**
- * Check whether a build was triggered (via cause chain) by the given upstream
- * pipeline name + one of the target build numbers.
+ * Check whether a build was triggered (directly or indirectly) by the given
+ * upstream pipeline name + one of the target build numbers.
  *
- * Causes are nested inside actions[].causes[].
- * Two forms are recognised:
+ * AQA_Test_Pipeline_RELEASE is not triggered directly by release-openjdk*-pipeline;
+ * there is at least one intermediate build-scripts job in between.  This function
+ * therefore walks the cause chain upward (up to maxDepth levels) by fetching each
+ * intermediate upstream build via the REST API until it either finds a match or
+ * exhausts the chain.
+ *
+ * At each level two match forms are checked:
  *   • Structured: upstreamProject contains pipelineName AND upstreamBuild is in targetBuildNums.
  *   • Text fallback (shortDescription): "Started by upstream project … build number 130"
+ *
+ * @param auth  "user:token" passed to curl -u for authenticated fetches of internal jobs.
  */
-def isBuildTriggeredBy(def buildInfo, String pipelineName, Set targetBuildNums) {
-    def actions = buildInfo?.actions ?: []
-    def allCauses = []
-    actions.each { action -> allCauses.addAll(action?.causes ?: []) }
+def isBuildTriggeredBy(def buildInfo, String pipelineName, Set targetBuildNums, int maxDepth = 3, String auth = null) {
+    def current = buildInfo
+    for (int depth = 0; depth < maxDepth; depth++) {
+        def actions = current?.actions ?: []
+        def allCauses = []
+        actions.each { action -> allCauses.addAll(action?.causes ?: []) }
 
-    for (cause in allCauses) {
-        // Structured cause fields
-        def proj  = cause?.upstreamProject?.toString() ?: ''
-        def upNum = cause?.upstreamBuild?.toString()   ?: ''
-        if (proj.contains(pipelineName) && targetBuildNums.contains(upNum)) {
-            return true
-        }
-        // Text fallback: "Started by upstream project build-scripts » release-openjdk8-pipeline build number 130"
-        def shortDesc = cause?.shortDescription?.toString() ?: ''
-        if (shortDesc.contains(pipelineName)) {
-            for (n in targetBuildNums) {
-                if (shortDesc.contains("build number ${n}") || shortDesc.contains("#${n}")) {
-                    return true
+        if (allCauses.isEmpty()) break
+
+        for (cause in allCauses) {
+            def proj      = cause?.upstreamProject?.toString() ?: ''
+            def upNumStr  = cause?.upstreamBuild?.toString()   ?: ''
+            def shortDesc = cause?.shortDescription?.toString() ?: ''
+
+            // Direct structured match
+            if (proj.contains(pipelineName) && targetBuildNums.contains(upNumStr)) {
+                return true
+            }
+            // Text fallback in shortDescription
+            if (shortDesc.contains(pipelineName)) {
+                for (n in targetBuildNums) {
+                    if (shortDesc.contains("build number ${n}") || shortDesc.contains("#${n}")) {
+                        return true
+                    }
                 }
             }
         }
+
+        // No match at this level — climb one level up via the first structured upstream cause.
+        def parentCause = allCauses.find { it?.upstreamProject && it?.upstreamBuild != null }
+        if (!parentCause) break
+
+        def parentProj     = parentCause.upstreamProject.toString()
+        def parentBuildNum = parentCause.upstreamBuild.toString()
+        def parentJobPath  = parentProj.split('/').join('/job/')
+        def parentApiUrl   = "${env.JENKINS_URL}job/${parentJobPath}/${parentBuildNum}/api/json" +
+            "?tree=actions%5Bcauses%5BupstreamProject,upstreamBuild,shortDescription%5D%5D"
+        def parentInfo = fetchJson(parentApiUrl, "'${parentProj}' #${parentBuildNum}", auth)
+        if (!parentInfo) break
+        current = parentInfo
     }
     return false
 }

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -67,12 +67,10 @@ pipeline {
             defaultValue: '',
             description: 'GitHub issue URL (e.g. https://github.com/adoptium/aqa-tests/issues/7612)'
         )
-        credentials(
+        choice(
             name: 'JENKINS_CREDENTIAL',
-            defaultValue: 'jenkins-bot-token',
-            description: 'Username with password credential for internal Jenkins REST API calls (user + API token)',
-            credentialType: 'com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl',
-            required: true
+            choices: ['eclipse_temurin_bot_email_and_token'],
+            description: 'Jenkins credential (username + API token) for internal Jenkins REST API calls'
         )
         credentials(
             name: 'GITHUB_CREDENTIAL',
@@ -128,7 +126,7 @@ pipeline {
                     allBuildsJson.builds.each { b ->
                         def num = b.number as int
                         def buildApiUrl = "${env.JENKINS_URL}job/${jobPath}/${num}/api/json" +
-                            "?tree=number,displayName,description,actions%5Bcauses%5BupstreamProject,upstreamBuild,shortDescription%5D%5D"
+                            "?tree=number,displayName,description,actions%5Bcauses%5BupstreamProject,upstreamBuild,upstreamUrl,shortDescription%5D%5D"
                         // AQA_Test_Pipeline_RELEASE is public — no auth needed here.
                         def info = fetchJson(buildApiUrl, "'${testJob}' #${num}")
                         if (!info) return
@@ -340,15 +338,18 @@ def isBuildTriggeredBy(def buildInfo, String pipelineName, Set targetBuildNums, 
             }
         }
 
-        // No match at this level — climb one level up via the first structured upstream cause.
-        def parentCause = allCauses.find { it?.upstreamProject && it?.upstreamBuild != null }
+        // No match at this level — climb one level up using upstreamUrl (the correct
+        // job path as Jenkins knows it) + upstreamBuild number.
+        def parentCause = allCauses.find { it?.upstreamUrl && it?.upstreamBuild != null }
         if (!parentCause) break
 
-        def parentProj     = parentCause.upstreamProject.toString()
+        def parentProj     = parentCause.upstreamProject?.toString() ?: ''
         def parentBuildNum = parentCause.upstreamBuild.toString()
-        def parentJobPath  = parentProj.split('/').join('/job/')
-        def parentApiUrl   = "${env.JENKINS_URL}job/${parentJobPath}/${parentBuildNum}/api/json" +
-            "?tree=actions%5Bcauses%5BupstreamProject,upstreamBuild,shortDescription%5D%5D"
+        // upstreamUrl is already a valid relative Jenkins path, e.g.
+        // "job/build-scripts/job/jobs/job/release/job/jobs/job/jdk8u/job/jdk8u-release-linux-arm-temurin/"
+        def parentJobUrl   = parentCause.upstreamUrl.toString().replaceAll('/$', '')
+        def parentApiUrl   = "${env.JENKINS_URL}${parentJobUrl}/${parentBuildNum}/api/json" +
+            "?tree=actions%5Bcauses%5BupstreamProject,upstreamBuild,upstreamUrl,shortDescription%5D%5D"
         def parentInfo = fetchJson(parentApiUrl, "'${parentProj}' #${parentBuildNum}", auth)
         if (!parentInfo) break
         current = parentInfo

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -90,6 +90,12 @@ pipeline {
 
     stages {
 
+        stage('Clean Workspace') {
+            steps {
+                cleanWs()
+            }
+        }
+
         // -----------------------------------------------------------------------
         // Stage 1: Collect TAP artifacts from matching Jenkins builds
         // -----------------------------------------------------------------------

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -67,11 +67,6 @@ pipeline {
             defaultValue: '',
             description: 'GitHub issue URL (e.g. https://github.com/adoptium/aqa-tests/issues/7612)'
         )
-        choice(
-            name: 'JENKINS_CREDENTIAL',
-            choices: ['eclipse_temurin_bot_email_and_token'],
-            description: 'Jenkins credential (username + API token) for internal Jenkins REST API calls'
-        )
         credentials(
             name: 'GITHUB_CREDENTIAL',
             defaultValue: 'github-bot-token',
@@ -79,6 +74,13 @@ pipeline {
             credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl',
             required: false
         )
+    }
+
+    environment {
+        // Bind JENKINS_AUTH (user:token) at pipeline level so it is available
+        // to all sh steps including those called from helper functions.
+        // The value is masked in logs by Jenkins automatically.
+        JENKINS_AUTH = credentials('eclipse_temurin_bot_email_and_token')
     }
 
     options {
@@ -97,7 +99,6 @@ pipeline {
                     def pipelineName  = params.PIPELINE_NAME?.trim()
                     def buildNumbers  = params.BUILD_NUMBERS?.trim()
                     def testJob       = params.TEST_PIPELINE_JOB?.trim() ?: 'AQA_Test_Pipeline_RELEASE'
-                    def jenkinsCred   = params.JENKINS_CREDENTIAL?.trim() ?: 'jenkins-bot-token'
 
                     if (!pipelineName) { error "PIPELINE_NAME parameter must be set." }
                     if (!buildNumbers) { error "BUILD_NUMBERS parameter must be set." }
@@ -109,7 +110,7 @@ pipeline {
                     def jobPath = testJob.split('/').join('/job/')
                     // Fetch the list of all build numbers for the job.
                     def allBuildsJson = fetchJson(
-                        "${env.JENKINS_URL}job/${jobPath}/api/json?tree=builds%5Bnumber%5D%7B0,20%7D",
+                        "${env.JENKINS_URL}job/${jobPath}/api/json?tree=builds%5Bnumber%5D",
                         "build list of '${testJob}'"
                     )
                     if (!allBuildsJson || !allBuildsJson.builds) {
@@ -122,7 +123,6 @@ pipeline {
                     // builds, one per platform. Each zip is named <platform>.zip.
                     def matchedBuilds = []
 
-                    withCredentials([usernameColonPassword(credentialsId: jenkinsCred, variable: 'JENKINS_AUTH')]) {
                     allBuildsJson.builds.each { b ->
                         def num = b.number as int
                         def buildApiUrl = "${env.JENKINS_URL}job/${jobPath}/${num}/api/json" +
@@ -145,7 +145,6 @@ pipeline {
                         echo "  Matched build #${num} — platform: '${platform}'"
                         matchedBuilds << [number: num, platform: platform]
                     }
-                    } // end withCredentials
 
                     if (matchedBuilds.isEmpty()) {
                         echo "No matching builds found in '${testJob}'."

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -1,0 +1,370 @@
+#!groovy
+/*
+ * TapArtifactCollector.groovy
+ *
+ * Two-stage pipeline that:
+ *
+ * Stage 1 – Collect TAP artifacts from Jenkins
+ * -----------------------------------------------
+ * Scans all builds of TEST_PIPELINE_JOB (default: AQA_Test_Pipeline_RELEASE)
+ * and finds every build that was triggered (directly or indirectly) by one of
+ * the specified upstream builds.  A match is detected in two ways:
+ *   a) The build's cause chain contains an upstream project whose name ends
+ *      with PIPELINE_NAME and whose build number is in BUILD_NUMBERS.
+ *   b) The build's display name description ends with a platform token that
+ *      also matches  "<PIPELINE_NAME> ... #<N>" — useful when cause info is
+ *      not set but the display name follows the convention:
+ *        "#346 - jdk8 : jdk8u504-b01_adopt_RELEASE : x86-64_windows"
+ *
+ * For every matched build the entire artifact tree is zipped and archived as
+ * Jenkins build artifacts of THIS job, named after the platform suffix of the
+ * display name (e.g. "x86-64_windows.zip").
+ *
+ * Stage 2 – Collect TAP attachments from GitHub
+ * -----------------------------------------------
+ * Given a GitHub issue URL (GITHUB_ISSUE_URL), downloads every attachment
+ * whose URL ends in ".tap.txt" from:
+ *   • The issue body itself
+ *   • All comments on the issue
+ *   • Any child issues whose numbers are listed in the issue description in
+ *     the form "- #<N>" or "- https://github.com/.../issues/<N>"
+ *
+ * All downloaded files are archived as Jenkins build artifacts.
+ *
+ * Parameters
+ * ----------
+ *   PIPELINE_NAME        Upstream pipeline name to match in cause/description.
+ *                        Example: release-openjdk8-pipeline
+ *   BUILD_NUMBERS        Comma-separated upstream build numbers.
+ *                        Example: 130,131
+ *   TEST_PIPELINE_JOB    Jenkins job to scan.  Default: AQA_Test_Pipeline_RELEASE
+ *   GITHUB_ISSUE_URL     GitHub issue URL.
+ *                        Example: https://github.com/adoptium/aqa-tests/issues/7612
+ *   GITHUB_CREDENTIAL    Jenkins credential ID for the GitHub token.
+ */
+
+pipeline {
+    agent { label 'ci.role.test&&hw.arch.x86&&sw.os.linux' }
+
+    parameters {
+        string(
+            name: 'PIPELINE_NAME',
+            defaultValue: '',
+            description: 'Upstream pipeline name to match (e.g. release-openjdk8-pipeline)'
+        )
+        string(
+            name: 'BUILD_NUMBERS',
+            defaultValue: '',
+            description: 'Comma-separated upstream build numbers to match (e.g. 130,131)'
+        )
+        string(
+            name: 'TEST_PIPELINE_JOB',
+            defaultValue: 'AQA_Test_Pipeline_RELEASE',
+            description: 'Jenkins job to scan for matching builds'
+        )
+        string(
+            name: 'GITHUB_ISSUE_URL',
+            defaultValue: '',
+            description: 'GitHub issue URL (e.g. https://github.com/adoptium/aqa-tests/issues/7612)'
+        )
+        string(
+            name: 'GITHUB_CREDENTIAL',
+            defaultValue: 'github-bot-token',
+            description: 'Jenkins credential ID for the GitHub API token'
+        )
+    }
+
+    options {
+        timestamps()
+        skipDefaultCheckout()
+    }
+
+    stages {
+
+        // -----------------------------------------------------------------------
+        // Stage 1: Collect TAP artifacts from matching Jenkins builds
+        // -----------------------------------------------------------------------
+        stage('Collect Jenkins Artifacts') {
+            steps {
+                script {
+                    def pipelineName  = params.PIPELINE_NAME?.trim()
+                    def buildNumbers  = params.BUILD_NUMBERS?.trim()
+                    def testJob       = params.TEST_PIPELINE_JOB?.trim() ?: 'AQA_Test_Pipeline_RELEASE'
+
+                    if (!pipelineName) { error "PIPELINE_NAME parameter must be set." }
+                    if (!buildNumbers) { error "BUILD_NUMBERS parameter must be set." }
+
+                    def targetBuildNums = buildNumbers.split(/\s*,\s*/).collect { it.trim() }.findAll { it } as Set
+
+                    echo "=== Stage 1: scanning '${testJob}' for builds triggered by '${pipelineName}' #${targetBuildNums} ==="
+
+                    def jobPath = testJob.split('/').join('/job/')
+                    // Fetch the list of all build numbers for the job.
+                    def allBuildsJson = fetchJson(
+                        "${env.JENKINS_URL}job/${jobPath}/api/json?tree=builds%5Bnumber%5D",
+                        "build list of '${testJob}'"
+                    )
+                    if (!allBuildsJson || !allBuildsJson.builds) {
+                        echo "No builds found for '${testJob}'. Skipping Stage 1."
+                        return
+                    }
+
+                    // Each entry: [number: N, platform: 'x86-64_windows']
+                    // One upstream build number fans out to many AQA_Test_Pipeline_RELEASE
+                    // builds, one per platform. Each zip is named <platform>.zip.
+                    def matchedBuilds = []
+
+                    allBuildsJson.builds.each { b ->
+                        def num = b.number as int
+                        def buildApiUrl = "${env.JENKINS_URL}job/${jobPath}/${num}/api/json" +
+                            "?tree=number,displayName,description,actions%5Bcauses%5BupstreamProject,upstreamBuild,shortDescription%5D%5D"
+                        def info = fetchJson(buildApiUrl, "'${testJob}' #${num}")
+                        if (!info) return
+
+                        // Gate: cause chain must match PIPELINE_NAME + one of BUILD_NUMBERS.
+                        if (!isBuildTriggeredBy(info, pipelineName, targetBuildNums)) return
+
+                        // Platform always comes from the build's own display name / description,
+                        // since each build is for exactly one platform regardless of which
+                        // upstream build number triggered it.
+                        def platform = extractPlatformFromDisplayName(
+                            info.displayName?.trim() ?: '',
+                            info.description?.trim()  ?: ''
+                        )
+                        echo "  Matched build #${num} — platform: '${platform}'"
+                        matchedBuilds << [number: num, platform: platform]
+                    }
+
+                    if (matchedBuilds.isEmpty()) {
+                        echo "No matching builds found in '${testJob}'."
+                        return
+                    }
+
+                    echo "Found ${matchedBuilds.size()} matching build(s). Downloading artifacts..."
+
+                    matchedBuilds.each { entry ->
+                        def bNum     = entry.number
+                        def platform = entry.platform ?: "unknown"
+                        def zipName  = "${platform}.zip"
+                        echo "  Downloading artifacts from '${testJob}' #${bNum} → ${zipName} ..."
+                        try {
+                            def artifactZipUrl = "${env.JENKINS_URL}job/${jobPath}/${bNum}/artifact/*zip*/archive.zip"
+                            sh "curl -sf -o '${zipName}' '${artifactZipUrl}'"
+                        } catch (Exception e) {
+                            echo "  WARNING: Failed to download artifacts for build #${bNum}: ${e.message}"
+                        }
+                    }
+
+                    archiveArtifacts artifacts: '*.zip', allowEmptyArchive: true
+                }
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // Stage 2: Collect .tap.txt attachments from GitHub issue + child issues
+        // -----------------------------------------------------------------------
+        stage('Collect GitHub TAP Attachments') {
+            steps {
+                script {
+                    def issueUrl    = params.GITHUB_ISSUE_URL?.trim()
+                    def credId      = params.GITHUB_CREDENTIAL?.trim() ?: 'github-bot-token'
+                    def tapsDir     = 'TAPs'
+
+                    if (!issueUrl) {
+                        echo "GITHUB_ISSUE_URL not set — skipping Stage 2."
+                        return
+                    }
+
+                    // Parse  https://github.com/<owner>/<repo>/issues/<number>
+                    def m = issueUrl =~ /github\.com\/([^\/]+\/[^\/]+)\/issues\/(\d+)/
+                    if (!m) { error "Cannot parse GITHUB_ISSUE_URL: '${issueUrl}'" }
+                    def repoSlug    = m[0][1]
+                    def issueNumber = m[0][2]
+
+                    sh "mkdir -p ${tapsDir}"
+
+                    echo "=== Stage 2: collecting .tap.txt attachments for ${repoSlug}#${issueNumber} ==="
+
+                    withCredentials([string(credentialsId: credId, variable: 'GITHUB_TOKEN')]) {
+
+                        // Helper: fetch JSON from GitHub API
+                        def ghFetch = { url, label ->
+                            def outFile = "gh_${label}.json"
+                            sh """curl -sf -H "Authorization: token \${GITHUB_TOKEN}" \
+                                -H "Accept: application/vnd.github.v3+json" \
+                                "${url}" -o "${outFile}" """
+                            return readJSON(file: outFile)
+                        }
+
+                        // Helper: download all .tap.txt attachments from a Markdown body.
+                        // Matches any github.com URL ending in .tap.txt (covers both
+                        // repo-files and user-attachments domains).
+                        def downloadTapTxt = { body ->
+                            if (!body) return
+                            body.split(/\r?\n/).each { line ->
+                                def urlMatcher = (line =~ /https:\/\/github\.com\/[^\s\)\]>'"]+\.tap\.txt/)
+                                urlMatcher.each {
+                                    def url      = it[0].replaceAll(/[\)\]>'"]+$/, '')
+                                    def filename = url.tokenize('/').last()
+                                    echo "    Downloading ${filename} ..."
+                                    sh "curl -Lsf -o '${tapsDir}/${filename}' '${url}'"
+                                }
+                            }
+                        }
+
+                        // --- Main issue ---
+                        def apiBase  = "https://api.github.com/repos/${repoSlug}"
+                        def issue    = ghFetch("${apiBase}/issues/${issueNumber}", "main_issue")
+                        def comments = ghFetch("${apiBase}/issues/${issueNumber}/comments", "main_comments")
+
+                        downloadTapTxt(issue.body)
+                        comments.each { c -> downloadTapTxt(c.body) }
+
+                        // --- Child issues linked in main issue description ---
+                        def childNums = extractChildIssueNumbers(issue.body ?: '', repoSlug)
+                        echo "Found ${childNums.size()} child issue(s): ${childNums}"
+
+                        childNums.eachWithIndex { childNum, idx ->
+                            echo "  Processing child issue #${childNum} ..."
+                            try {
+                                def childIssue    = ghFetch("${apiBase}/issues/${childNum}", "child_${idx}_issue")
+                                def childComments = ghFetch("${apiBase}/issues/${childNum}/comments", "child_${idx}_comments")
+                                downloadTapTxt(childIssue.body)
+                                childComments.each { c -> downloadTapTxt(c.body) }
+                            } catch (Exception e) {
+                                echo "  WARNING: Failed to fetch child issue #${childNum}: ${e.message}"
+                            }
+                        }
+                    }
+
+                    archiveArtifacts artifacts: "${tapsDir}/**", allowEmptyArchive: true
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            cleanWs()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a URL with curl and return a parsed JSON map.
+ * Returns null on failure.
+ */
+def fetchJson(String url, String label) {
+    try {
+        def json = sh(script: "curl -sf --connect-timeout 10 '${url}'", returnStdout: true).trim()
+        if (!json) { echo "Empty response for ${label}"; return null }
+        return readJSON(text: json)
+    } catch (Exception e) {
+        echo "Failed to fetch ${label}: ${e.message}"
+        return null
+    }
+}
+
+/**
+ * Check whether a build was triggered (via cause chain) by the given upstream
+ * pipeline name + one of the target build numbers.
+ *
+ * Causes are nested inside actions[].causes[].
+ * Two forms are recognised:
+ *   • Structured: upstreamProject contains pipelineName AND upstreamBuild is in targetBuildNums.
+ *   • Text fallback (shortDescription): "Started by upstream project … build number 130"
+ */
+def isBuildTriggeredBy(def buildInfo, String pipelineName, Set targetBuildNums) {
+    def actions = buildInfo?.actions ?: []
+    def allCauses = []
+    actions.each { action -> allCauses.addAll(action?.causes ?: []) }
+
+    for (cause in allCauses) {
+        // Structured cause fields
+        def proj  = cause?.upstreamProject?.toString() ?: ''
+        def upNum = cause?.upstreamBuild?.toString()   ?: ''
+        if (proj.contains(pipelineName) && targetBuildNums.contains(upNum)) {
+            return true
+        }
+        // Text fallback: "Started by upstream project build-scripts » release-openjdk8-pipeline build number 130"
+        def shortDesc = cause?.shortDescription?.toString() ?: ''
+        if (shortDesc.contains(pipelineName)) {
+            for (n in targetBuildNums) {
+                if (shortDesc.contains("build number ${n}") || shortDesc.contains("#${n}")) {
+                    return true
+                }
+            }
+        }
+    }
+    return false
+}
+
+/**
+ * Extract the platform name from a Jenkins build's display name and/or description.
+ *
+ * Display name convention:
+ *   "#346 - jdk8 : jdk8u504-b01_adopt_RELEASE : x86-64_windows"
+ *   → last colon-separated token trimmed → "x86-64_windows"
+ *
+ * Description convention (HTML, last segment after final ' : ' or last colon):
+ *   Same format, so same rule applies.
+ *
+ * Falls back to the last two underscore-delimited tokens from the description
+ * if neither source has a colon (e.g. "Test_openjdk8_hs_special.functional_arm_linux"
+ * → "arm_linux").
+ *
+ * @param displayName  value of buildInfo.displayName
+ * @param description  value of buildInfo.description (may contain HTML)
+ * @return platform string, or empty string if not determinable
+ */
+def extractPlatformFromDisplayName(String displayName, String description) {
+    // Try display name first (most reliable — always set by Jenkins)
+    if (displayName) {
+        def parts = displayName.split(':')
+        if (parts.size() >= 2) {
+            return parts.last().trim()
+        }
+    }
+    // Try description (strip HTML tags first)
+    if (description) {
+        def plain = description.replaceAll(/<[^>]+>/, '').trim()
+        def parts = plain.split(':')
+        if (parts.size() >= 2) {
+            return parts.last().trim()
+        }
+        // Last two underscore tokens as final fallback
+        def tokens = plain.tokenize('_')
+        if (tokens.size() >= 2) {
+            return "${tokens[-2]}_${tokens[-1]}"
+        }
+    }
+    return ''
+}
+
+/**
+ * Parse child issue numbers from a GitHub issue body.
+ *
+ * Recognises lines containing:
+ *   - #<N>
+ *   - https://github.com/<owner>/<repo>/issues/<N>
+ *
+ * Returns a de-duplicated list of issue number strings.
+ */
+def extractChildIssueNumbers(String body, String repoSlug) {
+    def nums = [] as LinkedHashSet
+    if (!body) return nums as List
+
+    body.split(/\r?\n/).each { line ->
+        // Full URL form
+        def urlM = (line =~ /github\.com\/${repoSlug}\/issues\/(\d+)/)
+        urlM.each { nums << it[1] }
+        // Short form: "- #123" or "closes #123" or "#123"
+        def shortM = (line =~ /(?:^|\s|-)#(\d+)/)
+        shortM.each { nums << it[1] }
+    }
+    return nums as List
+}

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -171,7 +171,7 @@ pipeline {
                         }
                     }
 
-                    archiveArtifacts artifacts: '*.zip', allowEmptyArchive: true
+                    // platform.zip files are intermediate — not archived here; merged into *.tar.gz in Stage 3.
                 }
             }
         }
@@ -273,7 +273,7 @@ pipeline {
                         }
                     }
 
-                    archiveArtifacts artifacts: 'grinder_*.zip', allowEmptyArchive: true
+                    // grinder_*.zip files are intermediate — not archived here; merged into *.tar.gz in Stage 3.
                 }
             }
         }

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -290,36 +290,44 @@ pipeline {
         stage('Merge Artifacts') {
             steps {
                 script {
-                    // Find all grinder_<platform>.zip files produced by Stage 2
-                    def grinderZips = findFiles(glob: 'grinder_*.zip')
-                    if (grinderZips.length == 0) {
-                        echo "No grinder zips found — skipping merge."
+                    // Collect all platforms from both sources:
+                    //   - grinder_<platform>.zip  → GitHub attachments (Stage 2)
+                    //   - <platform>.zip           → Jenkins artifacts  (Stage 1)
+                    def platforms = [] as LinkedHashSet
+
+                    findFiles(glob: 'grinder_*.zip').each { f ->
+                        platforms << f.name.replaceFirst(/^grinder_/, '').replaceFirst(/\.zip$/, '')
+                    }
+                    findFiles(glob: '*.zip').findAll { !it.name.startsWith('grinder_') }.each { f ->
+                        platforms << f.name.replaceFirst(/\.zip$/, '')
+                    }
+
+                    if (platforms.isEmpty()) {
+                        echo "No zip files found — skipping merge."
                         return
                     }
 
-                    grinderZips.each { gz ->
-                        // gz.name = "grinder_x86-64_linux.zip" → platform = "x86-64_linux"
-                        def platform   = gz.name.replaceFirst(/^grinder_/, '').replaceFirst(/\.zip$/, '')
-                        def jenkinsZip = "${platform}.zip"
-                        def mergeDir   = "merge_${platform}"
+                    platforms.each { platform ->
+                        def grinderZip  = "grinder_${platform}.zip"
+                        def jenkinsZip  = "${platform}.zip"
+                        def mergeDir    = "merge_${platform}"
+                        def haGrinder   = sh(script: "test -f '${grinderZip}'",  returnStatus: true) == 0
+                        def hasJenkins  = sh(script: "test -f '${jenkinsZip}'",  returnStatus: true) == 0
 
                         sh "mkdir -p '${mergeDir}'"
 
-                        // Unzip grinder attachments
-                        sh "unzip -o '${gz.name}' -d '${mergeDir}'"
-
-                        // Unzip Jenkins artifacts if present for this platform
-                        def jenkinsZipExists = sh(script: "test -f '${jenkinsZip}'", returnStatus: true) == 0
-                        if (jenkinsZipExists) {
+                        if (haGrinder) {
+                            sh "unzip -o '${grinderZip}' -d '${mergeDir}'"
+                            echo "  Unpacked grinder attachments for '${platform}'"
+                        }
+                        if (hasJenkins) {
                             sh "unzip -o '${jenkinsZip}' -d '${mergeDir}'"
-                            echo "  Merged Jenkins artifacts from ${jenkinsZip}"
-                        } else {
-                            echo "  No Jenkins artifact zip found for platform '${platform}' — skipping"
+                            echo "  Unpacked Jenkins artifacts for '${platform}'"
                         }
 
                         // Pack everything into <platform>.tar.gz
                         sh "tar -czf '${platform}.tar.gz' -C '${mergeDir}' ."
-                        echo "  Created merged ${platform}.tar.gz"
+                        echo "  Created ${platform}.tar.gz (grinder=${haGrinder}, jenkins=${hasJenkins})"
                     }
 
                     archiveArtifacts artifacts: '*.tar.gz', allowEmptyArchive: true

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -129,12 +129,12 @@ pipeline {
                         def num = b.number as int
                         def buildApiUrl = "${env.JENKINS_URL}job/${jobPath}/${num}/api/json" +
                             "?tree=number,displayName,description,actions%5Bcauses%5BupstreamProject,upstreamBuild,shortDescription%5D%5D"
-                        def info = fetchJson(buildApiUrl, "'${testJob}' #${num}", env.JENKINS_AUTH)
+                        // AQA_Test_Pipeline_RELEASE is public — no auth needed here.
+                        def info = fetchJson(buildApiUrl, "'${testJob}' #${num}")
                         if (!info) return
 
                         // Gate: cause chain must match PIPELINE_NAME + one of BUILD_NUMBERS.
-                        // The intermediate build-scripts job requires auth to fetch, so pass
-                        // credentials through to the recursive cause-chain walker.
+                        // Auth is only needed when fetching the intermediate build-scripts parent build.
                         if (!isBuildTriggeredBy(info, pipelineName, targetBuildNums, 3, env.JENKINS_AUTH)) return
 
                         // Platform always comes from the build's own display name / description,

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -128,12 +128,12 @@ pipeline {
                         def buildApiUrl = "${env.JENKINS_URL}job/${jobPath}/${num}/api/json" +
                             "?tree=number,displayName,description,actions%5Bcauses%5BupstreamProject,upstreamBuild,upstreamUrl,shortDescription%5D%5D"
                         // AQA_Test_Pipeline_RELEASE is public — no auth needed here.
-                        def info = fetchJson(buildApiUrl, "'${testJob}' #${num}")
+                        def info = fetchJson(buildApiUrl, "'${testJob}' #${num}", false)
                         if (!info) return
 
                         // Gate: cause chain must match PIPELINE_NAME + one of BUILD_NUMBERS.
-                        // Auth is only needed when fetching the intermediate build-scripts parent build.
-                        if (!isBuildTriggeredBy(info, pipelineName, targetBuildNums, 3, env.JENKINS_AUTH)) return
+                        // useAuth=true so the parent build-scripts fetch uses $JENKINS_AUTH from env.
+                        if (!isBuildTriggeredBy(info, pipelineName, targetBuildNums, 3, true)) return
 
                         // Platform always comes from the build's own display name / description,
                         // since each build is for exactly one platform regardless of which
@@ -336,23 +336,17 @@ pipeline {
 
 /**
  * Fetch a URL with curl and return a parsed JSON map.
- * @param auth  Optional "user:token" string for Basic auth (-u flag).  Pass null to skip.
+ * @param useAuth  When true, passes -u "$JENKINS_AUTH" to curl. JENKINS_AUTH must already
+ *                 be bound in the shell environment via withCredentials — it is never
+ *                 interpolated into the Groovy string, eliminating the insecure-interpolation warning.
  * Returns null on failure.
  */
-def fetchJson(String url, String label, String auth = null) {
+def fetchJson(String url, String label, boolean useAuth = false) {
     try {
-        def json
-        if (auth) {
-            // Pass credentials via environment variable to avoid secret interpolation warning.
-            // curl reads CURL_AUTH from the environment; never interpolated into the script string.
-            json = sh(
-                script: "curl -sf --connect-timeout 10 -u \"\$CURL_AUTH\" '${url}'",
-                returnStdout: true,
-                env: ["CURL_AUTH=${auth}"]
-            ).trim()
-        } else {
-            json = sh(script: "curl -sf --connect-timeout 10 '${url}'", returnStdout: true).trim()
-        }
+        def script = useAuth
+            ? "curl -sf --connect-timeout 10 -u \"\$JENKINS_AUTH\" '${url}'"
+            : "curl -sf --connect-timeout 10 '${url}'"
+        def json = sh(script: script, returnStdout: true).trim()
         if (!json) { echo "Empty response for ${label}"; return null }
         return readJSON(text: json)
     } catch (Exception e) {
@@ -375,9 +369,9 @@ def fetchJson(String url, String label, String auth = null) {
  *   • Structured: upstreamProject contains pipelineName AND upstreamBuild is in targetBuildNums.
  *   • Text fallback (shortDescription): "Started by upstream project … build number 130"
  *
- * @param auth  "user:token" passed to curl -u for authenticated fetches of internal jobs.
+ * @param useAuth  When true, fetches of parent builds use $JENKINS_AUTH (must be bound via withCredentials).
  */
-def isBuildTriggeredBy(def buildInfo, String pipelineName, Set targetBuildNums, int maxDepth = 3, String auth = null) {
+def isBuildTriggeredBy(def buildInfo, String pipelineName, Set targetBuildNums, int maxDepth = 3, boolean useAuth = false) {
     def current = buildInfo
     for (int depth = 0; depth < maxDepth; depth++) {
         def actions = current?.actions ?: []
@@ -417,7 +411,7 @@ def isBuildTriggeredBy(def buildInfo, String pipelineName, Set targetBuildNums, 
         def parentJobUrl   = parentCause.upstreamUrl.toString().replaceAll('/$', '')
         def parentApiUrl   = "${env.JENKINS_URL}${parentJobUrl}/${parentBuildNum}/api/json" +
             "?tree=actions%5Bcauses%5BupstreamProject,upstreamBuild,upstreamUrl,shortDescription%5D%5D"
-        def parentInfo = fetchJson(parentApiUrl, "'${parentProj}' #${parentBuildNum}", auth)
+        def parentInfo = fetchJson(parentApiUrl, "'${parentProj}' #${parentBuildNum}", useAuth)
         if (!parentInfo) break
         current = parentInfo
     }

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -185,7 +185,6 @@ pipeline {
                 script {
                     def issueUrl    = params.GITHUB_ISSUE_URL?.trim()
                     def credId      = params.GITHUB_CREDENTIAL?.trim() ?: 'github-bot-token'
-                    def tapsDir     = 'TAPs'
 
                     if (!issueUrl) {
                         echo "GITHUB_ISSUE_URL not set — skipping Stage 2."
@@ -197,8 +196,6 @@ pipeline {
                     if (!m) { error "Cannot parse GITHUB_ISSUE_URL: '${issueUrl}'" }
                     def repoSlug    = m[0][1]
                     def issueNumber = m[0][2]
-
-                    sh "mkdir -p ${tapsDir}"
 
                     echo "=== Stage 2: collecting .tap.txt attachments for ${repoSlug}#${issueNumber} ==="
 
@@ -213,37 +210,35 @@ pipeline {
                             return readJSON(file: outFile)
                         }
 
-                        // Helper: download all .tap.txt attachments from a Markdown body.
-                        // Mirrors the logic in TapCollection.groovy: only processes lines
-                        // that are Markdown attachment links ending with ')' and contain
-                        // a github.com files URL. Filters to .tap.txt files only.
-                        def downloadTapTxt = { body ->
+                        // Helper: download all .tap.txt attachments from a Markdown body
+                        // into destDir. Mirrors TapCollection.groovy URL extraction logic.
+                        def downloadTapTxt = { body, destDir ->
                             if (!body) return
                             body.split(/\r?\n/).each { line ->
                                 if (!line.endsWith(')')) return
                                 if (!line.contains('https://github.com/user-attachments/files/') &&
                                     !line.contains("https://github.com/${repoSlug}/files/")) return
-                                // Extract URL from Markdown [name](url) — take whichever domain matches
                                 def urlStart = line.indexOf('(https://github.com/user-attachments/files/')
                                 if (urlStart < 0) urlStart = line.indexOf("(https://github.com/${repoSlug}/files/")
                                 if (urlStart < 0) return
                                 def url      = line.substring(urlStart + 1, line.lastIndexOf(')'))
                                 if (!url.endsWith('.tap.txt')) return
                                 def filename = url.split('/').last()
-                                echo "    Downloading ${filename} ..."
-                                sh "curl -Lsf -o '${tapsDir}/${filename}' '${url}'"
+                                echo "    Downloading ${filename} → ${destDir}/"
+                                sh "curl -Lsf -o '${destDir}/${filename}' '${url}'"
                             }
                         }
 
-                        // --- Main issue ---
-                        def apiBase  = "https://api.github.com/repos/${repoSlug}"
+                        def apiBase = "https://api.github.com/repos/${repoSlug}"
+
+                        // --- Main issue: download attachments into TAPs/main/ ---
                         def issue    = ghFetch("${apiBase}/issues/${issueNumber}", "main_issue")
                         def comments = ghFetch("${apiBase}/issues/${issueNumber}/comments", "main_comments")
+                        sh "mkdir -p TAPs/main"
+                        downloadTapTxt(issue.body, 'TAPs/main')
+                        comments.each { c -> downloadTapTxt(c.body, 'TAPs/main') }
 
-                        downloadTapTxt(issue.body)
-                        comments.each { c -> downloadTapTxt(c.body) }
-
-                        // --- Child issues linked in main issue description ---
+                        // --- Child issues: each gets its own platform subdir ---
                         def childNums = extractChildIssueNumbers(issue.body ?: '', repoSlug)
                         echo "Found ${childNums.size()} child issue(s): ${childNums}"
 
@@ -252,15 +247,77 @@ pipeline {
                             try {
                                 def childIssue    = ghFetch("${apiBase}/issues/${childNum}", "child_${idx}_issue")
                                 def childComments = ghFetch("${apiBase}/issues/${childNum}/comments", "child_${idx}_comments")
-                                downloadTapTxt(childIssue.body)
-                                childComments.each { c -> downloadTapTxt(c.body) }
+
+                                // Extract platform from child issue title ("... - x86-64_linux")
+                                // or fall back to body "Platform: x86-64_linux" line.
+                                def platform = extractPlatformFromIssueTitle(childIssue.title ?: '')
+                                if (!platform) platform = extractPlatformFromIssueBody(childIssue.body ?: '')
+                                if (!platform) platform = "child_${childNum}"
+                                echo "    Platform: '${platform}'"
+
+                                def destDir = "TAPs/${platform}"
+                                sh "mkdir -p '${destDir}'"
+                                downloadTapTxt(childIssue.body, destDir)
+                                childComments.each { c -> downloadTapTxt(c.body, destDir) }
+
+                                // Zip all downloaded .tap.txt files as grinder_<platform>.zip
+                                def tapCount = sh(script: "ls '${destDir}'/*.tap.txt 2>/dev/null | wc -l", returnStdout: true).trim().toInteger()
+                                if (tapCount > 0) {
+                                    sh "cd '${destDir}' && zip -j '../../grinder_${platform}.zip' *.tap.txt"
+                                    echo "    Created grinder_${platform}.zip (${tapCount} file(s))"
+                                } else {
+                                    echo "    No .tap.txt files found for platform '${platform}'"
+                                }
                             } catch (Exception e) {
-                                echo "  WARNING: Failed to fetch child issue #${childNum}: ${e.message}"
+                                echo "  WARNING: Failed to process child issue #${childNum}: ${e.message}"
                             }
                         }
                     }
 
-                    archiveArtifacts artifacts: "${tapsDir}/**", allowEmptyArchive: true
+                    archiveArtifacts artifacts: 'grinder_*.zip', allowEmptyArchive: true
+                }
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // Stage 3: Merge Jenkins artifacts + GitHub attachments per platform
+        // -----------------------------------------------------------------------
+        stage('Merge Artifacts') {
+            steps {
+                script {
+                    // Find all grinder_<platform>.zip files produced by Stage 2
+                    def grinderZips = findFiles(glob: 'grinder_*.zip')
+                    if (grinderZips.length == 0) {
+                        echo "No grinder zips found — skipping merge."
+                        return
+                    }
+
+                    grinderZips.each { gz ->
+                        // gz.name = "grinder_x86-64_linux.zip" → platform = "x86-64_linux"
+                        def platform   = gz.name.replaceFirst(/^grinder_/, '').replaceFirst(/\.zip$/, '')
+                        def jenkinsZip = "${platform}.zip"
+                        def mergeDir   = "merge_${platform}"
+
+                        sh "mkdir -p '${mergeDir}'"
+
+                        // Unzip grinder attachments
+                        sh "unzip -o '${gz.name}' -d '${mergeDir}'"
+
+                        // Unzip Jenkins artifacts if present for this platform
+                        def jenkinsZipExists = sh(script: "test -f '${jenkinsZip}'", returnStatus: true) == 0
+                        if (jenkinsZipExists) {
+                            sh "unzip -o '${jenkinsZip}' -d '${mergeDir}'"
+                            echo "  Merged Jenkins artifacts from ${jenkinsZip}"
+                        } else {
+                            echo "  No Jenkins artifact zip found for platform '${platform}' — skipping"
+                        }
+
+                        // Pack everything into <platform>.tar.gz
+                        sh "tar -czf '${platform}.tar.gz' -C '${mergeDir}' ."
+                        echo "  Created merged ${platform}.tar.gz"
+                    }
+
+                    archiveArtifacts artifacts: '*.tar.gz', allowEmptyArchive: true
                 }
             }
         }
@@ -403,8 +460,8 @@ def extractPlatformFromDisplayName(String displayName, String description) {
  * Parse child issue numbers from a GitHub issue body.
  *
  * Recognises lines containing:
- *   - #<N>
  *   - https://github.com/<owner>/<repo>/issues/<N>
+ *   - - #<N>  (task list items)
  *
  * Returns a de-duplicated list of issue number strings.
  */
@@ -421,4 +478,29 @@ def extractChildIssueNumbers(String body, String repoSlug) {
         shortM.each { nums << it[1] }
     }
     return nums as List
+}
+
+/**
+ * Extract platform from a child issue title.
+ * Convention: "Triage Automated Tests for August 2026 JDK8 - x86-64_linux"
+ * → last token after " - " → "x86-64_linux"
+ */
+def extractPlatformFromIssueTitle(String title) {
+    if (!title) return ''
+    def idx = title.lastIndexOf(' - ')
+    if (idx < 0) return ''
+    return title.substring(idx + 3).trim()
+}
+
+/**
+ * Extract platform from a child issue body.
+ * Looks for a line matching "Platform: <platform>"
+ */
+def extractPlatformFromIssueBody(String body) {
+    if (!body) return ''
+    for (line in body.split(/\r?\n/)) {
+        def m = (line =~ /^Platform:\s*(\S+)/)
+        if (m) return m[0][1].trim()
+    }
+    return ''
 }

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -2,45 +2,78 @@
 /*
  * TapArtifactCollector.groovy
  *
- * Two-stage pipeline that:
+ * NEW STRATEGY — Reverse-engineering the trigger chain
+ * =====================================================
+ * Traditional TAP collection tools (e.g. TapCollection.groovy) work by tracing
+ * FORWARD: starting from a known upstream pipeline run, following its child jobs
+ * down to the test jobs, and collecting results.  That approach requires direct
+ * knowledge of the job topology and is tightly coupled to how the upstream
+ * pipeline fans out its work.
  *
- * Stage 1 – Collect TAP artifacts from Jenkins
- * -----------------------------------------------
- * Scans all builds of TEST_PIPELINE_JOB (default: AQA_Test_Pipeline_RELEASE)
- * and finds every build that was triggered (directly or indirectly) by one of
- * the specified upstream builds.  A match is detected in two ways:
- *   a) The build's cause chain contains an upstream project whose name ends
- *      with PIPELINE_NAME and whose build number is in BUILD_NUMBERS.
- *   b) The build's display name description ends with a platform token that
- *      also matches  "<PIPELINE_NAME> ... #<N>" — useful when cause info is
- *      not set but the display name follows the convention:
- *        "#346 - jdk8 : jdk8u504-b01_adopt_RELEASE : x86-64_windows"
+ * This pipeline takes a completely NEW approach: REVERSE ENGINEERING.
+ * Instead of tracing forward from the upstream pipeline, it inspects each
+ * AQA_Test_Pipeline_RELEASE build and traces BACKWARD through its cause chain
+ * to determine whether it was ultimately triggered by the specified upstream
+ * pipeline run.  This decouples the collector from the upstream topology — it
+ * does not need to know how the release pipeline fans out; it simply asks each
+ * test pipeline build "were you caused by this release?".
  *
- * For every matched build the entire artifact tree is zipped and archived as
- * Jenkins build artifacts of THIS job, named after the platform suffix of the
- * display name (e.g. "x86-64_windows.zip").
+ * This strategy is made possible by the new test job implementation in which
+ * AQA_Test_Pipeline_RELEASE records full cause provenance through the
+ * intermediate build-scripts jobs, allowing the origin pipeline and build
+ * number to be recovered by walking up the cause chain via the Jenkins REST API.
  *
- * Stage 2 – Collect TAP attachments from GitHub
- * -----------------------------------------------
- * Given a GitHub issue URL (GITHUB_ISSUE_URL), downloads every attachment
- * whose URL ends in ".tap.txt" from:
- *   • The issue body itself
- *   • All comments on the issue
- *   • Any child issues whose numbers are listed in the issue description in
- *     the form "- #<N>" or "- https://github.com/.../issues/<N>"
+ * Pipeline overview
+ * -----------------
+ * Stage 0 – Clean Workspace
+ *   Wipes the workspace before every run to prevent artifacts from a previous
+ *   run polluting the current one.
  *
- * All downloaded files are archived as Jenkins build artifacts.
+ * Stage 1 – Collect Jenkins Artifacts  [REVERSE-ENGINEERING]
+ *   Scans all builds of TEST_PIPELINE_JOB (default: AQA_Test_Pipeline_RELEASE)
+ *   and identifies every build whose cause chain traces back to the specified
+ *   PIPELINE_NAME + BUILD_NUMBERS.  Matching works in two steps:
+ *
+ *   Step A — check direct cause (no auth required):
+ *     Each AQA_Test_Pipeline_RELEASE build records its immediate upstream cause
+ *     (an intermediate build-scripts per-platform job).  If that job itself
+ *     matches PIPELINE_NAME + build number, we are done.
+ *
+ *   Step B — climb one level (auth required):
+ *     The immediate upstream is normally a per-platform build-scripts job
+ *     (e.g. jdk8u-release-linux-arm-temurin), not the top-level release pipeline.
+ *     The pipeline fetches that intermediate build via the Jenkins REST API
+ *     (using upstreamUrl for the correct path) and checks ITS cause, which
+ *     contains the original release-openjdk*-pipeline trigger.
+ *
+ *   For each matched build, the platform name is read from that build's own
+ *   displayName (last colon-separated token, e.g. "s390x_linux") and its full
+ *   artifact tree is downloaded as <platform>.zip.
+ *
+ * Stage 2 – Collect GitHub TAP Attachments
+ *   Given a GitHub triage issue URL, downloads all .tap.txt file attachments
+ *   from the main issue and each child issue linked in its description.
+ *   Child issues follow the naming convention
+ *     "Triage Automated Tests for <release> <jdk> - <platform>"
+ *   so the platform is extracted from the title (or body "Platform:" line) and
+ *   attachments are grouped per platform as grinder_<platform>.zip.
+ *
+ * Stage 3 – Merge Artifacts
+ *   Merges the Jenkins artifacts (<platform>.zip) and GitHub attachments
+ *   (grinder_<platform>.zip) for each platform into a single <platform>.tar.gz.
+ *   Platforms that only have one source are still converted to .tar.gz.
+ *   Only the final <platform>.tar.gz files are archived as build artifacts.
  *
  * Parameters
  * ----------
- *   PIPELINE_NAME        Upstream pipeline name to match in cause/description.
+ *   PIPELINE_NAME        Upstream release pipeline name to match.
  *                        Example: release-openjdk8-pipeline
- *   BUILD_NUMBERS        Comma-separated upstream build numbers.
+ *   BUILD_NUMBERS        Comma-separated build numbers of that pipeline.
  *                        Example: 130,131
  *   TEST_PIPELINE_JOB    Jenkins job to scan.  Default: AQA_Test_Pipeline_RELEASE
- *   GITHUB_ISSUE_URL     GitHub issue URL.
+ *   GITHUB_ISSUE_URL     Main GitHub triage issue URL.
  *                        Example: https://github.com/adoptium/aqa-tests/issues/7612
- *   GITHUB_CREDENTIAL    Jenkins credential ID for the GitHub token.
+ *   GITHUB_CREDENTIAL    Secret text credential for the GitHub API token.
  */
 
 pipeline {
@@ -144,9 +177,10 @@ pipeline {
                         // Platform always comes from the build's own display name / description,
                         // since each build is for exactly one platform regardless of which
                         // upstream build number triggered it.
+                        // Use jsonStr() to safely handle net.sf.json.JSONNull values.
                         def platform = extractPlatformFromDisplayName(
-                            info.displayName?.trim() ?: '',
-                            info.description?.trim()  ?: ''
+                            jsonStr(info.displayName),
+                            jsonStr(info.description)
                         )
                         echo "  Matched build #${num} — platform: '${platform}'"
                         matchedBuilds << [number: num, platform: platform]
@@ -348,6 +382,17 @@ pipeline {
 // ---------------------------------------------------------------------------
 
 /**
+ * Safely convert a JSON field value to a plain Groovy String.
+ * Handles Groovy null, net.sf.json.JSONNull, and normal values.
+ * Returns empty string for null/JSONNull so callers never get a crash on .trim() etc.
+ */
+def jsonStr(def value) {
+    if (value == null) return ''
+    def s = value.toString()
+    return (s == 'null') ? '' : s.trim()
+}
+
+/**
  * Fetch a URL with curl and return a parsed JSON map.
  * @param useAuth  When true, passes -u "$JENKINS_AUTH" to curl. JENKINS_AUTH must already
  *                 be bound in the shell environment via withCredentials — it is never
@@ -394,16 +439,17 @@ def isBuildTriggeredBy(def buildInfo, String pipelineName, Set targetBuildNums, 
         if (allCauses.isEmpty()) break
 
         for (cause in allCauses) {
-            def proj      = cause?.upstreamProject?.toString() ?: ''
-            def upNumStr  = cause?.upstreamBuild?.toString()   ?: ''
-            def shortDesc = cause?.shortDescription?.toString() ?: ''
+            // Use jsonStr() to guard against net.sf.json.JSONNull on any field.
+            def proj      = jsonStr(cause?.upstreamProject)
+            def upNumStr  = jsonStr(cause?.upstreamBuild)
+            def shortDesc = jsonStr(cause?.shortDescription)
 
             // Direct structured match
-            if (proj.contains(pipelineName) && targetBuildNums.contains(upNumStr)) {
+            if (proj && proj.contains(pipelineName) && targetBuildNums.contains(upNumStr)) {
                 return true
             }
             // Text fallback in shortDescription
-            if (shortDesc.contains(pipelineName)) {
+            if (shortDesc && shortDesc.contains(pipelineName)) {
                 for (n in targetBuildNums) {
                     if (shortDesc.contains("build number ${n}") || shortDesc.contains("#${n}")) {
                         return true
@@ -414,14 +460,14 @@ def isBuildTriggeredBy(def buildInfo, String pipelineName, Set targetBuildNums, 
 
         // No match at this level — climb one level up using upstreamUrl (the correct
         // job path as Jenkins knows it) + upstreamBuild number.
-        def parentCause = allCauses.find { it?.upstreamUrl && it?.upstreamBuild != null }
+        // Guard: upstreamUrl and upstreamBuild must be non-null, non-"null" strings.
+        def parentCause = allCauses.find { jsonStr(it?.upstreamUrl) && jsonStr(it?.upstreamBuild) }
         if (!parentCause) break
 
-        def parentProj     = parentCause.upstreamProject?.toString() ?: ''
-        def parentBuildNum = parentCause.upstreamBuild.toString()
-        // upstreamUrl is already a valid relative Jenkins path, e.g.
-        // "job/build-scripts/job/jobs/job/release/job/jobs/job/jdk8u/job/jdk8u-release-linux-arm-temurin/"
-        def parentJobUrl   = parentCause.upstreamUrl.toString().replaceAll('/$', '')
+        def parentProj     = jsonStr(parentCause.upstreamProject)
+        def parentBuildNum = jsonStr(parentCause.upstreamBuild)
+        def parentJobUrl   = jsonStr(parentCause.upstreamUrl).replaceAll('/$', '')
+        if (!parentJobUrl || !parentBuildNum) break
         def parentApiUrl   = "${env.JENKINS_URL}${parentJobUrl}/${parentBuildNum}/api/json" +
             "?tree=actions%5Bcauses%5BupstreamProject,upstreamBuild,upstreamUrl,shortDescription%5D%5D"
         def parentInfo = fetchJson(parentApiUrl, "'${parentProj}' #${parentBuildNum}", useAuth)

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -341,8 +341,18 @@ pipeline {
  */
 def fetchJson(String url, String label, String auth = null) {
     try {
-        def authFlag = auth ? "-u '${auth}'" : ''
-        def json = sh(script: "curl -sf --connect-timeout 10 ${authFlag} '${url}'", returnStdout: true).trim()
+        def json
+        if (auth) {
+            // Pass credentials via environment variable to avoid secret interpolation warning.
+            // curl reads CURL_AUTH from the environment; never interpolated into the script string.
+            json = sh(
+                script: "curl -sf --connect-timeout 10 -u \"\$CURL_AUTH\" '${url}'",
+                returnStdout: true,
+                env: ["CURL_AUTH=${auth}"]
+            ).trim()
+        } else {
+            json = sh(script: "curl -sf --connect-timeout 10 '${url}'", returnStdout: true).trim()
+        }
         if (!json) { echo "Empty response for ${label}"; return null }
         return readJSON(text: json)
     } catch (Exception e) {

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -111,7 +111,7 @@ pipeline {
                     def jobPath = testJob.split('/').join('/job/')
                     // Fetch the list of all build numbers for the job.
                     def allBuildsJson = fetchJson(
-                        "${env.JENKINS_URL}job/${jobPath}/api/json?tree=builds%5Bnumber%5D",
+                        "${env.JENKINS_URL}job/${jobPath}/api/json?tree=builds%5Bnumber%5D%7B0,20%7D",
                         "build list of '${testJob}'"
                     )
                     if (!allBuildsJson || !allBuildsJson.builds) {

--- a/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
+++ b/buildenv/jenkins/tapVerification/TapArtifactCollector.groovy
@@ -67,15 +67,19 @@ pipeline {
             defaultValue: '',
             description: 'GitHub issue URL (e.g. https://github.com/adoptium/aqa-tests/issues/7612)'
         )
-        string(
+        credentials(
             name: 'JENKINS_CREDENTIAL',
             defaultValue: 'jenkins-bot-token',
-            description: 'Jenkins credential ID (username:token) for internal Jenkins REST API calls'
+            description: 'Username with password credential for internal Jenkins REST API calls (user + API token)',
+            credentialType: 'com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl',
+            required: true
         )
-        string(
+        credentials(
             name: 'GITHUB_CREDENTIAL',
             defaultValue: 'github-bot-token',
-            description: 'Jenkins credential ID for the GitHub API token'
+            description: 'Secret text credential containing the GitHub personal access token',
+            credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl',
+            required: false
         )
     }
 


### PR DESCRIPTION
Collect Jenkins Artifacts

- Check if available TEST_PIPELINE_JOB is part of the release via REST API. For each build, checks the cause chain (up to 3 levels deep)
- On match, extracts platform from the build's displayName and downloads the full artifact zip as <platform>.zip 

Collect GitHub TAP Attachments

- Loop triage issue and its child issues to fetches the main issue body + comments to downloads .tap.txt attachments 

Merge Artifacts - per platform



Close #7515 

Assist by IBM BOB